### PR TITLE
Smooth out filter toggling by avoiding camera restart

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/capture/DefaultCameraCaptureSource.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/capture/DefaultCameraCaptureSource.swift
@@ -63,8 +63,7 @@ import UIKit
                                                     for: .video,
                                                     position: isUsingFrontCamera ? .front : .back)
             if session.isRunning {
-                stop()
-                start()
+                start() // Restart
             }
         }
     }
@@ -72,8 +71,7 @@ import UIKit
     public var format: VideoCaptureFormat = defaultCaptureFormat {
         didSet {
             if captureDevice != nil, session.isRunning {
-                stop()
-                start()
+                start() // Restart
             }
         }
     }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -86,7 +86,6 @@ class MeetingModel: NSObject {
     var isUsingExternalVideoSource = true {
         didSet {
             if isLocalVideoActive {
-                stopLocalVideo()
                 startLocalVideo()
             }
         }
@@ -96,7 +95,6 @@ class MeetingModel: NSObject {
     var isUsingCoreImageVideoProcessor = false {
         didSet {
             if isLocalVideoActive {
-                stopLocalVideo()
                 startLocalVideo()
             }
         }
@@ -108,7 +106,6 @@ class MeetingModel: NSObject {
     var isUsingMetalVideoProcessor = false {
         didSet {
             if isLocalVideoActive {
-                stopLocalVideo()
                 startLocalVideo()
             }
         }
@@ -123,7 +120,7 @@ class MeetingModel: NSObject {
     }
 
     var isLocalVideoActive = false {
-        didSet {
+        willSet(isLocalVideoActive) {
             if isLocalVideoActive {
                 startLocalVideo()
             } else {
@@ -320,7 +317,10 @@ class MeetingModel: NSObject {
                         customSource = metalVideoProcessor
                     }
                     self.currentMeetingSession.audioVideo.startLocalVideo(source: customSource)
-                    self.videoModel.customSource.start()
+                    if (!self.isLocalVideoActive) {
+                        // Only start capturer if it is not already running
+                        self.videoModel.customSource.start()
+                    }
                 } else {
                     do {
                         try self.currentMeetingSession.audioVideo.startLocalVideo()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Fixed `videoTileDidAdd` not being called for paused tiles.
 
 ### Changed
+
 * **Breaking** Changed default log level of `ConsoleLogger` to INFO.
 
 ## [0.11.1] - 2020-10-23


### PR DESCRIPTION
### Issue #, if available: None

### Description of changes:
Currently, stopping and starting local video will trigger multiple resubscribes, and clear and readd video on remote end.  This is used when switching filters, and it is best practice to not restart.  In addition even if not stopping, we would restart the capturer unnecessarily when changing filters, which is also not the practice we want to recommend to builders.  These changes fix both of those.

### Testing done:
Confirmed no longer resubscribes, or restarts camera on filter change.

#### Manual test cases (add more as needed):

- [x] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [x] Rejoin meeting
- [x] See metrics
- [ ] See attendee presence
- [x] Send audio
- [x] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [x] Enable and disable local video
- [x] Enable and disable remote video from remote side
- [x] Send local video
- [x] Pause and resume remote video
- [x] Switch local camera
- [x] Receive remote screen share

#### Integration validation (required before release)

- [x] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
