### PR TITLE
Fix camera start when switching between internal and external APIs without stopping

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
@@ -393,10 +393,13 @@ extension DefaultVideoClientController: VideoClientController {
     }
 
     public func startLocalVideo(source: VideoSource) {
+        if isInternalCaptureSourceRunning {
+            internalCaptureSource.stop()
+            isInternalCaptureSourceRunning = false
+        }
         setVideoSource(source: source)
 
         logger.info(msg: "Starting local video with custom source")
-        isInternalCaptureSourceRunning = false
     }
 
     private func setVideoSource(source: VideoSource) {


### PR DESCRIPTION
### Issue #, if available:
None

### Description of changes:
Basically we need to turn off previous capture if switching between APIs. iOS would not supercede camera on second start.

### Testing done:
Smoke tested toggle again.

#### Manual test cases (add more as needed):

- [x] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [x] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [x] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [x] Send local video
- [ ] Pause and resume remote video
- [x] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
