### PR TITLE
Provide default device api (#122)

### DIFF
--- a/AmazonChimeSDK/.swiftlint.yml
+++ b/AmazonChimeSDK/.swiftlint.yml
@@ -1,2 +1,3 @@
 excluded:
   - MockingbirdMocks
+  - MockingbirdSupport

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
@@ -198,4 +198,8 @@ import Foundation
     }
 
     public func hasBandwidthPriorityCallback(hasBandwidthPriority: Bool) {}
+
+    public func getActiveAudioDevice() -> MediaDevice? {
+        return deviceController.getActiveAudioDevice()
+    }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/device/DefaultDeviceController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/device/DefaultDeviceController.swift
@@ -33,7 +33,7 @@ import AVFoundation
 
     public func listAudioDevices() -> [MediaDevice] {
         var inputDevices: [MediaDevice] = []
-        let loudSpeaker = MediaDevice(label: "Built-in Speaker", type: MediaDeviceType.audioBuiltInSpeaker)
+        let loudSpeaker = getSpeakerMediaDevice()
         if let availablePort = audioSession.availableInputs {
             inputDevices = availablePort.map { port in MediaDevice.fromAVSessionPort(port: port) }
         }
@@ -121,5 +121,25 @@ import AVFoundation
 
     public func listSupportedVideoCaptureFormats(mediaDevice: MediaDevice) -> [VideoCaptureFormat] {
         return MediaDevice.listSupportedVideoCaptureFormats(mediaDevice: mediaDevice)
+    }
+
+    public func getActiveAudioDevice() -> MediaDevice? {
+        // Check for speaker case
+        if audioSession.currentRoute.outputs.count > 0 {
+            let currentOutput = audioSession.currentRoute.outputs[0]
+
+            if currentOutput.portType == .builtInSpeaker {
+                return getSpeakerMediaDevice()
+            }
+        }
+        if audioSession.currentRoute.inputs.count > 0 {
+            return MediaDevice.fromAVSessionPort(port: audioSession.currentRoute.inputs[0])
+        } else {
+            return nil
+        }
+    }
+
+    private func getSpeakerMediaDevice() -> MediaDevice {
+        return MediaDevice(label: "Built-in Speaker", type: MediaDeviceType.audioBuiltInSpeaker)
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/device/DeviceController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/device/DeviceController.swift
@@ -38,4 +38,8 @@ import Foundation
     /// e.g. one passed in via `AudioVideoControllerFacade.startLocalVideo`
     /// - Returns: a media device or nil if no device is present
     func getActiveCamera() -> MediaDevice?
+
+    /// Get currently used audio device
+    /// - Returns: a media device or nil if no device is present
+    func getActiveAudioDevice() -> MediaDevice?
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientProtocol.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientProtocol.swift
@@ -5,6 +5,7 @@
 //  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //  SPDX-License-Identifier: Apache-2.0
 //
+// swiftlint:disable identifier_name function_parameter_count
 
 import AmazonChimeSDKMedia
 import Foundation

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioSession.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioSession.swift
@@ -14,6 +14,7 @@ import Foundation
     var availableInputs: [AVAudioSessionPortDescription]? { get }
     func setPreferredInput(_ inPort: AVAudioSessionPortDescription?) throws
     func overrideOutputAudioPort(_ portOverride: AVAudioSession.PortOverride) throws
+    var currentRoute: AVAudioSessionRouteDescription { get }
 }
 
 extension AVAudioSession: AudioSession {}

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/utils/ConcurrentMutableSetTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/utils/ConcurrentMutableSetTests.swift
@@ -105,7 +105,7 @@ class ConcurrentMutableSetTests: XCTestCase {
             mainThreadEndedExpectation.fulfill()
         }
 
-        wait(for: [backgroundThreadEndedExpectation, mainThreadEndedExpectation], timeout: 5)
+        wait(for: [backgroundThreadEndedExpectation, mainThreadEndedExpectation], timeout: 7)
         XCTAssertEqual(count, 1)
         XCTAssertEqual(sum, 1)
         XCTAssertEqual(normalSet.count, 1)

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -118,6 +118,10 @@ class MeetingModel: NSObject {
         return currentMeetingSession.audioVideo.listAudioDevices()
     }
 
+    var currentAudioDevice: MediaDevice? {
+        return currentMeetingSession.audioVideo.getActiveAudioDevice()
+    }
+
     var isLocalVideoActive = false {
         didSet {
             if isLocalVideoActive {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -335,13 +335,20 @@ class MeetingViewController: UIViewController {
         guard let meetingModel = meetingModel else {
             return
         }
-        let optionMenu = UIAlertController(title: nil, message: "Choose Audio Device", preferredStyle: .actionSheet)
 
+        let optionMenu = UIAlertController(title: nil, message: "Choose Audio Device", preferredStyle: .actionSheet)
+        let currentAudioDevice = meetingModel.currentAudioDevice
         for inputDevice in meetingModel.audioDevices {
-            let deviceAction = UIAlertAction(title: inputDevice.label,
+            var label = inputDevice.label
+            if let selectedAudioDevice = currentAudioDevice {
+                if selectedAudioDevice.label == inputDevice.label {
+                    label = "\(label) ✔︎"
+                }
+            }
+            let deviceAction = UIAlertAction(title: label,
                                              style: .default,
                                              handler: { _ in meetingModel.chooseAudioDevice(inputDevice)
-                })
+            })
             optionMenu.addAction(deviceAction)
         }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Added new APIs in `RealtimeControllerFacade` to enable/disable Voice Focus (ML-based noise suppression) and get the on/off status of Voice Focus.
 * Added Voice Focus feature in Swift demo app.
 * Added more verbose logging from media layer to SDK layer for builders to control log level. Set `LogLevel` to `INFO` or above for production application to not be bombarded with logs.
+* Added `getActiveAudioDevice` API in `DefaultDeviceController`.
 
 ### Fixed
 * Fixed `DefaultDeviceController` not removing itself as observer from `NotificationCenter` after deallocation and causes crash in Swift demo app.


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:

### Testing done:

#### Manual test cases (add more as needed):

- [ ] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [ ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
