### PR TITLE
Add URL encoding for demo app

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -390,10 +390,11 @@ extension MeetingViewController: RealtimeObserver {
                 self.currentRoster[attendeeId] = RosterAttendee(
                     name: nil, attendeeId: attendeeId, volume: .notSpeaking, signal: .high)
                 self.dispatchGroup.enter()
-                let encodedTitle = HttpUtils.encodeStrForURL(str: self.meetingId ?? "")
-                let encodedAttendee = HttpUtils.encodeStrForURL(str: attendeeId)
+                let encodedURL = HttpUtils.encodeStrForURL(
+                    str: "\(AppConfiguration.url)attendee?title=\(self.meetingId ?? "")&attendee=\(attendeeId)"
+                )
                 HttpUtils.getRequest(
-                    url: "\(AppConfiguration.url)attendee?title=\(encodedTitle)&attendee=\(encodedAttendee)",
+                    url: encodedURL,
                     completion: { (data: Data?, _: Error?) in
                         if let data = data, let name = self.parseAttendee(data: data) {
                             let attendee = self.currentRoster[attendeeId]

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -390,8 +390,10 @@ extension MeetingViewController: RealtimeObserver {
                 self.currentRoster[attendeeId] = RosterAttendee(
                     name: nil, attendeeId: attendeeId, volume: .notSpeaking, signal: .high)
                 self.dispatchGroup.enter()
+                let encodedTitle = HttpUtils.encodeStrForURL(str: self.meetingId ?? "")
+                let encodedAttendee = HttpUtils.encodeStrForURL(str: attendeeId)
                 HttpUtils.getRequest(
-                    url: "\(AppConfiguration.url)attendee?title=\(self.meetingId ?? "")&attendee=\(attendeeId)",
+                    url: "\(AppConfiguration.url)attendee?title=\(encodedTitle)&attendee=\(encodedAttendee)",
                     completion: { (data: Data?, _: Error?) in
                         if let data = data, let name = self.parseAttendee(data: data) {
                             let attendee = self.currentRoster[attendeeId]

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/ViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/ViewController.swift
@@ -25,8 +25,8 @@ class ViewController: UIViewController {
     }
 
     @IBAction func joinMeeting(sender: UIButton) {
-        meetingID = meetingIDText.text?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-        name = nameText.text?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        meetingID = meetingIDText.text ?? ""
+        name = nameText.text ?? ""
 
         postRequest(completion: { data, error in
             guard error == nil else {
@@ -66,8 +66,11 @@ class ViewController: UIViewController {
             }
             return
         }
+        let encodedTitle = HttpUtils.encodeStrForURL(str: meetingID)
+        let encodedName = HttpUtils.encodeStrForURL(str: name)
+        let encodedRegion = HttpUtils.encodeStrForURL(str: AppConfiguration.region)
         HttpUtils.postRequest(
-            url: "\(AppConfiguration.url)join?title=\(meetingID)&name=\(name)&region=\(AppConfiguration.region)",
+            url: "\(AppConfiguration.url)join?title=\(encodedTitle)&name=\(encodedName)&region=\(encodedRegion)",
             completion: completion,
             jsonData: nil, logger: logger)
     }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/ViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/ViewController.swift
@@ -66,11 +66,12 @@ class ViewController: UIViewController {
             }
             return
         }
-        let encodedTitle = HttpUtils.encodeStrForURL(str: meetingID)
-        let encodedName = HttpUtils.encodeStrForURL(str: name)
-        let encodedRegion = HttpUtils.encodeStrForURL(str: AppConfiguration.region)
+
+        let encodedURL = HttpUtils.encodeStrForURL(
+            str: "\(AppConfiguration.url)join?title=\(meetingID)&name=\(name)&region=\(AppConfiguration.region)"
+        )
         HttpUtils.postRequest(
-            url: "\(AppConfiguration.url)join?title=\(encodedTitle)&name=\(encodedName)&region=\(encodedRegion)",
+            url: encodedURL,
             completion: completion,
             jsonData: nil, logger: logger)
     }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/ViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/ViewController.swift
@@ -25,8 +25,8 @@ class ViewController: UIViewController {
     }
 
     @IBAction func joinMeeting(sender: UIButton) {
-        meetingID = formatInput(text: meetingIDText.text ?? "")
-        name = formatInput(text: nameText.text ?? "")
+        meetingID = meetingIDText.text?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        name = nameText.text?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
 
         postRequest(completion: { data, error in
             guard error == nil else {
@@ -70,10 +70,6 @@ class ViewController: UIViewController {
             url: "\(AppConfiguration.url)join?title=\(meetingID)&name=\(name)&region=\(AppConfiguration.region)",
             completion: completion,
             jsonData: nil, logger: logger)
-    }
-
-    private func formatInput(text: String) -> String {
-        return text.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: " ", with: "+")
     }
 
     private func processJson(data: Data) -> (CreateMeetingResponse?, CreateAttendeeResponse?) {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/utils/HttpUtils.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/utils/HttpUtils.swift
@@ -54,4 +54,8 @@ class HttpUtils {
             completion(data, nil)
         }.resume()
     }
+
+    public static func encodeStrForURL(str: String) -> String {
+        return str.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? str
+    }
 }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemoObjC/ViewControllerObjC.m
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemoObjC/ViewControllerObjC.m
@@ -30,7 +30,11 @@
         return;
     }
 
-    NSString *url = [NSString stringWithFormat:@"%sjoin?title=%@&name=%@&region=%s", SERVER_URL, meetingId, name, SERVER_REGION];
+    NSCharacterSet *set = [NSCharacterSet URLQueryAllowedCharacterSet];
+    NSString *encodedTitle = [meetingId stringByAddingPercentEncodingWithAllowedCharacters:set];
+    NSString *encodedName = [name stringByAddingPercentEncodingWithAllowedCharacters:set];
+    NSString *encodedRegion = [@(SERVER_REGION) stringByAddingPercentEncodingWithAllowedCharacters:set];
+    NSString *url = [NSString stringWithFormat:@"%sjoin?title=%@&name=%@&region=%@", SERVER_URL, encodedTitle, encodedName, encodedRegion];
     [self makeHttpRequest:url withMethod:@"POST" withData:nil withCompletionBlock:^(NSData *data, NSError *error) {
         if (error != nil) {
             [self showAlertIn:self

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemoObjC/ViewControllerObjC.m
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemoObjC/ViewControllerObjC.m
@@ -31,10 +31,7 @@
     }
 
     NSCharacterSet *set = [NSCharacterSet URLQueryAllowedCharacterSet];
-    NSString *encodedTitle = [meetingId stringByAddingPercentEncodingWithAllowedCharacters:set];
-    NSString *encodedName = [name stringByAddingPercentEncodingWithAllowedCharacters:set];
-    NSString *encodedRegion = [@(SERVER_REGION) stringByAddingPercentEncodingWithAllowedCharacters:set];
-    NSString *url = [NSString stringWithFormat:@"%sjoin?title=%@&name=%@&region=%@", SERVER_URL, encodedTitle, encodedName, encodedRegion];
+    NSString *url = [[NSString stringWithFormat:@"%sjoin?title=%@&name=%@&region=%s", SERVER_URL, meetingId, name, SERVER_REGION] stringByAddingPercentEncodingWithAllowedCharacters:set];
     [self makeHttpRequest:url withMethod:@"POST" withData:nil withCompletionBlock:^(NSData *data, NSError *error) {
         if (error != nil) {
             [self showAlertIn:self


### PR DESCRIPTION
### Issue #, if available:
N/A

### Description of changes:
Encode URL for HTTP requests

### Testing done:
Tested on device to have a meeting with web demo

#### Manual test cases (add more as needed):

- [x] Join meeting
- [x] Leave meeting
- [x] Rejoin meeting
- [x] See metrics
- [x] See attendee presence
- [x] Send audio
- [x] Receive audio
- [x] Mute self
- [x] Unmute self
- [x] See local mute indicator when muted
- [x] See remote mute indicator when other is muted
- [x] Enable and disable local video
- [x] Enable and disable remote video from remote side
- [x] Send local video
- [x] Pause and resume remote video
- [x] Switch local camera
- [x] Receive remote screen share

#### Integration validation (required before release)
N/A

### Screenshots, if available:
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
