### PR TITLE
Remove extra bind to self video tile

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -426,11 +426,7 @@ extension MeetingViewController: UICollectionViewDataSource {
                 cell.videoRenderView.mirror = true
             }
             meetingModel.bind(videoRenderView: cell.videoRenderView, tileId: tileState.tileId)
-        } else if isSelf {
-            // If the tileState is nil and it's for local video, bind the current cell to the local tile (tileId=0)
-            meetingModel.bind(videoRenderView: cell.videoRenderView, tileId: 0)
         }
-
         return cell
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Fixed
+- Fixed a bug in Swift demo app: self video disappears when a remote video tile is added.
+
 ## [0.11.1] - 2020-10-23
 
 ### Changed


### PR DESCRIPTION
### Issue #, if available:
This PR is to fix a bug in our demo app:
turn on self video on mobile first, then turn on a remote video, self video disappears, but remote party can still see the stream from mobile
### Description of changes:

### Testing done:

#### Manual test cases (add more as needed):

- [X] Join meeting without CallKit
- [X] Join meeting with CallKit as Incoming
- [X] Join meeting with CallKit as Outgoing
- [X] Leave meeting
- [X] Rejoin meeting
- [X] See metrics
- [X] See attendee presence
- [X] Send audio
- [X] Receive audio
- [X] Mute self
- [X] Unmute self
- [X] See local mute indicator when muted
- [X] See remote mute indicator when other is muted
- [X] Enable and disable local video
- [X] Enable and disable remote video from remote side
- [X] Send local video
- [X] Pause and resume remote video
- [X] Switch local camera
- [X] Receive remote screen share

#### Integration validation (required before release)

- [X] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [X] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [X] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
