### PR TITLE
fix returned built-it speaker type; add tests

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
+++ b/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
@@ -34,7 +34,8 @@
 		00C9DC6B23FA393600876B41 /* DefaultVideoTileController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00C9DC6A23FA393600876B41 /* DefaultVideoTileController.swift */; };
 		00D9DBB2241AE23F00146467 /* DefaultVideoClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00D9DBB1241AE23F00146467 /* DefaultVideoClient.swift */; };
 		00EB5F612400591800007D3E /* VideoTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00EB5F602400591800007D3E /* VideoTile.swift */; };
-		32F235B3714DA0906335CC12 /* AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7CEAE89DD08E6E863FC8BE /* AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift */; };
+		025A5A2A24ACD58A00111488 /* MockVideoClientController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025A5A2924ACD58A00111488 /* MockVideoClientController.swift */; };
+		028D9EF124ACCDE7007164B1 /* DeviceControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028D9EF024ACCDE7007164B1 /* DeviceControllerTests.swift */; };
 		5A0E7317242EA072006636AB /* MediaDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A0E7316242EA072006636AB /* MediaDeviceTests.swift */; };
 		5A0E7319242EA283006636AB /* MeetingSessionStatusCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A0E7318242EA283006636AB /* MeetingSessionStatusCodeTests.swift */; };
 		5A0E731B242EA39E006636AB /* VideoTileStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A0E731A242EA39E006636AB /* VideoTileStateTests.swift */; };
@@ -116,6 +117,7 @@
 		F82D50D723FC752600D8F18C /* SignalStrength.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82D50C223FC732300D8F18C /* SignalStrength.swift */; };
 		F82D50D823FC752600D8F18C /* VolumeLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82D50C323FC732300D8F18C /* VolumeLevel.swift */; };
 		F83F53702452757700614913 /* ObserverUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F83F536F2452757700614913 /* ObserverUtils.swift */; };
+		F84CFCE0751438D8B8CFF7BB /* AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7CEAE89DD08E6E863FC8BE /* AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift */; };
 		F86CB7412411B9A6004FD82F /* exported_symbols in Resources */ = {isa = PBXBuildFile; fileRef = F86CB7402411B9A6004FD82F /* exported_symbols */; };
 		F8C0145E23F1D50E0083D478 /* VideoClientController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C0145D23F1D50E0083D478 /* VideoClientController.swift */; };
 		F8E42DEE247F9464004C8400 /* ConcurrentDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E42DED247F9464004C8400 /* ConcurrentDictionary.swift */; };
