### PR TITLE
Provide default device api

### DIFF
--- a/AmazonChimeSDK/.swiftlint.yml
+++ b/AmazonChimeSDK/.swiftlint.yml
@@ -1,2 +1,3 @@
 excluded:
   - MockingbirdMocks
+  - MockingbirdSupport

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
@@ -178,4 +178,8 @@ import Foundation
     }
 
     public func hasBandwidthPriorityCallback(hasBandwidthPriority: Bool) {}
+
+    public func getActiveAudioDevice() -> MediaDevice? {
+        return deviceController.getActiveAudioDevice()
+    }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/device/DefaultDeviceController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/device/DefaultDeviceController.swift
@@ -29,7 +29,7 @@ import AVFoundation
 
     public func listAudioDevices() -> [MediaDevice] {
         var inputDevices: [MediaDevice] = []
-        let loudSpeaker = MediaDevice(label: "Built-in Speaker", type: MediaDeviceType.audioBuiltInSpeaker)
+        let loudSpeaker = getSpeakerMediaDevice()
         if let availablePort = audioSession.availableInputs {
             inputDevices = availablePort.map { port in MediaDevice.fromAVSessionPort(port: port) }
         }
@@ -116,7 +116,7 @@ import AVFoundation
             let currentOutput = audioSession.currentRoute.outputs[0]
 
             if currentOutput.portType == .builtInSpeaker {
-                return MediaDevice(label: "Built-in Speaker", type: MediaDeviceType.audioBuiltInSpeaker)
+                return getSpeakerMediaDevice()
             }
         }
         if audioSession.currentRoute.inputs.count > 0 {
@@ -124,5 +124,9 @@ import AVFoundation
         } else {
             return nil
         }
+    }
+
+    private func getSpeakerMediaDevice() -> MediaDevice {
+        return MediaDevice(label: "Built-in Speaker", type: MediaDeviceType.audioBuiltInSpeaker)
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/device/DefaultDeviceController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/device/DefaultDeviceController.swift
@@ -13,7 +13,6 @@ import AVFoundation
     let logger: Logger
     let audioSession: AudioSession
     let deviceChangeObservers = ConcurrentMutableSet()
-    var currenDevice: MediaDevice?
 
     public init(audioSession: AudioSession,
                 videoClientController: VideoClientController,
@@ -50,7 +49,6 @@ import AVFoundation
             } else {
                 try audioSession.setPreferredInput(mediaDevice.port)
             }
-            self.currenDevice = mediaDevice
         } catch {
             logger.error(msg: "Error on setting audio input device: \(error.localizedDescription)")
         }
@@ -113,6 +111,18 @@ import AVFoundation
     }
 
     public func getActiveAudioDevice() -> MediaDevice? {
-        return self.currenDevice
+        // Check for speaker case
+        if audioSession.currentRoute.outputs.count > 0 {
+            let currentOutput = audioSession.currentRoute.outputs[0]
+
+            if currentOutput.portType == .builtInSpeaker {
+                return MediaDevice(label: "Built-in Speaker", type: MediaDeviceType.audioBuiltInSpeaker)
+            }
+        }
+        if audioSession.currentRoute.inputs.count > 0 {
+            return MediaDevice.fromAVSessionPort(port: audioSession.currentRoute.inputs[0])
+        } else {
+            return nil
+        }
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/device/DefaultDeviceController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/device/DefaultDeviceController.swift
@@ -13,6 +13,7 @@ import AVFoundation
     let logger: Logger
     let audioSession: AudioSession
     let deviceChangeObservers = ConcurrentMutableSet()
+    var currenDevice: MediaDevice?
 
     public init(audioSession: AudioSession,
                 videoClientController: VideoClientController,
@@ -49,6 +50,7 @@ import AVFoundation
             } else {
                 try audioSession.setPreferredInput(mediaDevice.port)
             }
+            self.currenDevice = mediaDevice
         } catch {
             logger.error(msg: "Error on setting audio input device: \(error.localizedDescription)")
         }
@@ -108,5 +110,9 @@ import AVFoundation
     public func getActiveCamera() -> MediaDevice? {
         let activeCamera = MediaDevice.fromVideoDevice(device: videoClientController.getCurrentDevice())
         return activeCamera.type == .other ? nil : activeCamera
+    }
+
+    public func getActiveAudioDevice() -> MediaDevice? {
+        return self.currenDevice
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/device/DeviceController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/device/DeviceController.swift
@@ -36,4 +36,8 @@ import Foundation
     /// Get currently used video device
     /// - Returns: a media device or nil if no device is present
     func getActiveCamera() -> MediaDevice?
+
+    /// Get currently used audio device
+    /// - Returns: a media device or nil if no device is present
+    func getActiveAudioDevice() -> MediaDevice?
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientProtocol.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientProtocol.swift
@@ -5,6 +5,7 @@
 //  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  SPDX-License-Identifier: Apache-2.0
 //
+// swiftlint:disable identifier_name function_parameter_count
 
 import AmazonChimeSDKMedia
 import Foundation

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioSession.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioSession.swift
@@ -14,6 +14,7 @@ import Foundation
     var availableInputs: [AVAudioSessionPortDescription]? { get }
     func setPreferredInput(_ inPort: AVAudioSessionPortDescription?) throws
     func overrideOutputAudioPort(_ portOverride: AVAudioSession.PortOverride) throws
+    var currentRoute: AVAudioSessionRouteDescription { get }
 }
 
 extension AVAudioSession: AudioSession {}

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/utils/ConcurrentMutableSetTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/utils/ConcurrentMutableSetTests.swift
@@ -106,7 +106,7 @@ class ConcurrentMutableSetTests: XCTestCase {
             mainThreadEndedExpectation.fulfill()
         }
 
