### PR TITLE
Fix videoTileSizeDidChange was called when frame is null

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/DefaultVideoTileController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/DefaultVideoTileController.swift
@@ -41,8 +41,8 @@ import UIKit
                 return
             }
 
-            if videoStreamContentWidth != videoTile.state.videoStreamContentWidth ||
-                videoStreamContentHeight != videoTile.state.videoStreamContentHeight {
+            if frame != nil && (videoStreamContentWidth != videoTile.state.videoStreamContentWidth ||
+                videoStreamContentHeight != videoTile.state.videoStreamContentHeight) {
                 videoTile.state.videoStreamContentWidth = videoStreamContentWidth
                 videoTile.state.videoStreamContentHeight = videoStreamContentHeight
                 ObserverUtils.forEach(observers: videoTileObservers) { (videoTileObserver: VideoTileObserver) in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 - Fixed a bug in Swift demo app: self video disappears when a remote video tile is added.
+- Fixed a bug where `videoTileSizeDidChange` is called even when frame is null
 
 ## [0.11.1] - 2020-10-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 - Fixed a bug in Swift demo app: self video disappears when a remote video tile is added.
-- Fixed a bug where `videoTileSizeDidChange` is called even when frame is null
+- **Breaking** Fixed a bug where `videoTileSizeDidChange` is called with width=0 and height=0 when the video is paused
 
 ## [0.11.1] - 2020-10-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 - Fixed a bug in Swift demo app: self video disappears when a remote video tile is added.
-- **Breaking** Fixed a bug where `videoTileSizeDidChange` is called with width=0 and height=0 when the video is paused
+- **Breaking** Changed behavior to no longer call `videoTileSizeDidChange` when a video is paused to fix a bug where pausing triggered this callback with width=0 and height=0
 
 ## [0.11.1] - 2020-10-23
 


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
When we call `pauseRemoteVideoTile(tileId)`, it notifies builder the `videoTileSizeDidChange` with 0x0. This should fix that issue. Verify that I am no longer receiving callback when frame is null.

### Testing done:
Pause the video and verify that I am no longer seeing the 0x0 logs.

#### Manual test cases (add more as needed):

- [X] Join meeting without CallKit
- [] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [X] Leave meeting
- [X] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [X] Send audio
- [X] Receive audio
- [X] Mute self
- [X] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [X] Enable and disable remote video from remote side
- [ ] Send local video
- [X] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
