### PR TITLE
Add debug log from media

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClient.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClient.swift
@@ -26,8 +26,12 @@ class DefaultAudioClient: AudioClient {
         switch logLevel.rawValue {
         case Constants.errorLevel, Constants.fatalLevel:
             DefaultAudioClient.logger?.error(msg: msg)
+        case Constants.warningLevel, Constants.infoLevel:
+            DefaultAudioClient.logger?.debug(debugFunction: { () -> String in
+                msg
+            })
         default:
-            break
+            DefaultAudioClient.logger?.default(msg: msg)
         }
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClient.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClient.swift
@@ -26,12 +26,10 @@ class DefaultAudioClient: AudioClient {
         switch logLevel.rawValue {
         case Constants.errorLevel, Constants.fatalLevel:
             DefaultAudioClient.logger?.error(msg: msg)
-        case Constants.warningLevel, Constants.infoLevel:
+        default:
             DefaultAudioClient.logger?.debug(debugFunction: { () -> String in
                 msg
             })
-        default:
-            DefaultAudioClient.logger?.default(msg: msg)
         }
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClient.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClient.swift
@@ -27,9 +27,7 @@ class DefaultAudioClient: AudioClient {
         case Constants.errorLevel, Constants.fatalLevel:
             DefaultAudioClient.logger?.error(msg: msg)
         default:
-            DefaultAudioClient.logger?.debug(debugFunction: { () -> String in
-                msg
-            })
+            DefaultAudioClient.logger?.default(msg: msg)
         }
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/utils/Constants.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/utils/Constants.swift
@@ -12,7 +12,7 @@ import Foundation
 @objcMembers class Constants: NSObject {
     static let modality = "#content"
     static let videoClientStatusCallAtCapacityViewOnly = 206
-    // We only cares ERROR and FATAL, which are 5, 6 respectively
+    // Corresponding log levels from media layer
     static let errorLevel: UInt32 = LOGGER_ERROR.rawValue
     static let fatalLevel: UInt32 = LOGGER_FATAL.rawValue
     static let warningLevel: UInt32 = LOGGER_WARNING.rawValue

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/utils/Constants.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/utils/Constants.swift
@@ -15,6 +15,10 @@ import Foundation
     // We only cares ERROR and FATAL, which are 5, 6 respectively
     static let errorLevel: UInt32 = LOGGER_ERROR.rawValue
     static let fatalLevel: UInt32 = LOGGER_FATAL.rawValue
+    static let warningLevel: UInt32 = LOGGER_WARNING.rawValue
+    static let infoLevel: UInt32 = LOGGER_INFO.rawValue
+    static let debugLevel: UInt32 = LOGGER_DEBUG.rawValue
+    static let traceLevel: UInt32 = LOGGER_TRACE.rawValue
     static let dataMessageMaxDataSizeInByte = 2048
     static let dataMessageTopicRegex = "^[a-zA-Z0-9_-]{1,36}$"
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClient.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClient.swift
@@ -23,12 +23,10 @@ class DefaultVideoClient: VideoClient {
         switch logLevel.rawValue {
         case Constants.errorLevel, Constants.fatalLevel:
             logger.error(msg: msg)
-        case Constants.warningLevel, Constants.infoLevel:
+        default:
             logger.debug(debugFunction: { () -> String in
                 msg
             })
-        default:
-            logger.default(msg: msg)
         }
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClient.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClient.swift
@@ -23,8 +23,12 @@ class DefaultVideoClient: VideoClient {
         switch logLevel.rawValue {
         case Constants.errorLevel, Constants.fatalLevel:
             logger.error(msg: msg)
+        case Constants.warningLevel, Constants.infoLevel:
+            logger.debug(debugFunction: { () -> String in
+                msg
+            })
         default:
-            break
+            logger.default(msg: msg)
         }
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClient.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClient.swift
@@ -24,9 +24,7 @@ class DefaultVideoClient: VideoClient {
         case Constants.errorLevel, Constants.fatalLevel:
             logger.error(msg: msg)
         default:
-            logger.debug(debugFunction: { () -> String in
-                msg
-            })
+            logger.default(msg: msg)
         }
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/utils/logger/ConsoleLogger.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/utils/logger/ConsoleLogger.swift
@@ -13,7 +13,7 @@ import os
 ///
 /// ```
 /// // working with the ConsoleLogger
-/// let logger = new ConsoleLogger("demo"); //default level is LogLevel.DEFAULT prints everything
+/// let logger = new ConsoleLogger("demo"); //default level is LogLevel.INFO
 /// logger.info("info");
 /// logger.debug("debug");
 /// logger.fault("fault");
@@ -29,7 +29,7 @@ import os
     let name: String
     var level: LogLevel
 
-    public init(name: String, level: LogLevel = .DEFAULT) {
+    public init(name: String, level: LogLevel = .INFO) {
         self.name = name
         self.level = level
     }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/utils/logger/ConsoleLoggerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/utils/logger/ConsoleLoggerTests.swift
@@ -17,7 +17,7 @@ class ConsoleLoggerTests: XCTestCase {
     }
 
     func testConsoleLoggerShouldBeInitialized() {
-        XCTAssertEqual(LogLevel.DEFAULT, logger?.getLogLevel())
+        XCTAssertEqual(LogLevel.INFO, logger?.getLogLevel())
     }
 
     func testConsoleLoggerShouldBeSetLogLevelWhenBeingInitializedWithGivenLevel() {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+* Added more verbose logging from media layer to SDK layer for builders to control log level. Set `LogLevel` to `INFO` or above for production application to not be bombarded with logs.
 
 ### Added
 * Added new APIs in `RealtimeControllerFacade` to enable/disable Voice Focus (ML-based noise suppression) and get the on/off status of Voice Focus.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 * Fixed a bug in Swift demo app: MeetingModel is not deallocated properly after meeting ends.
 * **Breaking** Changed behavior to no longer call `videoTileSizeDidChange` when a video is paused to fix a bug where pausing triggered this callback with width=0 and height=0.
 
+### Changed
+* **Breaking** Changed default log level of `ConsoleLogger` to INFO.
+
 ## [0.11.1] - 2020-10-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 ## Unreleased
-* Added more verbose logging from media layer to SDK layer for builders to control log level. Set `LogLevel` to `INFO` or above for production application to not be bombarded with logs.
-
 ### Added
 * Added new APIs in `RealtimeControllerFacade` to enable/disable Voice Focus (ML-based noise suppression) and get the on/off status of Voice Focus.
 * Added Voice Focus feature in Swift demo app.
+* Added more verbose logging from media layer to SDK layer for builders to control log level. Set `LogLevel` to `INFO` or above for production application to not be bombarded with logs.
 
 ### Fixed
 * Fixed `DefaultDeviceController` not removing itself as observer from `NotificationCenter` after deallocation and causes crash in Swift demo app.


### PR DESCRIPTION
### Issue #, if available:
Chime-32053
### Description of changes:

### Testing done:
Test and see the logs when I change log level of logger. However, this could bombard builders with logs if builders do not set their level to INFO or above
#### Manual test cases (add more as needed):

- [X] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [X] Leave meeting
- [ ] Rejoin meeting
- [X] See metrics
- [X] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
