### PR TITLE
 Update DataMessage timestamp type

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/data/DataMessage.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/data/DataMessage.swift
@@ -12,7 +12,7 @@ import AmazonChimeSDKMedia
 /// Data message received from server.
 @objcMembers public class DataMessage: NSObject {
     /// Monotonically increasing server ingest time
-    public let timestampMs: Int
+    public let timestampMs: Int64
 
     /// Topic this message was sent on
     public let topic: String
@@ -43,7 +43,7 @@ import AmazonChimeSDKMedia
                 data: Data,
                 senderAttendeeId: String,
                 senderExternalUserId: String,
-                timestampMs: Int,
+                timestampMs: Int64,
                 throttled: Bool) {
         self.topic = topic
         self.data = data

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo.xcodeproj/project.pbxproj
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo.xcodeproj/project.pbxproj
@@ -723,6 +723,7 @@
 		F8AC96352408840E0072EB04 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_CXX_LANGUAGE_STANDARD = "compiler-default";
 				CLANG_ENABLE_MODULES = YES;
@@ -763,6 +764,7 @@
 		F8AC96362408840E0072EB04 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_CXX_LANGUAGE_STANDARD = "compiler-default";
 				CLANG_ENABLE_MODULES = YES;

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -184,7 +184,7 @@ class MeetingModel: NSObject {
          }
 
          let currentTimestamp = NSDate().timeIntervalSince1970
-         let timestamp = TimeStampConversion.formatTimestamp(timestamp: CLong(currentTimestamp) * 1000)
+         let timestamp = TimeStampConversion.formatTimestamp(timestamp: Int64(currentTimestamp) * 1000)
 
          chatModel
              .addChatMessage(chatMessage:

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/utils/TimestampConversion.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/utils/TimestampConversion.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 class TimeStampConversion: NSObject {
-    static func formatTimestamp(timestamp: Int) -> String {
+    static func formatTimestamp(timestamp: Int64) -> String {
         let date = Date(timeIntervalSince1970: TimeInterval(timestamp / 1000))
         let dateFormatter = DateFormatter()
         dateFormatter.locale = NSLocale.current

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 ## Unreleased
 
 ### Changed
-* **Breaking** The returned label for the Built-In Speaker `MediaDevice` has been changed from "Build-in Speaker" to "Buil*t*-in Speaker
+* **Breaking** The returned label for the Built-In Speaker `MediaDevice` has been changed from "Build-in Speaker" to "Buil*t*-in Speaker".
+* **Breaking** `timestampMs` on `DataMessage` type is changed to `Int64` to prevent overflow on 32-bit system.
 * Changed `maxRemoteVideoTileCount` in the Swift demo app from 8 to 16. Now the Swift demo app can support at most 16 remote video tiles.
 
 ### Fixed
 - Fixed a crash when joining meeting on device with 32-bit system (iPhone 5/5c) due to integer overflow in `DefaultActiveSpeakerDetector`
+- Fixed a crash when sending DataMessage on 32-bit system (iPhone 5/5c)
+- Fixed a crash when opening ObjC demo app on iPhone 5/5c
 
 ## [0.10.0] - 2020-09-10
 


### PR DESCRIPTION
### Issue #, if available:
WTBugs-21635
WTBugs-21636
### Description of changes:
Update DataMessage timestamp type to `Int64` to prevent overflow on iPhone 5/5C
### Testing done:
Tested launching objc demo app on iPhone 5
Tested Send/receive data message on iPhone 5

#### Manual test cases (add more as needed):

- [X] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [ ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [X] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [X] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [X] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [X] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
