### PR TITLE
Remove the video tile mapping entry when video is removed instead of when video is unbound

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/DefaultVideoTileController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/DefaultVideoTileController.swift
@@ -102,9 +102,8 @@ import UIKit
     }
 
     private func removeVideoViewBindMapping(tileId: Int) {
-        videoViewToTileMap.filter({ $1.state.tileId == tileId }).forEach {renderView, videoTile in
+        videoViewToTileMap.first(where: { $1.state.tileId == tileId }).map { videoRenderKey, videoTile in
             videoTile.unbind()
-            let videoRenderKey = NSValue(nonretainedObject: videoTile.videoRenderView)
             videoViewToTileMap.removeValue(forKey: videoRenderKey)
         }
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
+## Unreleased
+
+### Changed
+* **Breaking** Changed SDK behavior to remove the internal video tile mapping entry when video is removed, instead of when video is unbound. This provides better API symmetry so that the video metadata will be added in `videoTileDidAdd(tileState)` callback and removed in `videoTileDidRemove(tileState)` callback.
+
 ## [0.12.1] - 2020-11-20
 
 ## [0.12.0] - 2020-11-17
+
 ### Added
 * Added new APIs in `RealtimeControllerFacade` to enable/disable Voice Focus (ML-based noise suppression) and get the on/off status of Voice Focus.
 * Added Voice Focus feature in Swift demo app.
@@ -21,9 +27,7 @@
 * **Breaking** Changed behavior to no longer call `videoTileSizeDidChange` when a video is paused to fix a bug where pausing triggered this callback with width=0 and height=0.
 * Fixed `videoTileDidAdd` not being called for paused tiles.
 
-
 ### Changed
-
 * **Breaking** Changed default log level of `ConsoleLogger` to INFO.
 * The render path has been changed to use `VideoFrame`s for consistency with the send side, this includes:
   * **Breaking** `VideoTileController.onReceiveFrame` now takes `VideoFrame?` instead of `CVPixelBuffer?`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 ### Changed
-* **Breaking** Changed SDK behavior to remove the internal video tile mapping entry when video is removed, instead of when video is unbound. This provides better API symmetry so that the video metadata will be added in `videoTileDidAdd(tileState)` callback and removed in `videoTileDidRemove(tileState)` callback.
+* **Breaking** Changed SDK behavior to remove the internal video tile mapping entry when video is *removed*, instead of when video is *unbound*. This fixes [`videoTileDidAdd(tileState)` is sometimes not called issue](https://github.com/aws/amazon-chime-sdk-android/issues/186), and provides better API symmetry so that builders no longer need to call `unbindVideoView(tileId:)` if they did not call `bindVideoView(videoView:tileId:)`.
 
 ## [0.12.1] - 2020-11-20
 


### PR DESCRIPTION
### Issue #, if available:
https://github.com/aws/amazon-chime-sdk-android/issues/186

### Description of changes:
Changed SDK behavior to remove the internal video tile mapping entry when video is removed, instead of when video is unbound. This provides better API symmetry so that the video metadata will be added in `videoTileDidAdd(tileState)` callback and removed in `videoTileDidRemove(tileState)` callback.

### Testing done:
Tested by modifying the demo app so that it does not bind remote video in `videoTileDidAdd(tileState)` and it does not unbind remote video in `videoTileDidRemove(tileState)`. Test steps:
1. UserA joined Web client and enabled video.
2. UserB joined mobile client. Verified in the log that videoTileDidAdd was called for UserA's video, but the view was not bound (so video was not showing on the screen).
3. UserA disabled video. Verified in the log that videoTileDidRemove was called for UserA's video.
4. UserA enabled video again. Verified in the log that videoTileDidAdd was called again for UserA's video.

#### Manual test cases (add more as needed):

- [x] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [x] Rejoin meeting
- [x] See metrics
- [x] See attendee presence
- [x] Send audio
- [x] Receive audio
- [x] Mute self
- [x] Unmute self
- [x] See local mute indicator when muted
- [x] See remote mute indicator when other is muted
- [x] Enable and disable local video
- [x] Enable and disable remote video from remote side
- [x] Send local video
- [x] Pause and resume remote video
- [x] Switch local camera
- [ ] Receive remote screen share
- [X] Unit tests pass

### Screenshots, if available:
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