-        wait(for: [backgroundThreadEndedExpectation, mainThreadEndedExpectation], timeout: 5)
+        wait(for: [backgroundThreadEndedExpectation, mainThreadEndedExpectation], timeout: 7)
         XCTAssertEqual(count, 1)
         XCTAssertEqual(sum, 1)
         XCTAssertEqual(normalSet.count, 1)

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -343,7 +343,7 @@ extension MeetingModel: AudioVideoObserver {
 
     func audioSessionDidStart(reconnecting: Bool) {
         notifyHandler?("Audio successfully started. Reconnecting: \(reconnecting)")
-        logWithFunctionName(message: "reconnecting \(reconnecting)")
+        logWithFunctionName(message: "reconnecting \(reconnecting), device \(currentMeetingSession.audioVideo.getActiveAudioDevice()?.label ?? "none")")
         if !reconnecting {
             call?.isConnectedHandler?()
         }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -80,6 +80,10 @@ class MeetingModel: NSObject {
         return currentMeetingSession.audioVideo.listAudioDevices()
     }
 
+    var currentAudioDevice: MediaDevice? {
+        return currentMeetingSession.audioVideo.getActiveAudioDevice()
+    }
+
     var isLocalVideoActive = false {
         didSet {
             if isLocalVideoActive {
@@ -234,6 +238,7 @@ class MeetingModel: NSObject {
             if audioSession.category != .playAndRecord {
                 try audioSession.setCategory(AVAudioSession.Category.playAndRecord,
                                              options: AVAudioSession.CategoryOptions.allowBluetooth)
+                try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
             }
             if audioSession.mode != .voiceChat {
                 try audioSession.setMode(.voiceChat)
@@ -343,7 +348,7 @@ extension MeetingModel: AudioVideoObserver {
 
     func audioSessionDidStart(reconnecting: Bool) {
         notifyHandler?("Audio successfully started. Reconnecting: \(reconnecting)")
-        logWithFunctionName(message: "reconnecting \(reconnecting), device \(currentMeetingSession.audioVideo.getActiveAudioDevice()?.label ?? "none")")
+        logWithFunctionName(message: "reconnecting \(reconnecting)")
         if !reconnecting {
             call?.isConnectedHandler?()
         }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -278,6 +278,7 @@ class MeetingViewController: UIViewController {
         guard let meetingModel = meetingModel else {
             return
         }
+
         let optionMenu = UIAlertController(title: nil, message: "Choose Audio Device", preferredStyle: .actionSheet)
 
         for inputDevice in meetingModel.audioDevices {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -280,18 +280,32 @@ class MeetingViewController: UIViewController {
         }
 
         let optionMenu = UIAlertController(title: nil, message: "Choose Audio Device", preferredStyle: .actionSheet)
-
+        let currentAudioDevice = meetingModel.currentAudioDevice
         for inputDevice in meetingModel.audioDevices {
-            let deviceAction = UIAlertAction(title: inputDevice.label,
+            var label = inputDevice.label
+            if let selectedAudioDevice = currentAudioDevice {
+                if selectedAudioDevice.label == inputDevice.label {
+                    label = "\(label) ✔︎"
+                }
+            }
+            let deviceAction = UIAlertAction(title: label,
                                              style: .default,
                                              handler: { _ in meetingModel.chooseAudioDevice(inputDevice)
-                })
+            })
             optionMenu.addAction(deviceAction)
         }
 
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
         optionMenu.addAction(cancelAction)
-
+        // We need to handle iPad
+        if let popoverController = optionMenu.popoverPresentationController {
+            popoverController.sourceView = self.view
+            popoverController.sourceRect = CGRect(x: self.view.bounds.midX,
+                                                  y: self.view.bounds.midY,
+                                                  width: 0,
+                                                  height: 0)
+            popoverController.permittedArrowDirections = []
+        }
         present(optionMenu, animated: true, completion: nil)
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Added
+* Added `getActiveAudioDevice` in `DefaultDeviceController`
+
 ## [0.11.0] - 2020-10-08
 
 ### Changed
@@ -11,6 +15,7 @@
 - Fixed a crash when opening ObjC demo app on iPhone 5/5c
 
 ## [0.10.0] - 2020-09-10
+
 
 ### Removed
 * **Breaking** Removed audio permission check in `DefaultAudioVideoController` which is performed in `DefaultAudioClientController`. For developers who has their own `AudioClientController` implementation, please make sure to check audio permission in `start()`.


### PR DESCRIPTION
### Issue #, if available:
Chime-30968
### Description of changes:
Add default device api
### Testing done:
![IMG_0049](https://user-images.githubusercontent.com/57926812/94188014-a01ead00-fe5d-11ea-8b2c-153a2888057d.PNG)
![Screen Shot 2020-09-24 at 11 59 22 AM](https://user-images.githubusercontent.com/57926812/94188033-a57bf780-fe5d-11ea-9e7a-330146cdb954.png)

#### Manual test cases (add more as needed):

- [ ] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [ ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
