### PR TITLE
Add background foreground

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/AppDelegate.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/AppDelegate.swift
@@ -17,6 +17,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         return true
     }
+    
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        if let meeting = MeetingModule.shared().activeMeeting {
+            meeting.isAppInBackground = true
+        }
+    }
+    
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        if let meeting = MeetingModule.shared().activeMeeting {
+            meeting.isAppInBackground = false
+        }
+    }
 
     // MARK: UISceneSession Lifecycle
 

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -41,9 +41,24 @@ class MeetingModel: NSObject {
                                                          cameraCaptureSource: videoModel.customSource)
     let uuid = UUID()
     var call: Call?
-
+    var isAppInBackground: Bool = false {
+        didSet {
+            if isAppInBackground {
+                wasLocalVideoOn = isLocalVideoActive
+                if wasLocalVideoOn {
+                    isLocalVideoActive = false
+                }
+                videoModel.pauseAllRemoteVideos()
+            } else {
+                if wasLocalVideoOn {
+                    isLocalVideoActive = true
+                }
+                videoModel.resumeAllRemoteVideosInCurrentPageExceptUserPausedVideos()
+            }
+        }
+    }
     private var savedModeBeforeOnHold: ActiveMode?
-
+    private var wasLocalVideoOn: Bool = false
     // States
     var activeMode: ActiveMode = .roster {
         didSet {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -91,31 +91,6 @@ class MeetingViewController: UIViewController {
             layout.scrollDirection = .vertical
         }
     }
-    
-    private func registerForAppLifeCycleNotification() {
-        NotificationCenter.default.addObserver(self, selector: #selector(appMovedToBackground), name: UIApplication.didEnterBackgroundNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(appMovedToForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
-    }
-    
-    private func deregisterForAppLifeCycleNotification() {
-        NotificationCenter.default.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: UIApplication.willEnterForegroundNotification, object: nil)
-    }
-    
-    @objc private func appMovedToBackground() {
-        isLocalOn = meetingModel?.isLocalVideoActive ?? false
-        if isLocalOn {
-            meetingModel?.isLocalVideoActive = false
-        }
-        meetingModel?.videoModel.pauseAllRemoteVideos()
-    }
-    
-    @objc private func appMovedToForeground() {
-        if isLocalOn {
-            meetingModel?.isLocalVideoActive = true
-        }
-        meetingModel?.videoModel.resumeAllRemoteVideosInCurrentPageExceptUserPausedVideos()
-    }
 
     private func registerForKeyboardNotifications() {
         // Adding notifies on keyboard appearing
@@ -233,7 +208,6 @@ class MeetingViewController: UIViewController {
         chatMessageTable.delegate = meetingModel?.chatModel
         chatMessageTable.dataSource = meetingModel?.chatModel
         registerForKeyboardNotifications()
-        registerForAppLifeCycleNotification()
         sendMessageButton.isEnabled = false
         chatMessageTable.separatorStyle = .none
         sendMessageButton.imageView?.contentMode = UIView.ContentMode.scaleAspectFit
@@ -400,7 +374,6 @@ class MeetingViewController: UIViewController {
     @IBAction func leaveButtonClicked(_: UIButton) {
         meetingModel?.endMeeting()
         deregisterFromKeyboardNotifications()
-        deregisterForAppLifeCycleNotification()
     }
 
     @IBAction func inputTextChanged(_: Any, forEvent _: UIEvent) {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -58,7 +58,7 @@ class MeetingViewController: UIViewController {
 
     // Model
     var meetingModel: MeetingModel?
-    
+
     // Local var
     private let logger = ConsoleLogger(name: "MeetingViewController")
 

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -59,9 +59,6 @@ class MeetingViewController: UIViewController {
     // Model
     var meetingModel: MeetingModel?
     
-    // isLocalOn
-    private var isLocalOn: Bool = false
-
     // Local var
     private let logger = ConsoleLogger(name: "MeetingViewController")
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Added
+* Update demo application to pause/resume when app is in background/foreground
+
 ## 0.13.0 - 2020-12-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
+
 ### Added
-* Update demo application to pause/resume when app is in background/foreground
+* Update demo application to pause/resume remote videos and stop/start local video when app is in background/foreground
 
 ## 0.13.0 - 2020-12-17
 


### PR DESCRIPTION
### Issue #, if available:
Chime-33481
### Description of changes:
Add logic of stopping local video 
### Testing done:
![Screen Shot 2020-12-15 at 4 57 30 PM](https://user-images.githubusercontent.com/57926812/102396053-c3ef1c00-3f90-11eb-9d52-5d7cf0f9813f.png)

![Screen Shot 2020-12-15 at 4 58 05 PM](https://user-images.githubusercontent.com/57926812/102396020-bb96e100-3f90-11eb-85f3-6a1008a8f934.png)

1. Background and foreground the app. In the background, confirm that network usage is low and local video is no longer sending
2. Pause the video and background/foreground the app. Confirm that it still shows paused video
3. While backgrounded, turn the one of remote video off. Confirm that it is removed when foregrounded.
4. While backgrounded, turn the one of remote video on. Confirm that it is added when foregrounded.
5. Join as Callkit. Video behaves the same.

#### Manual test cases (add more as needed):

- [X] Join meeting without CallKit
- [x] Join meeting with CallKit as Incoming
- [x] Join meeting with CallKit as Outgoing
- [X] Leave meeting
- [X] Rejoin meeting
- [X] See metrics
- [X] See attendee presence
- [X] Send audio
- [X] Receive audio
- [X] Mute self
- [X] Unmute self
- [X] See local mute indicator when muted
- [X] See remote mute indicator when other is muted
- [X] Enable and disable local video
- [X] Enable and disable remote video from remote side
- [X] Send local video
- [X] Pause and resume remote video
- [X] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
