### PR TITLE
Remove AVAudioSession dependency; add unit tests

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
+++ b/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		C6DA0B2924F71C1C00028F2B /* AudioSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DA0B2824F71C1C00028F2B /* AudioSession.swift */; };
 		C6DA0B5B24F80BAC00028F2B /* AudioClientProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DA0B5A24F80BAC00028F2B /* AudioClientProtocol.swift */; };
 		C6DA0B5D24F8107000028F2B /* AudioLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DA0B5C24F8107000028F2B /* AudioLock.swift */; };
+		C6DA0B6224F961AA00028F2B /* DefaultAudioVideoControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DA0B6124F961AA00028F2B /* DefaultAudioVideoControllerTests.swift */; };
 		F8204ADC23F499410099E3D1 /* MeetingSessionTURNCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8204ADB23F499410099E3D1 /* MeetingSessionTURNCredentials.swift */; };
 		F82D50D723FC752600D8F18C /* SignalStrength.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82D50C223FC732300D8F18C /* SignalStrength.swift */; };
 		F82D50D823FC752600D8F18C /* VolumeLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82D50C323FC732300D8F18C /* VolumeLevel.swift */; };
@@ -261,6 +262,7 @@
 		C6DA0B2824F71C1C00028F2B /* AudioSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSession.swift; sourceTree = "<group>"; };
 		C6DA0B5A24F80BAC00028F2B /* AudioClientProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioClientProtocol.swift; sourceTree = "<group>"; };
 		C6DA0B5C24F8107000028F2B /* AudioLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioLock.swift; sourceTree = "<group>"; };
+		C6DA0B6124F961AA00028F2B /* DefaultAudioVideoControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAudioVideoControllerTests.swift; sourceTree = "<group>"; };
 		F8204ADB23F499410099E3D1 /* MeetingSessionTURNCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingSessionTURNCredentials.swift; sourceTree = "<group>"; };
 		F82D50C223FC732300D8F18C /* SignalStrength.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalStrength.swift; sourceTree = "<group>"; };
 		F82D50C323FC732300D8F18C /* VolumeLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeLevel.swift; sourceTree = "<group>"; };
@@ -555,6 +557,7 @@
 				5A631A52242993AE00C8DAF3 /* video */,
 				5AE76F2424203AA2009C41FD /* SignalStrengthTests.swift */,
 				5AE76F2624203AAA009C41FD /* VolumeLevelTests.swift */,
+				C6DA0B6124F961AA00028F2B /* DefaultAudioVideoControllerTests.swift */,
 			);
 			path = audiovideo;
 			sourceTree = "<group>";
@@ -1010,6 +1013,7 @@
 				5AE1323323EA972C00BF5997 /* MeetingSessionURLsTests.swift in Sources */,
 				C6DA0B2624F7118000028F2B /* DefaultAudioClientControllerTests.swift in Sources */,
 				5AE76F2924203AB8009C41FD /* ObservableMetricTests.swift in Sources */,
