### PR TITLE
Add Logging of AudioClient state and status

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientObserver.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientObserver.swift
@@ -20,20 +20,26 @@ class DefaultAudioClientObserver: NSObject, AudioClientDelegate {
     private var currentAudioState = SessionStateControllerAction.initialize
     private var currentAudioStatus = MeetingSessionStatusCode.ok
     private let realtimeObservers = ConcurrentMutableSet()
+    private let logger: Logger
 
     private let audioLock: NSLock
 
     init(audioClient: AudioClient, clientMetricsCollector: ClientMetricsCollector,
-         audioClientLock: NSLock, configuration: MeetingSessionConfiguration) {
+         audioClientLock: NSLock, configuration: MeetingSessionConfiguration, logger: Logger) {
         self.audioClient = audioClient
         self.clientMetricsCollector = clientMetricsCollector
         self.configuration = configuration
+        self.logger = logger
         audioLock = audioClientLock
         super.init()
         audioClient.delegate = self
     }
 
     public func audioClientStateChanged(_ audioClientState: audio_client_state_t, status: audio_client_status_t) {
+        logger.debug(debugFunction: {
+            return "AudioClient State: \(audioClientState.rawValue) Status: \(status.rawValue)"
+        })
+
         let newAudioState = Converters.AudioClientState.toSessionStateControllerAction(state: audioClientState)
         let newAudioStatus = Converters.AudioClientStatus.toMeetingSessionStatusCode(status: status)
 

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientObserver.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientObserver.swift
@@ -40,7 +40,7 @@ class DefaultAudioClientObserver: NSObject, AudioClientDelegate {
         let newAudioStatus = Converters.AudioClientStatus.toMeetingSessionStatusCode(status: status)
 
         if newAudioState == .unknown {
-            logger.info(msg: "AudioClient State: \(newAudioState) Unknown Status rawValue: \(status.rawValue)")
+            logger.info(msg: "AudioClient State rawValue: \(audioClientState.rawValue) Unknown Status rawValue: \(status.rawValue)")
         } else {
             logger.info(msg: "AudioClient State: \(newAudioState) Status: \(newAudioStatus)")
         }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientObserver.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientObserver.swift
@@ -36,12 +36,14 @@ class DefaultAudioClientObserver: NSObject, AudioClientDelegate {
     }
 
     public func audioClientStateChanged(_ audioClientState: audio_client_state_t, status: audio_client_status_t) {
-        logger.debug(debugFunction: {
-            return "AudioClient State: \(audioClientState.rawValue) Status: \(status.rawValue)"
-        })
-
         let newAudioState = Converters.AudioClientState.toSessionStateControllerAction(state: audioClientState)
         let newAudioStatus = Converters.AudioClientStatus.toMeetingSessionStatusCode(status: status)
+
+        if newAudioState == .unknown {
+            logger.info(msg: "AudioClient State: \(newAudioState) Unknown Status rawValue: \(status.rawValue)")
+        } else {
+            logger.info(msg: "AudioClient State: \(newAudioState) Status: \(newAudioStatus)")
+        }
 
         if newAudioState == .unknown || (newAudioState == currentAudioState && newAudioStatus == currentAudioStatus) {
             return

--- a/AmazonChimeSDK/AmazonChimeSDK/session/DefaultMeetingSession.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/session/DefaultMeetingSession.swift
@@ -29,7 +29,8 @@ import Foundation
         let audioClientObserver = DefaultAudioClientObserver(audioClient: audioClient,
                                                              clientMetricsCollector: clientMetricsCollector,
                                                              audioClientLock: audioClientLock,
-                                                             configuration: configuration)
+                                                             configuration: configuration,
+                                                             logger: logger)
         let audioClientController = DefaultAudioClientController(audioClient: audioClient,
                                                                  audioClientObserver: audioClientObserver,
                                                                  audioSession: audioSession,


### PR DESCRIPTION
### Issue #, if available:
Chime-30933

### Description of changes:

### Testing done:
Verified log shows us as DEBUG

#### Manual test cases (add more as needed):

- [X] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [X] Join meeting with CallKit as Outgoing
- [ ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [X] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [X] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [X] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [X] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
