### PR TITLE
Pause stop start resume

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/DefaultVideoTileController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/DefaultVideoTileController.swift
@@ -71,9 +71,10 @@ import UIKit
             if videoTile.state.pauseState == .unpaused, let frame = frame {
                 videoTile.onVideoFrameReceived(frame: frame)
             }
-        } else if frame != nil {
+        } else if (frame != nil || pauseState != .unpaused) {
             onAddTrack(tileId: videoId,
                        attendeeId: attendeeId,
+                       pauseState: pauseState,
                        videoStreamContentWidth: videoStreamContentWidth,
                        videoStreamContentHeight: videoStreamContentHeight)
         }
@@ -111,6 +112,7 @@ import UIKit
 
     private func onAddTrack(tileId: Int,
                             attendeeId: String?,
+                            pauseState: VideoPauseState,
                             videoStreamContentWidth: Int,
                             videoStreamContentHeight: Int) {
         var isLocalTile: Bool
@@ -129,6 +131,7 @@ import UIKit
                                     videoStreamContentHeight: videoStreamContentHeight,
                                     isLocalTile: isLocalTile,
                                     logger: logger)
+        tile.setPauseState(pauseState: pauseState)
         videoTileMap[tileId] = tile
         ObserverUtils.forEach(observers: videoTileObservers) { (videoTileObserver: VideoTileObserver) in
             videoTileObserver.videoTileDidAdd(tileState: tile.state)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Fixed a bug in Swift demo app: self video disappears when a remote video tile is added.
 * Fixed a bug in Swift demo app: MeetingModel is not deallocated properly after meeting ends.
 * **Breaking** Changed behavior to no longer call `videoTileSizeDidChange` when a video is paused to fix a bug where pausing triggered this callback with width=0 and height=0.
+* Fixed `videoTileDidAdd` not being called for paused tiles.
 
 ### Changed
 * **Breaking** Changed default log level of `ConsoleLogger` to INFO.


### PR DESCRIPTION
### Issue #, if available:
https://issues.amazon.com/issues/ChimeVideo-817
### Description of changes:
For nil pauseFrame, add track if there is no tile associated with it
### Testing done:
Verified that after setRemotePause(true), stopRemoteVideo(), startRemoteVideo() will add tiles for all paused stream. Subsequent resume hence works.

#### Manual test cases (add more as needed):

- [x ] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [x ] Leave meeting
- [x ] Rejoin meeting
- [x ] See metrics
- [ x] See attendee presence
- [ x] Send audio
- [x ] Receive audio
- [x ] Mute self
- [x ] Unmute self
- [x ] See local mute indicator when muted
- [x ] See remote mute indicator when other is muted
- [x ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [x ] Send local video
- [ x] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
