### PR TITLE
Remove the video from both mappings when unbind, in order to keep the old SDK behavior

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/DefaultVideoTileController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/DefaultVideoTileController.swift
@@ -110,6 +110,8 @@ import UIKit
 
     public func unbindVideoView(tileId: Int) {
         logger.info(msg: "Unbinding VideoView to Tile with tileId = \(tileId)")
+        // Remove the video from both mappings when unbind, in order to keep the old SDK behavior
+        videoTileMap.removeValue(forKey: tileId)
         removeVideoViewBindMapping(tileId: tileId)
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Unreleased
 
 ### Changed
-* **Breaking** Changed SDK behavior to remove the internal video tile mapping entry when video is *removed*, instead of when video is *unbound*. This fixes [`videoTileDidAdd(tileState)` is sometimes not called issue](https://github.com/aws/amazon-chime-sdk-android/issues/186), and provides better API symmetry so that builders no longer need to call `unbindVideoView(tileId:)` if they did not call `bindVideoView(videoView:tileId:)`.
+* **Breaking** Remove the internal video tile mapping entry not only when the video is *unbound*, but also when the video is *removed*. This fixes [`videoTileDidAdd(tileState)` is sometimes not called issue](https://github.com/aws/amazon-chime-sdk-android/issues/186), and provides better API symmetry so that builders no longer need to call `unbindVideoView(tileId:)` if they did not call `bindVideoView(videoView:tileId:)`.
+  * After this fix, the internal video tile mapping entry will be removed before `videoTileDidRemove(tileState:)` callback is called. Please check your `VideoTileObserver`s and make sure your `videoTileDidRemove(tileState:)` handlers do not call any SDK APIs that depend on the existance of video tiles (e.g. `bindVideoView(videoView:tileId:)`).
 
 ## [0.12.1] - 2020-11-20
 


### PR DESCRIPTION
### Issue #, if available:
https://github.com/aws/amazon-chime-sdk-android/issues/186

### Description of changes:
This is a follow-up PR for #179.

In #179, we changed the SDK behavior to remove the internal video tile mapping entry when video is *removed*, instead of when video is *unbound*. This change will have a pretty big impact to builders' existing video handling workflows.

In this PR, we try to reduce the impact of the fix by keeping the old behavior when builder calls `unbindVideoView`. The only delta before and after the fix is, SDK now also removes the internal video tile mapping entry when video is *removed*, in addition to the time when video is *unbound*.

### Testing done:

#### Manual test cases (add more as needed):

- [x] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [x] Rejoin meeting
- [x] See metrics
- [x] See attendee presence
- [x] Send audio
- [x] Receive audio
- [x] Mute self
- [x] Unmute self
- [x] See local mute indicator when muted
- [x] See remote mute indicator when other is muted
- [x] Enable and disable local video
- [x] Enable and disable remote video from remote side
- [x] Send local video
- [x] Pause and resume remote video
- [x] Switch local camera
- [x] Receive remote screen share

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
