### PR TITLE
Expose default classes to ObjC by inheriting NSObject

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoController.swift
@@ -9,7 +9,7 @@
 import AVFoundation
 import Foundation
 
-@objcMembers public class DefaultAudioVideoController: AudioVideoControllerFacade {
+@objcMembers public class DefaultAudioVideoController: NSObject, AudioVideoControllerFacade {
     public let configuration: MeetingSessionConfiguration
     public let logger: Logger
 

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-@objcMembers public class DefaultAudioVideoFacade: AudioVideoFacade {
+@objcMembers public class DefaultAudioVideoFacade: NSObject, AudioVideoFacade {
     public let configuration: MeetingSessionConfiguration
     public let logger: Logger
 

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/audio/activespeakerdetector/DefaultActiveSpeakerDetector.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/audio/activespeakerdetector/DefaultActiveSpeakerDetector.swift
@@ -13,7 +13,7 @@ import Foundation
  */
 typealias DetectorCallback = (_ attendeeIds: [AttendeeInfo]) -> Void
 
-@objcMembers public class DefaultActiveSpeakerDetector: ActiveSpeakerDetectorFacade, RealtimeObserver {
+@objcMembers public class DefaultActiveSpeakerDetector: NSObject, ActiveSpeakerDetectorFacade, RealtimeObserver {
     private static let activityWaitIntervalMs = 1000
     private static let activityUpdateIntervalMs = 200
 
@@ -33,6 +33,7 @@ typealias DetectorCallback = (_ attendeeIds: [AttendeeInfo]) -> Void
     ) {
         self.audioClientObserver = audioClientObserver
         self.selfAttendeeId = selfAttendeeId
+        super.init()
         audioClientObserver.subscribeToRealTimeEvents(observer: self)
 
         timer = IntervalScheduler(

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/audio/activespeakerpolicy/DefaultActiveSpeakerPolicy.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/audio/activespeakerpolicy/DefaultActiveSpeakerPolicy.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-@objcMembers public class DefaultActiveSpeakerPolicy: ActiveSpeakerPolicy {
+@objcMembers public class DefaultActiveSpeakerPolicy: NSObject, ActiveSpeakerPolicy {
     private let volumes = ConcurrentDictionary<String, Double>()
     private let speakerWeight: Double
     private let cutoffThreshold: Double

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/audio/scheduler/IntervalScheduler.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/audio/scheduler/IntervalScheduler.swift
@@ -13,7 +13,7 @@ private let millisPerSecond = 1000.0
 /**
  * `IntervalScheduler` calls the callback every intervalMs milliseconds.
  */
-@objcMembers public class IntervalScheduler: Scheduler {
+@objcMembers public class IntervalScheduler: NSObject, Scheduler {
     private enum IntervalSchedulerState {
         case started
         case stopped

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/DefaultVideoTile.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/DefaultVideoTile.swift
@@ -9,7 +9,7 @@
 import Foundation
 import VideoToolbox
 
-@objcMembers public class DefaultVideoTile: VideoTile {
+@objcMembers public class DefaultVideoTile: NSObject, VideoTile {
     public var state: VideoTileState
 
     private let logger: Logger
@@ -21,8 +21,7 @@ import VideoToolbox
                 videoStreamContentWidth: Int,
                 videoStreamContentHeight: Int,
                 isLocalTile: Bool,
-                logger: Logger)
-    {
+                logger: Logger) {
         state = VideoTileState(tileId: tileId,
                                attendeeId: attendeeId,
                                videoStreamContentWidth: videoStreamContentWidth,

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/DefaultVideoTileController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/DefaultVideoTileController.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-@objcMembers public class DefaultVideoTileController: VideoTileController {
+@objcMembers public class DefaultVideoTileController: NSObject, VideoTileController {
     private let logger: Logger
     private var videoTileMap = [Int: VideoTile]()
     private var videoViewToTileMap = [NSValue: Int]()

--- a/AmazonChimeSDK/AmazonChimeSDK/device/DefaultDeviceController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/device/DefaultDeviceController.swift
@@ -8,7 +8,7 @@
 
 import AVFoundation
 
-@objcMembers public class DefaultDeviceController: DeviceController {
+@objcMembers public class DefaultDeviceController: NSObject, DeviceController {
     let videoClientController: VideoClientController
     let logger: Logger
     let audioSession: AudioSession
@@ -16,11 +16,11 @@ import AVFoundation
 
     public init(audioSession: AudioSession,
                 videoClientController: VideoClientController,
-                logger: Logger)
-    {
+                logger: Logger) {
         self.videoClientController = videoClientController
         self.logger = logger
         self.audioSession = audioSession
+        super.init()
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(handleSystemAudioChange),
                                                name: AVAudioSession.routeChangeNotification,

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
@@ -24,8 +24,7 @@ class DefaultAudioClientController: NSObject {
     init(audioClient: AudioClientProtocol,
          audioClientObserver: AudioClientObserver,
          audioSession: AudioSession,
-         audioClientLock: AudioLock)
-    {
+         audioClientLock: AudioLock) {
         self.audioClient = audioClient
         self.audioClientObserver = audioClientObserver
         self.audioSession = audioSession
@@ -49,8 +48,7 @@ extension DefaultAudioClientController: AudioClientController {
                       meetingId: String,
                       attendeeId: String,
                       joinToken: String,
-                      callKitEnabled: Bool) throws
-    {
+                      callKitEnabled: Bool) throws {
         audioLock.lock()
         defer {
             audioLock.unlock()

--- a/AmazonChimeSDK/AmazonChimeSDK/realtime/DefaultRealtimeController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/realtime/DefaultRealtimeController.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-@objcMembers public class DefaultRealtimeController: RealtimeControllerFacade {
+@objcMembers public class DefaultRealtimeController: NSObject, RealtimeControllerFacade {
 
     private let audioClientController: AudioClientController
     private let audioClientObserver: AudioClientObserver


### PR DESCRIPTION
### Issue #, if available:
#117 
Chime-30958

### Description of changes:

### Testing done:

Checked that the classes updated shows up in `AmazonChimeSDK-Swift.h` header file

#### Manual test cases (add more as needed):

- [ ] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [ ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [X] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [X] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
