### PR TITLE
Implement video tile pagination and active-speaker-based video tiles

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/DefaultVideoRenderView.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/DefaultVideoRenderView.swift
@@ -63,6 +63,7 @@ import VideoToolbox
     public func renderFrame(frame: CVPixelBuffer?) {
         if frame == nil {
             isHidden = true
+            imageView.image = nil
         } else if let frame = frame {
             isHidden = false
             var cgImage: CGImage?

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/birdrides/mockingbird",
         "state": {
           "branch": null,
-          "revision": "796ee37672784994431ed3ccb2b9ffdcd80fc3ad",
-          "version": "0.13.1"
+          "revision": "50feb5e24587091abfc5c37b2dc9be7c1bbdd7f0",
+          "version": "0.15.0"
         }
       },
       {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
@@ -389,14 +389,14 @@
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ce1-zU-74I">
                                                 <rect key="frame" x="0.0" y="0.0" width="414" height="30"/>
                                                 <subviews>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LyA-wt-IwP">
+                                                    <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LyA-wt-IwP">
                                                         <rect key="frame" x="0.0" y="0.0" width="203" height="30"/>
                                                         <state key="normal" title="&lt;&lt; Prev Page"/>
                                                         <connections>
                                                             <action selector="prevPageButtonClicked:" destination="Sfo-A7-USF" eventType="touchUpInside" id="yky-PK-KLG"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rze-mq-tyX">
+                                                    <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rze-mq-tyX">
                                                         <rect key="frame" x="211" y="0.0" width="203" height="30"/>
                                                         <state key="normal" title="Next Page &gt;&gt;"/>
                                                         <connections>

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -298,7 +298,7 @@
                                         </prototypes>
                                     </tableView>
                                     <collectionView hidden="YES" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="Qja-lL-6xQ">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="608"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="578"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="F0D-d0-6d0">
                                             <size key="itemSize" width="313" height="161"/>
@@ -383,6 +383,40 @@
                                             <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="Video Collection"/>
                                         </userDefinedRuntimeAttributes>
                                     </collectionView>
+                                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eZ2-xQ-Pkf" userLabel="VideoPaginationControlView">
+                                        <rect key="frame" x="0.0" y="578" width="414" height="30"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="ce1-zU-74I">
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="30"/>
+                                                <subviews>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LyA-wt-IwP">
+                                                        <rect key="frame" x="0.0" y="0.0" width="203" height="30"/>
+                                                        <state key="normal" title="&lt;&lt; Prev Page"/>
+                                                        <connections>
+                                                            <action selector="prevPageButtonClicked:" destination="Sfo-A7-USF" eventType="touchUpInside" id="yky-PK-KLG"/>
+                                                        </connections>
+                                                    </button>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rze-mq-tyX">
+                                                        <rect key="frame" x="211" y="0.0" width="203" height="30"/>
+                                                        <state key="normal" title="Next Page &gt;&gt;"/>
+                                                        <connections>
+                                                            <action selector="nextPageButtonClicked:" destination="Sfo-A7-USF" eventType="touchUpInside" id="ssp-yj-5Tb"/>
+                                                        </connections>
+                                                    </button>
+                                                </subviews>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="30" id="JS3-J2-l6b"/>
+                                                </constraints>
+                                            </stackView>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="bottom" secondItem="ce1-zU-74I" secondAttribute="bottom" id="1gm-UV-ujB"/>
+                                            <constraint firstItem="ce1-zU-74I" firstAttribute="top" secondItem="eZ2-xQ-Pkf" secondAttribute="top" id="3KI-4s-wPO"/>
+                                            <constraint firstItem="ce1-zU-74I" firstAttribute="leading" secondItem="eZ2-xQ-Pkf" secondAttribute="leading" id="EgR-gz-spf"/>
+                                            <constraint firstAttribute="height" constant="30" id="qDY-zs-U1l"/>
+                                            <constraint firstAttribute="trailing" secondItem="ce1-zU-74I" secondAttribute="trailing" id="waA-f9-GQV"/>
+                                        </constraints>
+                                    </view>
                                     <view hidden="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gJX-ez-OMF" userLabel="ScreenView">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="608"/>
                                         <subviews>
@@ -461,8 +495,11 @@
                                     <constraint firstItem="pnJ-hW-dw5" firstAttribute="trailing" secondItem="ELJ-Ld-nMt" secondAttribute="trailing" id="1Yz-uf-zle"/>
                                     <constraint firstItem="ELJ-Ld-nMt" firstAttribute="top" secondItem="rZi-u5-BDg" secondAttribute="top" id="2k6-gy-dwL"/>
                                     <constraint firstAttribute="bottom" secondItem="ugK-9v-6P7" secondAttribute="bottom" id="KgX-tr-8GQ"/>
+                                    <constraint firstItem="eZ2-xQ-Pkf" firstAttribute="centerX" secondItem="rZi-u5-BDg" secondAttribute="centerX" id="M12-EQ-qCr"/>
                                     <constraint firstItem="pnJ-hW-dw5" firstAttribute="leading" secondItem="ELJ-Ld-nMt" secondAttribute="leading" id="MUO-kr-ZiN"/>
+                                    <constraint firstAttribute="bottom" secondItem="eZ2-xQ-Pkf" secondAttribute="bottom" id="OgJ-5k-Tk3"/>
                                     <constraint firstItem="Qja-lL-6xQ" firstAttribute="leading" secondItem="rZi-u5-BDg" secondAttribute="leading" id="TEZ-ji-Fy1"/>
+                                    <constraint firstItem="eZ2-xQ-Pkf" firstAttribute="leading" secondItem="rZi-u5-BDg" secondAttribute="leading" id="UIw-g3-OKn"/>
                                     <constraint firstItem="ugK-9v-6P7" firstAttribute="leading" secondItem="rZi-u5-BDg" secondAttribute="leading" id="aWe-uh-kDY"/>
                                     <constraint firstItem="ELJ-Ld-nMt" firstAttribute="leading" secondItem="rZi-u5-BDg" secondAttribute="leading" id="agi-Sl-fmQ"/>
                                     <constraint firstAttribute="bottom" secondItem="ELJ-Ld-nMt" secondAttribute="bottom" id="b7u-jJ-m5k"/>
@@ -471,7 +508,8 @@
                                     <constraint firstItem="pnJ-hW-dw5" firstAttribute="bottom" secondItem="ELJ-Ld-nMt" secondAttribute="bottom" id="gDI-8z-scJ"/>
                                     <constraint firstAttribute="trailing" secondItem="ugK-9v-6P7" secondAttribute="trailing" id="gpx-KY-rwU"/>
                                     <constraint firstAttribute="trailing" secondItem="Qja-lL-6xQ" secondAttribute="trailing" id="jW1-ix-GKK"/>
-                                    <constraint firstAttribute="bottom" secondItem="Qja-lL-6xQ" secondAttribute="bottom" id="lTe-Rn-UWH"/>
+                                    <constraint firstAttribute="bottom" secondItem="Qja-lL-6xQ" secondAttribute="bottom" constant="30" id="lTe-Rn-UWH"/>
+                                    <constraint firstAttribute="trailing" secondItem="eZ2-xQ-Pkf" secondAttribute="trailing" id="rXJ-TW-yce"/>
                                     <constraint firstAttribute="bottom" secondItem="gJX-ez-OMF" secondAttribute="bottom" id="tfP-mj-ZAn"/>
                                     <constraint firstItem="Qja-lL-6xQ" firstAttribute="top" secondItem="rZi-u5-BDg" secondAttribute="top" id="wc9-Zz-Jg7"/>
                                     <constraint firstAttribute="bottom" secondItem="ugK-9v-6P7" secondAttribute="bottom" id="whc-IC-tTh"/>
@@ -623,7 +661,9 @@
                         <outlet property="inputText" destination="QdP-Dc-MY3" id="ibb-Bi-gcg"/>
                         <outlet property="metricsTable" destination="pnJ-hW-dw5" id="uDF-Kl-QTz"/>
                         <outlet property="muteButton" destination="fzH-S4-QOP" id="vmO-mV-2jv"/>
+                        <outlet property="nextVideoPageButton" destination="rze-mq-tyX" id="gz7-bR-78L"/>
                         <outlet property="noScreenViewLabel" destination="a6m-dY-eYQ" id="rMc-sk-tSp"/>
+                        <outlet property="prevVideoPageButton" destination="LyA-wt-IwP" id="kXS-Pr-56y"/>
                         <outlet property="resumeCallKitMeetingButton" destination="3gp-l6-EdL" id="9Da-AF-S8v"/>
                         <outlet property="rosterTable" destination="ELJ-Ld-nMt" id="R2u-1L-jEP"/>
                         <outlet property="screenRenderView" destination="SGw-l9-hMc" id="RQc-8i-6Gl"/>
@@ -633,6 +673,7 @@
                         <outlet property="titleLabel" destination="eGg-Lr-MVg" id="GHP-SY-nSu"/>
                         <outlet property="titleView" destination="awH-B0-U5A" id="bDk-fK-cti"/>
                         <outlet property="videoCollection" destination="Qja-lL-6xQ" id="dIx-E3-6pz"/>
+                        <outlet property="videoPaginationControlView" destination="eZ2-xQ-Pkf" id="oWi-6t-rkS"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Gja-bz-aQW" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -517,7 +517,7 @@ extension MeetingModel: VideoTileObserver {
                     if success {
                         if self.activeMode == .video {
                             // If the video is not currently being displayed, pause it
-                            if !self.videoModel.remoteVideoStatesInCurrentPage.contains(where: { $0.0 == tileState.tileId }) {
+                            if !self.videoModel.isRemoteVideoDisplaying(tileId: tileState.tileId) {
                                 self.currentMeetingSession.audioVideo.pauseRemoteVideoTile(tileId: tileState.tileId)
                             }
                             self.videoModel.videoUpdatedHandler?()
@@ -551,7 +551,7 @@ extension MeetingModel: VideoTileObserver {
         } else {
             videoModel.removeRemoteVideoTileState(tileState, completion: { success in
                 if success {
-                    self.videoModel.revalidateRemoteVideoPageNumber()
+                    self.videoModel.revalidateRemoteVideoPageIndex()
                     if self.activeMode == .video {
                         self.videoModel.videoUpdatedHandler?()
                     }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -46,9 +46,9 @@ class MeetingModel: NSObject {
     var activeMode: ActiveMode = .roster {
         didSet {
             if activeMode == .video {
-                startRemoteVideo()
-            } else if activeMode == .screenShare {
-                startScreenShare()
+                videoModel.resumeAllRemoteVideosInCurrentPageExceptUserPausedVideos()
+            } else {
+                videoModel.pauseAllRemoteVideos()
             }
             activeModeDidSetHandler?(activeMode)
         }
@@ -125,7 +125,7 @@ class MeetingModel: NSObject {
         if self.callKitOption == .disabled {
             self.configureAudioSession()
             self.startAudioVideoConnection(isCallKitEnabled: false)
-            self.startRemoteVideo()
+            self.currentMeetingSession.audioVideo.startRemoteVideo()
         }
     }
 
@@ -254,16 +254,6 @@ class MeetingModel: NSObject {
         }
     }
 
-    private func startRemoteVideo() {
-        videoModel.resumeAllRemoteVideo()
-        currentMeetingSession.audioVideo.startRemoteVideo()
-    }
-
-    private func startScreenShare() {
-        videoModel.pauseAllRemoteVideo()
-        currentMeetingSession.audioVideo.startRemoteVideo()
-    }
-
     private func startLocalVideo() {
         MeetingModule.shared().requestVideoPermission { success in
             if success {
@@ -299,7 +289,7 @@ class MeetingModel: NSObject {
         }
         call.isAudioSessionActiveHandler = { [weak self] in
             self?.startAudioVideoConnection(isCallKitEnabled: true)
-            self?.startRemoteVideo()
+            self?.currentMeetingSession.audioVideo.startRemoteVideo()
             if self?.isMuted ?? false {
                 _ = self?.currentMeetingSession.audioVideo.realtimeLocalMute()
             }
@@ -526,7 +516,14 @@ extension MeetingModel: VideoTileObserver {
                 videoModel.addRemoteVideoTileState(tileState, completion: { success in
                     if success {
                         if self.activeMode == .video {
+                            // If the video is not currently being displayed, pause it
+                            if !self.videoModel.remoteVideoStatesInCurrentPage.contains(where: { $0.0 == tileState.tileId }) {
+                                self.currentMeetingSession.audioVideo.pauseRemoteVideoTile(tileId: tileState.tileId)
+                            }
                             self.videoModel.videoUpdatedHandler?()
+                        } else {
+                            // Currently not in the video view, no need to render the video tile
+                            self.currentMeetingSession.audioVideo.pauseRemoteVideoTile(tileId: tileState.tileId)
                         }
                     } else {
                         self.logger.info(msg: "Cannot add more video tile tileId: \(tileState.tileId)")
@@ -554,6 +551,7 @@ extension MeetingModel: VideoTileObserver {
         } else {
             videoModel.removeRemoteVideoTileState(tileState, completion: { success in
                 if success {
+                    self.videoModel.revalidateRemoteVideoPageNumber()
                     if self.activeMode == .video {
                         self.videoModel.videoUpdatedHandler?()
                     }
@@ -600,6 +598,11 @@ extension MeetingModel: ActiveSpeakerObserver {
     }
 
     func activeSpeakerDidDetect(attendeeInfo: [AttendeeInfo]) {
+        videoModel.updateRemoteVideoStatesBasedOnActiveSpeakers(activeSpeakers: attendeeInfo)
+        if activeMode == .video {
+            videoModel.videoUpdatedHandler?()
+        }
+
         rosterModel.updateActiveSpeakers(attendeeInfo.map { $0.attendeeId })
         if activeMode == .roster {
             rosterModel.rosterUpdatedHandler?()
@@ -622,4 +625,3 @@ extension MeetingModel: DataMessageObserver {
         chatModel.addDataMessage(dataMessage: dataMessage)
     }
 }
-

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -326,23 +326,13 @@ class MeetingViewController: UIViewController {
     }
 
     @IBAction func prevPageButtonClicked(_ sender: UIButton) {
-        meetingModel?.videoModel.getPreviousRemoteVideoPage(completion: { [weak self] success in
-            if success {
-                self?.meetingModel?.videoModel.videoUpdatedHandler?()
-            } else {
-                self?.logger.error(msg: "Failed to get the previous remote video page")
-            }
-        })
+        meetingModel?.videoModel.getPreviousRemoteVideoPage()
+        meetingModel?.videoModel.videoUpdatedHandler?()
     }
 
     @IBAction func nextPageButtonClicked(_ sender: UIButton) {
-        meetingModel?.videoModel.getNextRemoteVideoPage(completion: { [weak self] success in
-            if success {
-                self?.meetingModel?.videoModel.videoUpdatedHandler?()
-            } else {
-                self?.logger.error(msg: "Failed to get the next remote video page")
-            }
-        })
+        meetingModel?.videoModel.getNextRemoteVideoPage()
+        meetingModel?.videoModel.videoUpdatedHandler?()
     }
 
     @objc private func keyboardShowHandler(notification: NSNotification) {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -135,6 +135,8 @@ class MeetingViewController: UIViewController {
         }
         meetingModel.videoModel.videoUpdatedHandler = { [weak self] in
             meetingModel.videoModel.resumeAllRemoteVideosInCurrentPageExceptUserPausedVideos()
+            self?.prevVideoPageButton.isEnabled = meetingModel.videoModel.canGoToPrevRemoteVideoPage
+            self?.nextVideoPageButton.isEnabled = meetingModel.videoModel.canGoToNextRemoteVideoPage
             self?.videoCollection.reloadData()
         }
         meetingModel.videoModel.localVideoUpdatedHandler = { [weak self] in
@@ -174,6 +176,8 @@ class MeetingViewController: UIViewController {
         }
         endButton.tintColor = .red
         resumeCallKitMeetingButton.isHidden = true
+        prevVideoPageButton.isEnabled = false
+        nextVideoPageButton.isEnabled = false
 
         // Segmented Controler
         segmentedControl.selectedSegmentIndex = SegmentedControlIndex.attendees.rawValue

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
@@ -117,35 +117,23 @@ class VideoModel: NSObject {
         }
     }
 
-    func getPreviousRemoteVideoPage(completion: @escaping (Bool) -> Void) {
-        if !canGoToPrevRemoteVideoPage {
-            completion(false)
-            return
-        }
-
+    func getPreviousRemoteVideoPage() {
         for remoteVideoTileState in remoteVideoStatesInCurrentPage {
             audioVideoFacade.pauseRemoteVideoTile(tileId: remoteVideoTileState.0)
         }
         currentRemoteVideoPageIndex -= 1
-        completion(true)
     }
 
-    func getNextRemoteVideoPage(completion: @escaping (Bool) -> Void) {
-        if !canGoToNextRemoteVideoPage {
-            completion(false)
-            return
-        }
-
+    func getNextRemoteVideoPage() {
         for remoteVideoTileState in remoteVideoStatesInCurrentPage {
             audioVideoFacade.pauseRemoteVideoTile(tileId: remoteVideoTileState.0)
         }
         currentRemoteVideoPageIndex += 1
-        completion(true)
     }
 
     func revalidateRemoteVideoPageIndex() {
         while canGoToPrevRemoteVideoPage, remoteVideoCountInCurrentPage == 0 {
-            getPreviousRemoteVideoPage(completion: { _ in })
+            getPreviousRemoteVideoPage()
         }
     }
 

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
@@ -11,9 +11,13 @@ import UIKit
 
 class VideoModel: NSObject {
     private let maxRemoteVideoTileCount = 8
+    private let remoteVideoTileCountPerPage = 2
+
+    private var remoteVideoPageNumber = 1
 
     private var selfVideoTileState: VideoTileState?
     private var remoteVideoTileStates: [(Int, VideoTileState)] = []
+    private var userPausedVideoTileIds: Set<Int> = Set()
     private let audioVideoFacade: AudioVideoFacade
 
     var videoUpdatedHandler: (() -> Void)?
@@ -25,15 +29,57 @@ class VideoModel: NSObject {
     }
 
     var videoTileCount: Int {
-        return currentRemoteVideoCount + 1
+        return remoteVideoCountInCurrentPage + 1
     }
 
     private var currentRemoteVideoCount: Int {
         return remoteVideoTileStates.count
     }
 
+    var remoteVideoStatesInCurrentPage: [(Int, VideoTileState)] {
+        let remoteVideoStartIndex = (remoteVideoPageNumber - 1) * remoteVideoTileCountPerPage
+        let remoteVideoEndIndex = min(currentRemoteVideoCount, remoteVideoStartIndex + remoteVideoTileCountPerPage) - 1
+
+        if remoteVideoEndIndex < remoteVideoStartIndex {
+            return []
+        }
+        return Array(remoteVideoTileStates[remoteVideoStartIndex...remoteVideoEndIndex])
+    }
+
+    private var remoteVideoStatesNotInCurrentPage: [(Int, VideoTileState)] {
+        let remoteVideoAttendeeIdsInCurrentPage = Set(remoteVideoStatesInCurrentPage.map { $0.1.attendeeId })
+        return remoteVideoTileStates.filter { !remoteVideoAttendeeIdsInCurrentPage.contains($0.1.attendeeId) }
+    }
+
+    private var remoteVideoCountInCurrentPage: Int {
+        return remoteVideoStatesInCurrentPage.count
+    }
+
     private var isMaximumRemoteVideoReached: Bool {
         return currentRemoteVideoCount >= maxRemoteVideoTileCount
+    }
+
+    func updateRemoteVideoStatesBasedOnActiveSpeakers(activeSpeakers: [AttendeeInfo]) {
+        let activeSpeakerIds = Set(activeSpeakers.map { $0.attendeeId })
+
+        // Cast to NSArray to make sure the sorting implementation is stable
+        remoteVideoTileStates = (remoteVideoTileStates as NSArray).sortedArray(options: .stable,
+                                                                               usingComparator: { (lhs, rhs) -> ComparisonResult in
+            let lhsIsActiveSpeaker = activeSpeakerIds.contains((lhs as? (Int, VideoTileState))?.1.attendeeId ?? "")
+            let rhsIsActiveSpeaker = activeSpeakerIds.contains((rhs as? (Int, VideoTileState))?.1.attendeeId ?? "")
+
+            if lhsIsActiveSpeaker == rhsIsActiveSpeaker {
+                return ComparisonResult.orderedSame
+            } else if lhsIsActiveSpeaker && !rhsIsActiveSpeaker {
+                return ComparisonResult.orderedAscending
+            } else {
+                return ComparisonResult.orderedDescending
+            }
+        }) as? [(Int, VideoTileState)] ?? []
+
+        for remoteVideoTileState in remoteVideoStatesNotInCurrentPage {
+            audioVideoFacade.pauseRemoteVideoTile(tileId: remoteVideoTileState.0)
+        }
     }
 
     func setSelfVideoTileState(_ videoTileState: VideoTileState?) {
@@ -58,13 +104,48 @@ class VideoModel: NSObject {
         }
     }
 
-    func resumeAllRemoteVideo() {
-        for remoteVideoTileState in remoteVideoTileStates {
-            audioVideoFacade.resumeRemoteVideoTile(tileId: remoteVideoTileState.0)
+    func getPreviousRemoteVideoPage(completion: @escaping (Bool) -> Void) {
+        if remoteVideoPageNumber <= 1 {
+            completion(false)
+            return
+        }
+
+        for remoteVideoTileState in remoteVideoStatesInCurrentPage {
+            audioVideoFacade.pauseRemoteVideoTile(tileId: remoteVideoTileState.0)
+        }
+        remoteVideoPageNumber -= 1
+        completion(true)
+    }
+
+    func getNextRemoteVideoPage(completion: @escaping (Bool) -> Void) {
+        let maxPageNumber = Int(ceil(Double(currentRemoteVideoCount) / Double(remoteVideoTileCountPerPage)))
+        if remoteVideoPageNumber >= maxPageNumber {
+            completion(false)
+            return
+        }
+
+        for remoteVideoTileState in remoteVideoStatesInCurrentPage {
+            audioVideoFacade.pauseRemoteVideoTile(tileId: remoteVideoTileState.0)
+        }
+        remoteVideoPageNumber += 1
+        completion(true)
+    }
+
+    func revalidateRemoteVideoPageNumber() {
+        while remoteVideoPageNumber != 1, remoteVideoCountInCurrentPage == 0 {
+            getPreviousRemoteVideoPage(completion: { _ in })
         }
     }
 
-    func pauseAllRemoteVideo() {
+    func resumeAllRemoteVideosInCurrentPageExceptUserPausedVideos() {
+        for remoteVideoTileState in remoteVideoStatesInCurrentPage {
+            if !userPausedVideoTileIds.contains(remoteVideoTileState.0) {
+                audioVideoFacade.resumeRemoteVideoTile(tileId: remoteVideoTileState.0)
+            }
+        }
+    }
+
+    func pauseAllRemoteVideos() {
         for remoteVideoTileState in remoteVideoTileStates {
             audioVideoFacade.pauseRemoteVideoTile(tileId: remoteVideoTileState.0)
         }
@@ -74,10 +155,10 @@ class VideoModel: NSObject {
         if indexPath.item == 0 {
             return selfVideoTileState
         }
-        if indexPath.item > currentRemoteVideoCount {
+        if indexPath.item > remoteVideoTileCountPerPage {
             return nil
         }
-        return remoteVideoTileStates[indexPath.item - 1].1
+        return remoteVideoStatesInCurrentPage[indexPath.item - 1].1
     }
 }
 
@@ -88,8 +169,10 @@ extension VideoModel: VideoTileCellDelegate {
         } else {
             if let tileState = getVideoTileState(for: IndexPath(item: tag, section: 0)), !tileState.isLocalTile {
                 if selected {
+                    userPausedVideoTileIds.insert(tileState.tileId)
                     audioVideoFacade.pauseRemoteVideoTile(tileId: tileState.tileId)
                 } else {
+                    userPausedVideoTileIds.remove(tileState.tileId)
                     audioVideoFacade.resumeRemoteVideoTile(tileId: tileState.tileId)
                 }
             }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoTileCell.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoTileCell.swift
@@ -32,9 +32,6 @@ class VideoTileCell: UICollectionViewCell {
         backgroundColor = .systemGray
         isHidden = false
 
-        // Clean up old video image to prevent frame flicker
-        videoRenderView.renderFrame(frame: nil)
-
         // Self video cell not active
         if isSelf, !isVideoActive {
             onTileButton.isHidden = true
@@ -74,6 +71,8 @@ class VideoTileCell: UICollectionViewCell {
         videoRenderView.backgroundColor = .systemGray
         videoRenderView.isHidden = true
         videoRenderView.mirror = false
+        // Clean up old video image to prevent frame flicker
+        videoRenderView.renderFrame(frame: nil)
     }
 
     @objc func onTileButtonClicked(_ sender: UIButton) {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoTileCell.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoTileCell.swift
@@ -24,10 +24,16 @@ class VideoTileCell: UICollectionViewCell {
 
     weak var delegate: VideoTileCellDelegate?
 
-    func updateCell(name: String, isSelf: Bool, isVideoActive: Bool, tag: Int) {
+    func updateCell(name: String, isSelf: Bool, videoTileState: VideoTileState?, tag: Int) {
+        let isVideoActive = videoTileState != nil
+        let isVideoPausedByUser = isVideoActive && videoTileState?.pauseState == .pausedByUserRequest
+
         attendeeName.text = name
         backgroundColor = .systemGray
         isHidden = false
+
+        // Clean up old video image to prevent frame flicker
+        videoRenderView.renderFrame(frame: nil)
 
         // Self video cell not active
         if isSelf, !isVideoActive {
@@ -44,6 +50,7 @@ class VideoTileCell: UICollectionViewCell {
         onTileButton.isHidden = false
         onTileButton.tag = tag
         onTileButton.addTarget(self, action: #selector(onTileButtonClicked), for: .touchUpInside)
+        onTileButton.isSelected = isVideoPausedByUser
 
         if isSelf {
             onTileButton.setImage(UIImage(named: "switch-camera")?.withRenderingMode(.alwaysTemplate),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ### Added
 * **Breaking** Added additional `externalUserId` field for `MeetingSessionCredentials`
+* Added video pagination feature in the Swift demo app. Remote videos will be paginated into several pages. Each page contains at most 2 remote videos, and user can switch between different pages. Videos that are not being displayed will not consume any network bandwidth or computation resource.
+* Added active-speaker-based video tile feature in the Swift demo app. Video tiles of active speakers will be promoted to the top of the list automatically.
+
+### Changed
+* **Breaking** Changed the behavior of `DefaultVideoRenderView` so that it clears the internal `ImageView` when it receives a nil frame.
+* Changed the Swift demo app so that it will not subscribe to video streams when user is not viewing the Videos tab.
 
 ### Fixed
 * Fixed a bug that attendee events got filtered out due to absence of `externalUserId`
+* Fixed the video flicker issue when binding video tile to a recycled `DefaultVideoRenderView`.
+* Fixed the local video binding issue when local video was not enabled yet.
 
 ## [0.8.2] - 2020-08-13
 


### PR DESCRIPTION
### Issue #, if available:
- Chime-30251
- Chime-30288

### Description of changes:
**New major features:**
- Video pagination. Remote videos will be paginated into several pages. Each page contains at most 2 remote videos, and user can switch between different pages. Videos that are not being displayed will not consume any network bandwidth or computation resource.
- Video tiles ordered by the active speaker status. Video tiles of active speakers will be promoted to the top of the list automatically.

**Bug fixes:**
- Clear `imageView` when `DefaultVideoRenderView` receives a nil frame, to fix the video flicker issue.
- Properly bind local video even when local video was not enabled yet.

**General improvement:**
- Do not subscribe to video stream when user is not looking at the Videos tab.

### Testing done:
- Was able to view remote videos when # of remote videos <= 2
- Was able to view remote videos when # of remote videos > 2. Was able to switch pages by clicking the "Prev page" and "Next page" buttons.
- Was able to promote the video tiles of active speakers to the first page, and properly push other video tiles to the following pages.
- Was able to pause/resume video tiles by clicking the pause/resume button on the remote video tile. The pause status from user was not impacted by the new pagination logic.
- Was able to switch to the previous page automatically when remote videos were not available anymore and the current page does not have any video tile.
- Was able to unsubscribe(pause) remote videos when user switch to other tabs, and resubscribe(resume) remote videos when user switch back to the Video tab.
- The pagination UI looks fine in both portrait mode and landscape mode.
- Unit tests passed.

#### Manual test cases (add more as needed):

- [x] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [x] Rejoin meeting
- [x] See metrics
- [x] See attendee presence
- [x] Send audio
- [x] Receive audio
- [x] Mute self
- [x] Unmute self
- [x] See local mute indicator when muted
- [x] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [x] Enable and disable remote video from remote side
- [ ] Send local video
- [x] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

### Screenshots, if available:
![active-speaker-pagination](https://user-images.githubusercontent.com/40373084/91774514-d2f6bd80-eb9d-11ea-8e65-e284709ef9bb.gif)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
