### PR TITLE
Fix crash in DefaultDeviceController

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/audio/activespeakerdetector/DefaultActiveSpeakerDetector.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/audio/activespeakerdetector/DefaultActiveSpeakerDetector.swift
@@ -85,8 +85,9 @@ typealias DetectorCallback = (_ attendeeIds: [AttendeeInfo]) -> Void
         activeSpeakers = speakerScores.sorted(by: { $0.value > $1.value })
             .filter { $0.value > 0.0 }
             .map { $0.0 }
-        DispatchQueue.main.async {
-            callback(self.activeSpeakers)
+        DispatchQueue.main.async { [weak self] in
+            guard let strongSelf = self else { return }
+            callback(strongSelf.activeSpeakers)
         }
         let selfIsActive =
             !activeSpeakers.isEmpty && activeSpeakers[0].attendeeId == selfAttendeeId

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
@@ -91,15 +91,16 @@ extension DefaultAudioClientController: AudioClientController {
             return
         }
 
-        DispatchQueue.global().async {
-            self.audioLock.lock()
-            let audioClientStatusCode = self.audioClient.stopSession()
+        DispatchQueue.global().async { [weak self] in
+            guard let strongSelf = self else { return }
+            strongSelf.audioLock.lock()
+            let audioClientStatusCode = strongSelf.audioClient.stopSession()
             Self.state = .stopped
             let meetingSessionStatusCode = Converters.AudioClientStatus.toMeetingSessionStatusCode(
                 rawValue: UInt32(audioClientStatusCode)
             )
-            self.audioLock.unlock()
-            self.audioClientObserver.notifyAudioClientObserver { (observer: AudioVideoObserver) in
+            strongSelf.audioLock.unlock()
+            strongSelf.audioClientObserver.notifyAudioClientObserver { (observer: AudioVideoObserver) in
                 observer.audioSessionDidStopWithStatus(
                     sessionStatus: MeetingSessionStatus(statusCode: meetingSessionStatusCode)
                 )

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientObserver.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientObserver.swift
@@ -269,12 +269,13 @@ class DefaultAudioClientObserver: NSObject, AudioClientDelegate {
             return
         }
 
-        DispatchQueue.global().async {
-            self.audioLock.lock()
-            self.audioClient.stopSession()
+        DispatchQueue.global().async { [weak self] in
+            guard let strongSelf = self else { return }
+            strongSelf.audioLock.lock()
+            strongSelf.audioClient.stopSession()
             DefaultAudioClientController.state = .stopped
-            self.audioLock.unlock()
-            self.notifyAudioClientObserver { (observer: AudioVideoObserver) in
+            strongSelf.audioLock.unlock()
+            strongSelf.notifyAudioClientObserver { (observer: AudioVideoObserver) in
                 observer.audioSessionDidStopWithStatus(sessionStatus: MeetingSessionStatus(statusCode: newAudioStatus))
             }
         }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
@@ -347,15 +347,16 @@ extension DefaultVideoClientController: VideoClientController {
     // MARK: - Lifecycle: stop and destroy
 
     public func stopAndDestroy() {
-        DispatchQueue.global().async {
-            switch self.videoClientState {
+        DispatchQueue.global().async { [weak self] in
+            guard let strongSelf = self else { return }
+            switch strongSelf.videoClientState {
             case .uninitialized:
-                self.logger.info(msg: "VideoClient is uninitialized so cannot be stopped and destroyed")
+                strongSelf.logger.info(msg: "VideoClient is uninitialized so cannot be stopped and destroyed")
             case .started:
-                self.stopVideoClient()
-                self.destroyVideoClient()
+                strongSelf.stopVideoClient()
+                strongSelf.destroyVideoClient()
             case .initialized, .stopped:
-                self.destroyVideoClient()
+                strongSelf.destroyVideoClient()
             }
         }
     }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Call.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Call.swift
@@ -33,10 +33,11 @@ class Call {
         didSet {
             if isUnansweredCallTimerActive {
                 endCallBackgroundTaskId = UIApplication.shared.beginBackgroundTask(expirationHandler: nil)
-                DispatchQueue.main.asyncAfter(deadline: .now() + Call.maxIncomingCallAnswerTime) {
-                    if self.endCallBackgroundTaskId != .invalid {
-                        self.isUnansweredHandler?()
-                        self.isUnansweredCallTimerActive = false
+                DispatchQueue.main.asyncAfter(deadline: .now() + Call.maxIncomingCallAnswerTime) { [weak self] in
+                    guard let strongSelf = self else { return }
+                    if strongSelf.endCallBackgroundTaskId != .invalid {
+                        strongSelf.isUnansweredHandler?()
+                        strongSelf.isUnansweredCallTimerActive = false
                     }
                 }
             } else {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModule.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModule.swift
@@ -67,8 +67,8 @@ class MeetingModule {
                     }
                     CallKitManager.shared().startOutgoingCall(with: call)
                 case .disabled:
-                    DispatchQueue.main.async {
-                        self.joinMeeting(meetingModel, completion: completion)
+                    DispatchQueue.main.async { [weak self] in
+                        self?.joinMeeting(meetingModel, completion: completion)
                     }
                 }
                 completion(true)
@@ -107,6 +107,8 @@ class MeetingModule {
     func dismissMeeting(_ meeting: MeetingModel) {
         if let activeMeeting = activeMeeting, meeting.uuid == activeMeeting.uuid {
             meetingPresenter.dismissActiveMeetingView(completion: {})
+            meetings[meeting.uuid] = nil
+            self.activeMeeting = nil
         } else {
             meetings[meeting.uuid] = nil
         }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -123,8 +123,9 @@ class MeetingViewController: UIViewController {
         meetingModel.isMutedHandler = { [weak self] isMuted in
             self?.muteButton.isSelected = isMuted
         }
-        meetingModel.isEndedHandler = {
+        meetingModel.isEndedHandler = { [weak meetingModel] in
             DispatchQueue.main.async {
+                guard let meetingModel = meetingModel else { return }
                 MeetingModule.shared().dismissMeeting(meetingModel)
             }
         }
@@ -134,17 +135,21 @@ class MeetingViewController: UIViewController {
         meetingModel.metricsModel.metricsUpdatedHandler = { [weak self] in
             self?.metricsTable.reloadData()
         }
-        meetingModel.videoModel.videoUpdatedHandler = { [weak self] in
+        meetingModel.videoModel.videoUpdatedHandler = { [weak self, weak meetingModel] in
+            guard let strongSelf = self, let meetingModel = meetingModel else { return }
             meetingModel.videoModel.resumeAllRemoteVideosInCurrentPageExceptUserPausedVideos()
-            self?.prevVideoPageButton.isEnabled = meetingModel.videoModel.canGoToPrevRemoteVideoPage
-            self?.nextVideoPageButton.isEnabled = meetingModel.videoModel.canGoToNextRemoteVideoPage
-            self?.videoCollection.reloadData()
+            strongSelf.prevVideoPageButton.isEnabled = meetingModel.videoModel.canGoToPrevRemoteVideoPage
+            strongSelf.nextVideoPageButton.isEnabled = meetingModel.videoModel.canGoToNextRemoteVideoPage
+            strongSelf.videoCollection.reloadData()
         }
         meetingModel.videoModel.localVideoUpdatedHandler = { [weak self] in
             self?.videoCollection?.reloadItems(at: [IndexPath(item: 0, section: 0)])
         }
-        meetingModel.screenShareModel.tileIdDidSetHandler = { [weak self] tileId in
-            if let tileId = tileId, let screenRenderView = self?.screenRenderView {
+        meetingModel.screenShareModel.tileIdDidSetHandler = { [weak self, weak meetingModel] tileId in
+            if let tileId = tileId,
+               let screenRenderView = self?.screenRenderView,
+               let meetingModel = meetingModel {
+
                 meetingModel.bind(videoRenderView: screenRenderView, tileId: tileId)
             }
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 * Added Voice Focus feature in Swift demo app.
 
 ### Fixed
+* Fixed `DefaultDeviceController` not removing itself as observer from `NotificationCenter` after deallocation and causes crash in Swift demo app.
 * Fixed a crash in Swift demo app when user opens the device selection Action Sheet in iPad.
 * Fixed a crash in Swift demo app when building with Xcode 12: `DefaultActiveSpeakerPolicy.init()` not implemented.
 * Fixed a bug in Swift demo app: self video disappears when a remote video tile is added.
-* Fixed a bug in Swift demo app: self video disappears when a remote video tile is added.
+* Fixed a bug in Swift demo app: MeetingModel is not deallocated properly after meeting ends.
 * **Breaking** Changed behavior to no longer call `videoTileSizeDidChange` when a video is paused to fix a bug where pausing triggered this callback with width=0 and height=0.
 
 ## [0.11.1] - 2020-10-23


### PR DESCRIPTION
### Issue #, if available:
#148 
There are several problems that led to this crash:
1. `MeetingModel` is not deallocated properly, which causes `DefaultDeviceController` to not being deallocated.
2. `DefaultDeviceController` is still listening to `NotificationCenter` after meeting ends.
3. `oldDevice.inputs` is empty when the notification comes in, so crash on index out of bound.

### Description of changes:

### Testing done:
deinit on DefaultDeviceController is getting hit after meeting ends, and no longer receives notification.
#### Manual test cases (add more as needed):

- [X] Join meeting without CallKit
- [X] Join meeting with CallKit as Incoming
- [X] Join meeting with CallKit as Outgoing
- [X] Leave meeting
- [X] Rejoin meeting
- [X] See metrics
- [X] See attendee presence
- [X] Send audio
- [X] Receive audio
- [X] Mute self
- [X] Unmute self
- [X] See local mute indicator when muted
- [X] See remote mute indicator when other is muted
- [X] Enable and disable local video
- [X] Enable and disable remote video from remote side
- [X] Send local video
- [X] Pause and resume remote video
- [X] Switch local camera
- [X] Receive remote screen share

#### Integration validation (required before release)

- [X] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [X] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [X] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [X] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
