### PR TITLE
Change remoteVideoTileCountPerPage in the Swift demo app from 2 to 6

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
@@ -11,7 +11,7 @@ import UIKit
 
 class VideoModel: NSObject {
     private let maxRemoteVideoTileCount = 16
-    private let remoteVideoTileCountPerPage = 2
+    private let remoteVideoTileCountPerPage = 6
 
     private var currentRemoteVideoPageIndex = 0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Changed
+* Changed the max number of remote video tiles per page in the Swift demo app from 2 to 6.
+
 ## [0.11.0] - 2020-10-08
 
 ### Changed


### PR DESCRIPTION
### Issue #, if available:
N/A

### Description of changes:
Change remoteVideoTileCountPerPage in the Swift demo app from 2 to 6

### Testing done:
Tested with local video and 7 remote videos. Was able to see 6 remote videos on the first page, and was able to switch to the next page to see the remaining remote video.

#### Manual test cases (add more as needed):

- [x] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [x] Rejoin meeting
- [ ] See metrics
- [x] See attendee presence
- [x] Send audio
- [x] Receive audio
- [x] Mute self
- [x] Unmute self
- [x] See local mute indicator when muted
- [x] See remote mute indicator when other is muted
- [x] Enable and disable local video
- [x] Enable and disable remote video from remote side
- [x] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