@@ -159,6 +161,8 @@
 		00C9DC6A23FA393600876B41 /* DefaultVideoTileController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultVideoTileController.swift; sourceTree = "<group>"; };
 		00D9DBB1241AE23F00146467 /* DefaultVideoClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultVideoClient.swift; sourceTree = "<group>"; };
 		00EB5F602400591800007D3E /* VideoTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoTile.swift; sourceTree = "<group>"; };
+		025A5A2924ACD58A00111488 /* MockVideoClientController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockVideoClientController.swift; sourceTree = "<group>"; };
+		028D9EF024ACCDE7007164B1 /* DeviceControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceControllerTests.swift; sourceTree = "<group>"; };
 		5A0E7316242EA072006636AB /* MediaDeviceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDeviceTests.swift; sourceTree = "<group>"; };
 		5A0E7318242EA283006636AB /* MeetingSessionStatusCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingSessionStatusCodeTests.swift; sourceTree = "<group>"; };
 		5A0E731A242EA39E006636AB /* VideoTileStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoTileStateTests.swift; sourceTree = "<group>"; };
@@ -576,6 +580,7 @@
 		5A631A502429936200C8DAF3 /* device */ = {
 			isa = PBXGroup;
 			children = (
+				028D9EF024ACCDE7007164B1 /* DeviceControllerTests.swift */,
 				5A0E7316242EA072006636AB /* MediaDeviceTests.swift */,
 				5AE76F3524204A03009C41FD /* MediaDeviceTypeTests.swift */,
 			);
@@ -664,6 +669,7 @@
 			isa = PBXGroup;
 			children = (
 				5AE76F15242037A4009C41FD /* MockAudioSession.swift */,
+				025A5A2924ACD58A00111488 /* MockVideoClientController.swift */,
 			);
 			path = mocks;
 			sourceTree = "<group>";
@@ -977,9 +983,11 @@
 				006894F8246B481D00611C75 /* AttendeeStatusTest.swift in Sources */,
 				5AE76F2D24203AEF009C41FD /* VideoPauseStateTests.swift in Sources */,
 				5A0E731B242EA39E006636AB /* VideoTileStateTests.swift in Sources */,
+				025A5A2A24ACD58A00111488 /* MockVideoClientController.swift in Sources */,
 				5AE76F2724203AAA009C41FD /* VolumeLevelTests.swift in Sources */,
 				5AE76F2024203A6E009C41FD /* VolumeUpdateTests.swift in Sources */,
-				32F235B3714DA0906335CC12 /* AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift in Sources */,
+				028D9EF124ACCDE7007164B1 /* DeviceControllerTests.swift in Sources */,
+				F84CFCE0751438D8B8CFF7BB /* AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AmazonChimeSDK/AmazonChimeSDK/device/DefaultDeviceController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/device/DefaultDeviceController.swift
@@ -28,7 +28,7 @@ import AVFoundation
 
     public func listAudioDevices() -> [MediaDevice] {
         var inputDevices: [MediaDevice] = []
-        let loudSpeaker = MediaDevice(label: "Build-in Speaker")
+        let loudSpeaker = MediaDevice(label: "Built-in Speaker", type: MediaDeviceType.audioBuiltInSpeaker)
         if let availablePort = audioSession.availableInputs {
             inputDevices = availablePort.map { port in MediaDevice.fromAVSessionPort(port: port) }
         }

--- a/AmazonChimeSDK/AmazonChimeSDK/device/MediaDevice.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/device/MediaDevice.swift
@@ -33,6 +33,12 @@ import Foundation
     static func fromVideoDevice(device: VideoDevice?) -> MediaDevice {
         return MediaDevice(label: device?.name ?? "unknown", videoDevice: device)
     }
+    
+    public init(label: String, type: MediaDeviceType) {
+        self.label = label
+        self.type = type
+        self.port = nil
+    }
 
     public init(label: String, port: AVAudioSessionPortDescription? = nil, videoDevice: VideoDevice? = nil) {
         self.label = label
@@ -54,6 +60,8 @@ import Foundation
                 type = .audioHandset
             case .headphones, .headsetMic:
                 type = .audioWiredHeadset
+            case .builtInSpeaker:
+                type = .audioBuiltInSpeaker
             default:
                 type = .other
             }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/device/DeviceControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/device/DeviceControllerTests.swift
@@ -1,0 +1,25 @@
+//
+//  DeviceControllerTests.swift
+//  AmazonChimeSDK
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import AmazonChimeSDK
+import AVFoundation
+import XCTest
+
+class DeviceControllerTests: XCTestCase {
+    func testListDevicesReturnsSpeakerWithCorrectType() {
+        let audioSession = MockAudioSession()
+        let videoClient = MockVideoClientController()
+        let logger = ConsoleLogger(name: "logger")
+        
+        let controller = DefaultDeviceController(audioSession: audioSession, videoClientController: videoClient, logger: logger)
+        let devices = controller.listAudioDevices()
+        let secondDevice = devices[1]
+        
+        XCTAssertEqual(secondDevice.type, MediaDeviceType.audioBuiltInSpeaker)
+    }
+}

--- a/AmazonChimeSDK/AmazonChimeSDKTests/mocks/MockVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/mocks/MockVideoClientController.swift
@@ -1,0 +1,56 @@
+//
+//  MockVideoClientController.swift
+//  AmazonChimeSDK
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import AmazonChimeSDK
+import AmazonChimeSDKMedia
+
+public final class MockVideoClientController: VideoClientController {
+    init() {
+    }
+    
+    public func start(turnControlUrl: String, signalingUrl: String, meetingId: String, joinToken: String) {
+    }
+    
+    public func stopAndDestroy() {
+    }
+    
+    public func startLocalVideo() throws {
+    }
+    
+    public func stopLocalVideo() {
+    }
+    
+    public func startRemoteVideo() {
+    }
+    
+    public func stopRemoteVideo() {
+    }
+    
+    public func switchCamera() {
+    }
+    
+    public func getCurrentDevice() -> VideoDevice? {
+        return nil
+    }
+    
+    public func subscribeToVideoClientStateChange(observer: AudioVideoObserver) {
+    }
+    
+    public func unsubscribeToVideoClientStateChange(observer: AudioVideoObserver) {
+    }
+    
+    public func subscribeToVideoTileControllerObservers(observer: VideoTileController) {
+    }
+    
+    public func unsubscribeToVideoTileControllerObservers(observer: VideoTileController) {
+    }
+    
+    public func pauseResumeRemoteVideo(_ videoId: UInt32, pause: Bool) {
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+### Fixed
+- `DefaultDeviceController` now uses the correct `MediaDeviceType` for the default Built-In Speaker. ([#62](https://github.com/aws/amazon-chime-sdk-ios/issues/62))
+
+### Added
+- Added unit test for `DefaultDeviceController`
+
+### Changed
+- **Breaking** the returned label for the Built-In Speaker `MediaDevice` has been changed from "Build-in Speaker" to "Buil*t*-in Speaker
+
 ## [0.7.1] - 2020-06-24
 ### Changed
 - `DefaultAudioClientController` no longer defaults to Speaker as audio output when starting audio session.


### PR DESCRIPTION
### Issue #, if available:

https://github.com/aws/amazon-chime-sdk-ios/issues/62

### Description of changes:

Fixed the returned `MediceDeviceType` for the Built-In Speaker option. Also added unit test.

### Testing done:

#### Manual test cases (add more as needed):

- [ ] Join meeting
- [ ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
