### PR TITLE
Fix issue of missing PSTN attendee events

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/session/DefaultMeetingSession.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/session/DefaultMeetingSession.swift
@@ -28,7 +28,8 @@ import Foundation
 
         let audioClientObserver = DefaultAudioClientObserver(audioClient: audioClient,
                                                              clientMetricsCollector: clientMetricsCollector,
-                                                             audioClientLock: audioClientLock)
+                                                             audioClientLock: audioClientLock,
+                                                             configuration: configuration)
         let audioClientController = DefaultAudioClientController(audioClient: audioClient,
                                                                  audioClientObserver: audioClientObserver,
                                                                  audioSession: audioSession,

--- a/AmazonChimeSDK/AmazonChimeSDK/session/MeetingSessionConfiguration.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/session/MeetingSessionConfiguration.swift
@@ -36,6 +36,7 @@ import Foundation
                 urlRewriter: @escaping URLRewriter) {
         self.meetingId = createMeetingResponse.meeting.meetingId
         self.credentials = MeetingSessionCredentials(attendeeId: createAttendeeResponse.attendee.attendeeId,
+                                                     externalUserId: createAttendeeResponse.attendee.externalUserId,
                                                      joinToken: createAttendeeResponse.attendee.joinToken)
         self.urls = MeetingSessionURLs(audioFallbackUrl: createMeetingResponse.meeting.mediaPlacement.audioFallbackUrl,
                                        audioHostUrl: createMeetingResponse.meeting.mediaPlacement.audioHostUrl,

--- a/AmazonChimeSDK/AmazonChimeSDK/session/MeetingSessionCredentials.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/session/MeetingSessionCredentials.swift
@@ -14,11 +14,15 @@ import Foundation
     /// The attendee id for these credentials.
     public let attendeeId: String
 
-    /// The token that the session will be authenticated with
+    /// The external user Id associated with the attendee.
+    public let externalUserId: String
+
+    /// The token that the session will be authenticated with.
     public let joinToken: String
 
-    public init(attendeeId: String, joinToken: String) {
+    public init(attendeeId: String, externalUserId: String, joinToken: String) {
         self.attendeeId = attendeeId
+        self.externalUserId = externalUserId
         self.joinToken = joinToken
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/session/MeetingSessionCredentialsTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/session/MeetingSessionCredentialsTests.swift
@@ -11,9 +11,13 @@ import XCTest
 
 class MeetingSessionCredentialsTests: XCTestCase {
     func testMeetingSessionCredentialsShouldBeInitialized() {
-        let credentials = MeetingSessionCredentials(attendeeId: "attendeeId", joinToken: "joinToken")
+        let credentials = MeetingSessionCredentials(
+            attendeeId: "attendeeId",
+            externalUserId: "externalUserId",
+            joinToken: "joinToken")
 
         XCTAssertEqual(credentials.attendeeId, "attendeeId")
+        XCTAssertEqual(credentials.externalUserId, "externalUserId")
         XCTAssertEqual(credentials.joinToken, "joinToken")
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+### Added
+* **Breaking** Added additional `externalUserId` field for `MeetingSessionCredentials`
+
+### Fixed
+* Fixed a bug that attendee events got filtered out due to absence of `externalUserId`
+
 ## [0.8.2] - 2020-08-13
 
 ## [0.8.1] - 2020-07-31


### PR DESCRIPTION
### Issue #, if available:
Chime-29742

### Description of changes:
- Remove filter for attendees with empty external user Id, which could from PSTN
- Fill in external user Id for local attendee before notify audio callbacks
### Testing done:

#### VoiceConnector meeting
Joined meeting with both VOIP and PSTN attendees and verified
- Receive presence, volume, signal strength events for PSTN attendee
- No other attendee in callbacks are having empty external user Id

#### Manual test cases (add more as needed):

- [x] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [x] See attendee presence
- [x] Send audio
- [x] Receive audio
- [x] Mute self
- [x] Unmute self
- [x] See local mute indicator when muted
- [x] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
