### PR TITLE
fix default video render view aspect ratio

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/DefaultVideoRenderView.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/DefaultVideoRenderView.swift
@@ -28,6 +28,9 @@ import os
                        """, type: .info)
             }
         }
+        didSet {
+            imageView.contentMode = contentMode
+        }
     }
 
     // Delay the transform until the next frame


### PR DESCRIPTION
When using a `DefaultVideoRenderView`, setting the `contentMode` to `.scaleAspectFit` was not taken into account.
When the size of the image view containing the video was modified, the resulting video aspect ratio was wrong (stretched).

### Issue #, if available:

### Description of changes:

Fix the default video render view aspect ratio (when using content mode such as scale aspect fit) :
In the `DefaultVideoRenderView`, in the `contentMode` setter, forward the `contentMode` to the child `UIImageView`.
Previously, this was only done in the initializer.

### Testing done:

In our App, replacing the SDK with the patched one fixed the video aspect ratio bug after a device rotation.

#### Manual test cases (add more as needed):

- [ ] Join meeting
- [ ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