+				C6DA0B6224F961AA00028F2B /* DefaultAudioVideoControllerTests.swift in Sources */,
 				5AE76F32242044A6009C41FD /* PermissionErrorTests.swift in Sources */,
 				5AE76F2524203AA2009C41FD /* SignalStrengthTests.swift in Sources */,
 				5AE76F1E24203A63009C41FD /* SignalUpdateTests.swift in Sources */,

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoController.swift
@@ -44,11 +44,11 @@ import Foundation
         }
 
         try audioClientController.start(audioFallbackUrl: configuration.urls.audioFallbackUrl,
-                                    audioHostUrl: configuration.urls.audioHostUrl,
-                                    meetingId: configuration.meetingId,
-                                    attendeeId: configuration.credentials.attendeeId,
-                                    joinToken: configuration.credentials.joinToken,
-                                    callKitEnabled: callKitEnabled)
+                                        audioHostUrl: configuration.urls.audioHostUrl,
+                                        meetingId: configuration.meetingId,
+                                        attendeeId: configuration.credentials.attendeeId,
+                                        joinToken: configuration.credentials.joinToken,
+                                        callKitEnabled: callKitEnabled)
         videoClientController.start(turnControlUrl: configuration.urls.turnControlUrl,
                                     signalingUrl: configuration.urls.signalingUrl,
                                     meetingId: configuration.meetingId,

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoController.swift
@@ -39,11 +39,6 @@ import Foundation
     }
 
     public func start(callKitEnabled: Bool) throws {
-        let audioPermissionStatus = AVAudioSession.sharedInstance().recordPermission
-        if audioPermissionStatus == .denied || audioPermissionStatus == .undetermined {
-            throw PermissionError.audioPermissionError
-        }
-
         if let audioClientObserver = audioClientObserver as? DefaultAudioClientObserver {
             DefaultAudioClient.shared(logger: logger).delegate = audioClientObserver
         }
@@ -55,9 +50,9 @@ import Foundation
                                     joinToken: configuration.credentials.joinToken,
                                     callKitEnabled: callKitEnabled)
         videoClientController.start(turnControlUrl: configuration.urls.turnControlUrl,
-                                        signalingUrl: configuration.urls.signalingUrl,
-                                        meetingId: configuration.meetingId,
-                                        joinToken: configuration.credentials.joinToken)
+                                    signalingUrl: configuration.urls.signalingUrl,
+                                    meetingId: configuration.meetingId,
+                                    joinToken: configuration.credentials.joinToken)
     }
 
     public func stop() {
@@ -72,7 +67,7 @@ import Foundation
 
     public func removeAudioVideoObserver(observer: AudioVideoObserver) {
         audioClientObserver.unsubscribeFromAudioClientStateChange(observer: observer)
-        videoClientController.unsubscribeToVideoClientStateChange(observer: observer)
+        videoClientController.unsubscribeFromVideoClientStateChange(observer: observer)
     }
 
     public func addMetricsObserver(observer: MetricsObserver) {

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientProtocol.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientProtocol.swift
@@ -10,7 +10,17 @@ import AmazonChimeSDKMedia
 import Foundation
 
 @objc public protocol AudioClientProtocol {
-    func startSession(_ host: String!, basePort port: Int, callId: String!, profileId: String!, microphoneMute mic_mute: Bool, speakerMute spk_mute: Bool, isPresenter presenter: Bool, sessionToken tokenString: String!, audioWsUrl: String!, callKitEnabled: Bool) -> audio_client_status_t
+    // swiftlint:disable function_parameter_count variable_name
+    func startSession(_ host: String!,
+                      basePort port: Int,
+                      callId: String!,
+                      profileId: String!,
+                      microphoneMute mic_mute: Bool,
+                      speakerMute spk_mute: Bool,
+                      isPresenter presenter: Bool,
+                      sessionToken tokenString: String!,
+                      audioWsUrl: String!,
+                      callKitEnabled: Bool) -> audio_client_status_t
 
     func stopSession() -> Int
 

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientProtocol.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientProtocol.swift
@@ -21,6 +21,7 @@ import Foundation
                       sessionToken tokenString: String!,
                       audioWsUrl: String!,
                       callKitEnabled: Bool) -> audio_client_status_t
+    // swiftlint:enable function_parameter_count variable_name
 
     func stopSession() -> Int
 

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
@@ -430,7 +430,7 @@ extension DefaultVideoClientController: VideoClientController {
         videoObservers.add(observer)
     }
 
-    public func unsubscribeToVideoClientStateChange(observer: AudioVideoObserver) {
+    public func unsubscribeFromVideoClientStateChange(observer: AudioVideoObserver) {
         videoObservers.remove(observer)
     }
 
@@ -438,7 +438,7 @@ extension DefaultVideoClientController: VideoClientController {
         videoTileControllerObservers.add(observer)
     }
 
-    public func unsubscribeToVideoTileControllerObservers(observer: VideoTileController) {
+    public func unsubscribeFromVideoTileControllerObservers(observer: VideoTileController) {
         videoTileControllerObservers.remove(observer)
     }
 

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientController.swift
@@ -23,9 +23,9 @@ import Foundation
     func getCurrentDevice() -> VideoDevice?
     func getConfiguration() -> MeetingSessionConfiguration
     func subscribeToVideoClientStateChange(observer: AudioVideoObserver)
-    func unsubscribeToVideoClientStateChange(observer: AudioVideoObserver)
+    func unsubscribeFromVideoClientStateChange(observer: AudioVideoObserver)
     func subscribeToVideoTileControllerObservers(observer: VideoTileController)
-    func unsubscribeToVideoTileControllerObservers(observer: VideoTileController)
+    func unsubscribeFromVideoTileControllerObservers(observer: VideoTileController)
     func pauseResumeRemoteVideo(_ videoId: UInt32, pause: Bool)
     func subscribeToReceiveDataMessage(topic: String, observer: DataMessageObserver)
     func unsubscribeFromReceiveDataMessageFromTopic(topic: String)

--- a/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/DefaultAudioVideoControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/DefaultAudioVideoControllerTests.swift
@@ -1,0 +1,163 @@
+//
+//  DefaultAudioVideoControllerTests.swift
+//  AmazonChimeSDK
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import AmazonChimeSDK
+import AVFoundation
+import Mockingbird
+import XCTest
+
+class DefaultAudioVideoControllerTests: XCTestCase {
+    let externalMeetingId = "external-meeting-id"
+    let audioFallbackUrl = "audioFallbackUrl"
+    let audioHostUrl = "audioHostUrl"
+    let signalingUrl = "signalingUrl"
+    let turnControlUrl = "turnControlUrl"
+    let mediaRegion = "us-east-1"
+    let meetingId = "meeting-id"
+    let attendeeId = "attendee-id"
+    let externalUserId = "externalUserId"
+    let joinToken = "join-token"
+
+    var meetingSessionConfigurationMock: MeetingSessionConfigurationMock!
+    var loggerMock: LoggerMock!
+    var audioClientControllerMock: AudioClientControllerMock!
+    var audioClientObserverMock: AudioClientObserverMock!
+    var clientMetricsCollectorMock: ClientMetricsCollectorMock!
+    var videoClientControllerMock: VideoClientControllerMock!
+    var defaultAudioClientMock: DefaultAudioClientMock!
+    var defaultAudioVideoController: DefaultAudioVideoController!
+
+    override func setUp() {
+        let mediaPlacementMock: MediaPlacementMock = mock(MediaPlacement.self)
+            .initialize(audioFallbackUrl: audioFallbackUrl,
+                        audioHostUrl: audioHostUrl,
+                        signalingUrl: signalingUrl,
+                        turnControlUrl: turnControlUrl)
+        let meetingMock: MeetingMock = mock(Meeting.self).initialize(externalMeetingId: externalMeetingId,
+                                                                     mediaPlacement: mediaPlacementMock,
+                                                                     mediaRegion: mediaRegion,
+                                                                     meetingId: meetingId)
+        let createMeetingResponseMock: CreateMeetingResponseMock = mock(CreateMeetingResponse.self)
+            .initialize(meeting: meetingMock)
+
+        let attendeeMock: AttendeeMock = mock(Attendee.self).initialize(attendeeId: attendeeId,
+                                                                        externalUserId: externalUserId,
+                                                                        joinToken: joinToken)
+        let createAttendeeResponseMock: CreateAttendeeResponseMock = mock(CreateAttendeeResponse.self)
+            .initialize(attendee: attendeeMock)
+
+        meetingSessionConfigurationMock = mock(MeetingSessionConfiguration.self)
+            .initialize(createMeetingResponse: createMeetingResponseMock,
+                        createAttendeeResponse: createAttendeeResponseMock,
+                        urlRewriter: URLRewriterUtils.defaultUrlRewriter)
+        loggerMock = mock(Logger.self)
+        audioClientControllerMock = mock(AudioClientController.self)
+        audioClientObserverMock = mock(AudioClientObserver.self)
+        clientMetricsCollectorMock = mock(ClientMetricsCollector.self)
+        videoClientControllerMock = mock(VideoClientController.self)
+
+        defaultAudioVideoController = DefaultAudioVideoController(audioClientController: audioClientControllerMock,
+                                                                  audioClientObserver: audioClientObserverMock,
+                                                                  clientMetricsCollector: clientMetricsCollectorMock,
+                                                                  videoClientController: videoClientControllerMock,
+                                                                  configuration: meetingSessionConfigurationMock,
+                                                                  logger: loggerMock)
+    }
+
+    func testStart() {
+        XCTAssertNoThrow(try defaultAudioVideoController.start())
+        
+        verify(audioClientControllerMock.start(audioFallbackUrl: self.meetingSessionConfigurationMock.urls.audioFallbackUrl,
+                                               audioHostUrl: self.meetingSessionConfigurationMock.urls.audioHostUrl,
+                                               meetingId: self.meetingSessionConfigurationMock.meetingId,
+                                               attendeeId: self.meetingSessionConfigurationMock.credentials.attendeeId,
+                                               joinToken: self.meetingSessionConfigurationMock.credentials.joinToken,
+                                               callKitEnabled: false)).wasCalled()
+        verify(videoClientControllerMock.start(turnControlUrl: self.meetingSessionConfigurationMock.urls.turnControlUrl,
+                                               signalingUrl: self.meetingSessionConfigurationMock.urls.signalingUrl,
+                                               meetingId: self.meetingSessionConfigurationMock.meetingId,
+                                               joinToken: self.meetingSessionConfigurationMock.credentials.joinToken)).wasCalled()
+    }
+    
+    func testStart_callKitEnabled() {
+        let callKitEnabled = true;
+        XCTAssertNoThrow(try defaultAudioVideoController.start(callKitEnabled: callKitEnabled))
+        
+        verify(audioClientControllerMock.start(audioFallbackUrl: self.meetingSessionConfigurationMock.urls.audioFallbackUrl,
+                                               audioHostUrl: self.meetingSessionConfigurationMock.urls.audioHostUrl,
+                                               meetingId: self.meetingSessionConfigurationMock.meetingId,
+                                               attendeeId: self.meetingSessionConfigurationMock.credentials.attendeeId,
+                                               joinToken: self.meetingSessionConfigurationMock.credentials.joinToken,
+                                               callKitEnabled: callKitEnabled)).wasCalled()
+        verify(videoClientControllerMock.start(turnControlUrl: self.meetingSessionConfigurationMock.urls.turnControlUrl,
+                                               signalingUrl: self.meetingSessionConfigurationMock.urls.signalingUrl,
+                                               meetingId: self.meetingSessionConfigurationMock.meetingId,
+                                               joinToken: self.meetingSessionConfigurationMock.credentials.joinToken)).wasCalled()
+    }
+
+    func testStop() {
+        defaultAudioVideoController.stop()
+
+        verify(audioClientControllerMock.stop()).wasCalled()
+        verify(videoClientControllerMock.stopAndDestroy()).wasCalled()
+    }
+    
+    func testAddAudioVideoObserver() {
+        let audioVideoObserverMock: AudioVideoObserverMock = mock(AudioVideoObserver.self)
+        defaultAudioVideoController.addAudioVideoObserver(observer: audioVideoObserverMock)
+
+        verify(audioClientObserverMock.subscribeToAudioClientStateChange(observer: audioVideoObserverMock)).wasCalled()
+        verify(videoClientControllerMock.subscribeToVideoClientStateChange(observer: audioVideoObserverMock)).wasCalled()
+    }
+    
+    func testRemoveAudioVideoObserver() {
+        let audioVideoObserverMock: AudioVideoObserverMock = mock(AudioVideoObserver.self)
+        defaultAudioVideoController.removeAudioVideoObserver(observer: audioVideoObserverMock)
+        
+        verify(audioClientObserverMock.unsubscribeFromAudioClientStateChange(observer: audioVideoObserverMock)).wasCalled()
+        verify(videoClientControllerMock.unsubscribeFromVideoClientStateChange(observer: audioVideoObserverMock)).wasCalled()
+    }
+    
+    func testAddMetricsObserver() {
+        let metricsObserverMock: MetricsObserverMock = mock(MetricsObserver.self)
+        defaultAudioVideoController.addMetricsObserver(observer: metricsObserverMock)
+        
+        verify(clientMetricsCollectorMock.subscribeToMetrics(observer: metricsObserverMock)).wasCalled()
+    }
+    
+    func testRemoveMetricsObserver() {
+        let metricsObserverMock: MetricsObserverMock = mock(MetricsObserver.self)
+        defaultAudioVideoController.removeMetricsObserver(observer: metricsObserverMock)
+        
+        verify(clientMetricsCollectorMock.unsubscribeFromMetrics(observer: metricsObserverMock)).wasCalled()
+    }
+    
+    func testStartLocalVideo() {
+        XCTAssertNoThrow(try defaultAudioVideoController.startLocalVideo())
+        
+        verify(videoClientControllerMock.startLocalVideo()).wasCalled()
+    }
+    
+    func testStopLocalVideo() {
+        defaultAudioVideoController.stopLocalVideo()
+        
+        verify(videoClientControllerMock.stopLocalVideo()).wasCalled()
+    }
+    
+    func testStartRemoteVideo() {
+        defaultAudioVideoController.startRemoteVideo()
+        
+        verify(videoClientControllerMock.startRemoteVideo()).wasCalled()
+    }
+    
+    func testStopRemoteVideo() {
+        defaultAudioVideoController.stopRemoteVideo()
+        
+        verify(videoClientControllerMock.stopRemoteVideo()).wasCalled()
+    }
+}

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientControllerTests.swift
@@ -53,7 +53,12 @@ class DefaultAudioClientControllerTests: XCTestCase {
     func testStart_recordPermissionNotGranted() {
         given(audioSessionMock.getRecordPermission()).willReturn(.denied)
 
-        XCTAssertThrowsError(try defaultAudioClientController.start(audioFallbackUrl: audioFallbackUrl, audioHostUrl: audioHostUrl, meetingId: meetingId, attendeeId: attendeeId, joinToken: joinToken, callKitEnabled: callKitEnabled))
+        XCTAssertThrowsError(try defaultAudioClientController.start(audioFallbackUrl: audioFallbackUrl,
+                                                                    audioHostUrl: audioHostUrl,
+                                                                    meetingId: meetingId,
+                                                                    attendeeId: attendeeId,
+                                                                    joinToken: joinToken,
+                                                                    callKitEnabled: callKitEnabled))
         verify(audioLockMock.lock()).wasCalled()
         verify(audioLockMock.unlock()).wasCalled()
     }
@@ -62,7 +67,12 @@ class DefaultAudioClientControllerTests: XCTestCase {
         DefaultAudioClientController.state = .started
         given(audioSessionMock.getRecordPermission()).willReturn(.granted)
 
-        XCTAssertThrowsError(try defaultAudioClientController.start(audioFallbackUrl: audioFallbackUrl, audioHostUrl: audioHostUrl, meetingId: meetingId, attendeeId: attendeeId, joinToken: joinToken, callKitEnabled: callKitEnabled))
+        XCTAssertThrowsError(try defaultAudioClientController.start(audioFallbackUrl: audioFallbackUrl,
+                                                                    audioHostUrl: audioHostUrl,
+                                                                    meetingId: meetingId,
+                                                                    attendeeId: attendeeId,
+                                                                    joinToken: joinToken,
+                                                                    callKitEnabled: callKitEnabled))
         verify(audioLockMock.lock()).wasCalled()
         verify(audioLockMock.unlock()).wasCalled()
     }
@@ -70,9 +80,23 @@ class DefaultAudioClientControllerTests: XCTestCase {
     func testStart_startedOk() {
         DefaultAudioClientController.state = .initialized
         given(audioSessionMock.getRecordPermission()).willReturn(.granted)
-        given(audioClientMock.startSession(any(), basePort: any(), callId: any(), profileId: any(), microphoneMute: any(), speakerMute: any(), isPresenter: any(), sessionToken: any(), audioWsUrl: any(), callKitEnabled: any())).willReturn(AUDIO_CLIENT_OK)
+        given(audioClientMock.startSession(any(),
+                                           basePort: any(),
+                                           callId: any(),
+                                           profileId: any(),
+                                           microphoneMute: any(),
+                                           speakerMute: any(),
+                                           isPresenter: any(),
+                                           sessionToken: any(),
+                                           audioWsUrl: any(),
+                                           callKitEnabled: any())).willReturn(AUDIO_CLIENT_OK)
 
-        XCTAssertNoThrow(try defaultAudioClientController.start(audioFallbackUrl: audioFallbackUrl, audioHostUrl: audioHostUrl, meetingId: meetingId, attendeeId: attendeeId, joinToken: joinToken, callKitEnabled: callKitEnabled))
+        XCTAssertNoThrow(try defaultAudioClientController.start(audioFallbackUrl: audioFallbackUrl,
+                                                                audioHostUrl: audioHostUrl,
+                                                                meetingId: meetingId,
+                                                                attendeeId: attendeeId,
+                                                                joinToken: joinToken,
+                                                                callKitEnabled: callKitEnabled))
         verify(audioLockMock.lock()).wasCalled()
         verify(audioClientObserverMock.notifyAudioClientObserver(observerFunction: any())).wasCalled()
         verify(audioClientMock.startSession("audio-host-url",
@@ -92,9 +116,23 @@ class DefaultAudioClientControllerTests: XCTestCase {
     func testStart_failedToStart() {
         DefaultAudioClientController.state = .initialized
         given(audioSessionMock.getRecordPermission()).willReturn(.granted)
-        given(audioClientMock.startSession(any(), basePort: any(), callId: any(), profileId: any(), microphoneMute: any(), speakerMute: any(), isPresenter: any(), sessionToken: any(), audioWsUrl: any(), callKitEnabled: any())).willReturn(AUDIO_CLIENT_ERR)
+        given(audioClientMock.startSession(any(),
+                                           basePort: any(),
+                                           callId: any(),
+                                           profileId: any(),
+                                           microphoneMute: any(),
+                                           speakerMute: any(),
+                                           isPresenter: any(),
+                                           sessionToken: any(),
+                                           audioWsUrl: any(),
+                                           callKitEnabled: any())).willReturn(AUDIO_CLIENT_ERR)
 
-        XCTAssertThrowsError(try defaultAudioClientController.start(audioFallbackUrl: audioFallbackUrl, audioHostUrl: audioHostUrl, meetingId: meetingId, attendeeId: attendeeId, joinToken: joinToken, callKitEnabled: callKitEnabled))
+        XCTAssertThrowsError(try defaultAudioClientController.start(audioFallbackUrl: audioFallbackUrl,
+                                                                    audioHostUrl: audioHostUrl,
+                                                                    meetingId: meetingId,
+                                                                    attendeeId: attendeeId,
+                                                                    joinToken: joinToken,
+                                                                    callKitEnabled: callKitEnabled))
         verify(audioLockMock.lock()).wasCalled()
         verify(audioClientObserverMock.notifyAudioClientObserver(observerFunction: any())).wasCalled()
         verify(audioClientMock.startSession("audio-host-url",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* **Breaking** Removed audio permission check in `DefaultAudioVideoController` which is performed in `DefaultAudioClientController`. For developers who has their own `AudioClientController` implementation, please make sure to check audio permission in `start()`.
+
 ## [0.9.0] - 2020-09-01
 
 ### Added


### PR DESCRIPTION
### Issue #, if available:
Chime-24740

### Description of changes:
* `DefaultAudioVideoController.start()` checks audio record permission, and hards code dependency of AVAudioSession which prevents running unit tests properly
* Removed the permission check since it's done in `DefaultAudioVideoController.start()` on the same call stack
* Unit test coverage is now at 40.3%

### Testing done:
Tested with fresh install of the demo app, permission popup shows up correctly on first use.

#### Manual test cases (add more as needed):

- [x] Join meeting without CallKit
- [x] Join meeting with CallKit as Incoming
- [x] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [x] See attendee presence
- [x] Send audio
- [x] Receive audio
- [x] Mute self
- [x] Unmute self
- [x] See local mute indicator when muted
- [x] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [x] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
