### PR TITLE
Add bug label in exempt

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,6 +6,7 @@ daysUntilClose: 14
 exemptLabels:
   - enhancement
   - crash
+  - bug
 # Label to use when marking an issue as stale
 staleLabel: inactive
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
### Issue #, if available:
N/A
### Description of changes:
Add bug label to stale bot so that it doesn't close bug labels.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
