### PR TITLE
Fix DefaultActiveSpeakerPolicy init on Xcode 12

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/audio/activespeakerpolicy/DefaultActiveSpeakerPolicy.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/audio/activespeakerpolicy/DefaultActiveSpeakerPolicy.swift
@@ -9,19 +9,28 @@
 import Foundation
 
 @objcMembers public class DefaultActiveSpeakerPolicy: NSObject, ActiveSpeakerPolicy {
+    public static let defaultSpeakerWeight = 0.9
+    public static let defaultCutoffThreshold = 0.01
+    public static let defaultTakeoverRate = 0.2
+
     private let volumes = ConcurrentDictionary<String, Double>()
     private let speakerWeight: Double
     private let cutoffThreshold: Double
     private let takeoverRate: Double
 
-    public init(
-        speakerWeight: Double = 0.9,
-        cutoffThreshold: Double = 0.01,
-        takeoverRate: Double = 0.2
-    ) {
+    convenience public override init() {
+        self.init(speakerWeight: Self.defaultSpeakerWeight,
+                  cutoffThreshold: Self.defaultCutoffThreshold,
+                  takeoverRate: Self.defaultTakeoverRate)
+    }
+
+    public init(speakerWeight: Double = DefaultActiveSpeakerPolicy.defaultSpeakerWeight,
+                cutoffThreshold: Double = DefaultActiveSpeakerPolicy.defaultCutoffThreshold,
+                takeoverRate: Double = DefaultActiveSpeakerPolicy.defaultTakeoverRate) {
         self.speakerWeight = speakerWeight
         self.cutoffThreshold = cutoffThreshold
         self.takeoverRate = takeoverRate
+        super.init()
     }
 
     public func calculateScore(attendeeInfo: AttendeeInfo, volume: VolumeLevel) -> Double {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemoObjC/ViewControllerObjC.h
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemoObjC/ViewControllerObjC.h
@@ -10,7 +10,7 @@
 #import <AVFoundation/AVFoundation.h>
 #import <AmazonChimeSDK/AmazonChimeSDK-Swift.h>
 
-@interface ViewControllerObjC : UIViewController <RealtimeObserver, MetricsObserver, VideoTileObserver>
+@interface ViewControllerObjC : UIViewController <RealtimeObserver, MetricsObserver, VideoTileObserver, ActiveSpeakerObserver>
 
 #define SERVER_URL "YOUR_SERVER_URL"
 #define SERVER_REGION "YOUR_SERVER_REGION"

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemoObjC/ViewControllerObjC.m
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemoObjC/ViewControllerObjC.m
@@ -114,6 +114,9 @@
         [self.meetingSession.audioVideo addRealtimeObserverWithObserver:self];
         [self.meetingSession.audioVideo addMetricsObserverWithObserver:self];
         [self.meetingSession.audioVideo addVideoTileObserverWithObserver:self];
+        DefaultActiveSpeakerPolicy *policy = [DefaultActiveSpeakerPolicy new];
+        [self.meetingSession.audioVideo addActiveSpeakerObserverWithPolicy:policy
+                                                                  observer:self];
 
         [self startVideoClient];
     } else {
@@ -277,6 +280,8 @@
     [task resume];
 }
 
+# pragma mark - RealtimeObserver
+
 - (void)attendeesDidJoinWithAttendeeInfo:(NSArray<AttendeeInfo *> * _Nonnull)attendeeInfo {
     for (id currentAttendeeInfo in attendeeInfo) {
         [self.logger infoWithMsg:[NSString stringWithFormat:@"Attendee %@ joined", [currentAttendeeInfo attendeeId]]];
@@ -319,9 +324,13 @@
     }
 }
 
+# pragma mark - MetricsObserver
+
 - (void)metricsDidReceiveWithMetrics:(NSDictionary *)metrics {
     [self.logger infoWithMsg:[NSString stringWithFormat:@"Media metrics have been received: %@", metrics]];
 }
+
+# pragma mark - VideoTileObserver
 
 - (void)videoTileDidAddWithTileState:(VideoTileState *)tileState {
     [self.logger infoWithMsg:[NSString stringWithFormat:@"Adding Video Tile tileId: %ld, attendeeId: %@", (long)tileState.tileId, tileState.attendeeId]];
@@ -359,5 +368,17 @@
 - (void)videoTileSizeDidChangeWithTileState:(VideoTileState *)tileState {
     [self.logger infoWithMsg:[NSString stringWithFormat:@"Video Tile size changed: tileId: %ld, attendeeId: %@", (long)tileState.tileId, tileState.attendeeId]];
 }
+
+# pragma mark - ActiveSpeakerObserver
+
+- (void)activeSpeakerScoreDidChangeWithScores:(NSDictionary<AttendeeInfo *, NSNumber *> * _Nonnull)scores {
+    [self.logger infoWithMsg:@"activeSpeakerScoreDidChangeWithScores callback invoked"];
+}
+
+- (void)activeSpeakerDidDetectWithAttendeeInfo:(NSArray<AttendeeInfo *> * _Nonnull)attendeeInfo {
+    [self.logger infoWithMsg:@"activeSpeakerDidDetectWithAttendeeInfo callback invoked"];
+}
+
+@synthesize observerId;
 
 @end

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemoObjC/ViewControllerObjC.m
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemoObjC/ViewControllerObjC.m
@@ -379,6 +379,12 @@
     [self.logger infoWithMsg:@"activeSpeakerDidDetectWithAttendeeInfo callback invoked"];
 }
 
-@synthesize observerId;
+- (NSInteger)scoresCallbackIntervalMs {
+    return 5000;
+}
+
+- (NSString*) observerId {
+    return [NSUUID new].UUIDString;
+}
 
 @end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 * Fixed a crash in Swift demo app when user opens the device selection Action Sheet in iPad.
+* Fixed a crash in Swift demo app when building with Xcode 12: `DefaultActiveSpeakerPolicy.init()` not implemented.
 * Fixed a bug in Swift demo app: self video disappears when a remote video tile is added.
 * Fixed a bug in Swift demo app: self video disappears when a remote video tile is added.
 * **Breaking** Changed behavior to no longer call `videoTileSizeDidChange` when a video is paused to fix a bug where pausing triggered this callback with width=0 and height=0.


### PR DESCRIPTION
### Issue #, if available:
When running Swift Demo with SDK build as binary in Xcode 12, it crashes accessing `DefaultActiveSpeakerPolicy` init with no param, and this is also not accessible in ObjC

Added init with no param explicitly, and use in obj c demo app
### Description of changes:

### Testing done:
Swift demo does not crash anymore on Xcode 12
Obj C demo works as expected and gets the ActiveSpeakerObserver callbacks

#### Manual test cases (add more as needed):

- [X] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [X] Leave meeting
- [X] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [X] Send audio
- [X] Receive audio
- [] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [X] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [X] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [X] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [X] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [X] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [X] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [X] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
