### PR TITLE
Add getActiveAudioDevice api

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
@@ -178,4 +178,8 @@ import Foundation
     }
 
     public func hasBandwidthPriorityCallback(hasBandwidthPriority: Bool) {}
+
+    public func getActiveAudioDevice() -> MediaDevice? {
+        return deviceController.getActiveAudioDevice()
+    }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/device/DeviceController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/device/DeviceController.swift
@@ -36,4 +36,8 @@ import Foundation
     /// Get currently used video device
     /// - Returns: a media device or nil if no device is present
     func getActiveCamera() -> MediaDevice?
+
+    /// Get currently used audio device
+    /// - Returns: a media device or nil if no device is present
+    func getActiveAudioDevice() -> MediaDevice?
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientProtocol.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientProtocol.swift
@@ -5,6 +5,7 @@
 //  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  SPDX-License-Identifier: Apache-2.0
 //
+// swiftlint:disable identifier_name function_parameter_count
 
 import AmazonChimeSDKMedia
 import Foundation

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioSession.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioSession.swift
@@ -14,6 +14,7 @@ import Foundation
     var availableInputs: [AVAudioSessionPortDescription]? { get }
     func setPreferredInput(_ inPort: AVAudioSessionPortDescription?) throws
     func overrideOutputAudioPort(_ portOverride: AVAudioSession.PortOverride) throws
+    var currentRoute: AVAudioSessionRouteDescription { get }
 }
 
 extension AVAudioSession: AudioSession {}

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -343,7 +343,7 @@ extension MeetingModel: AudioVideoObserver {
 
     func audioSessionDidStart(reconnecting: Bool) {
         notifyHandler?("Audio successfully started. Reconnecting: \(reconnecting)")
-        logWithFunctionName(message: "reconnecting \(reconnecting)")
+        logWithFunctionName(message: "reconnecting \(reconnecting), device \(currentMeetingSession.audioVideo.getActiveAudioDevice()?.label ?? "none")")
         if !reconnecting {
             call?.isConnectedHandler?()
         }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -278,6 +278,7 @@ class MeetingViewController: UIViewController {
         guard let meetingModel = meetingModel else {
             return
         }
+
         let optionMenu = UIAlertController(title: nil, message: "Choose Audio Device", preferredStyle: .actionSheet)
 
         for inputDevice in meetingModel.audioDevices {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## Unreleased
+
+### Added
+* Added `getActiveAudioDevice` in `DefaultDeviceController`
+
+### Removed
 * **Breaking** Removed audio permission check in `DefaultAudioVideoController` which is performed in `DefaultAudioClientController`. For developers who has their own `AudioClientController` implementation, please make sure to check audio permission in `start()`.
 
 ## [0.9.0] - 2020-09-01


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
Added current audio device API

### Testing done:

#### Manual test cases (add more as needed):

- [ ] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [ ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
