### PR TITLE
Fix ObjC demo Video Tiles invisible

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemoObjC/ViewControllerObjC.m
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemoObjC/ViewControllerObjC.m
@@ -209,6 +209,7 @@
     [self.meetingSession.audioVideo removeRealtimeObserverWithObserver:self];
     [self.meetingSession.audioVideo removeMetricsObserverWithObserver:self];
     [self.meetingSession.audioVideo removeVideoTileObserverWithObserver:self];
+    [self.meetingSession.audioVideo removeActiveSpeakerObserverWithObserver:self];
     [self.meetingSession.audioVideo stop];
     [self updateUIWithMeetingStarted:NO];
 }
@@ -220,9 +221,8 @@
         [self.nameText setEnabled:!started];
         [self.joinButton setHidden:started];
         [self.leaveButton setHidden:!started];
-        // Currently using setAlpha as a workaround as setHidden is not working properly
-        [self.selfVideoView setAlpha:started ? 1 : 0];
-        [self.remoteVideoView setAlpha:started ? 1 : 0];
+        [self.selfVideoView setHidden:!started];
+        [self.remoteVideoView setHidden:!started];
     });
 }
 
@@ -383,7 +383,7 @@
     return 5000;
 }
 
-- (NSString*) observerId {
+- (NSString*)observerId {
     return [NSUUID new].UUIDString;
 }
 


### PR DESCRIPTION
### Issue #, if available:
Fix self and remote video tiles are invisible for obj c demo app
Remove self as active speaker observer when meeting ends
### Description of changes:

### Testing done:

#### Manual test cases (add more as needed):

- [X] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [ ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [X] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
