### PR TITLE
Add path to url

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/utils/JoinRequestService.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/utils/JoinRequestService.swift
@@ -19,8 +19,9 @@ class JoinRequestService: NSObject {
     }
 
     static func postJoinRequest(meetingId: String, name: String, completion: @escaping (MeetingSessionConfiguration?) -> Void) {
+        let url = AppConfiguration.url.hasSuffix("/") ? AppConfiguration.url : "\(AppConfiguration.url)/"
         let encodedURL = HttpUtils.encodeStrForURL(
-            str: "\(AppConfiguration.url)join?title=\(meetingId)&name=\(name)&region=\(AppConfiguration.region)"
+            str: "\(url)join?title=\(meetingId)&name=\(name)&region=\(AppConfiguration.region)"
         )
         HttpUtils.postRequest(url: encodedURL, jsonData: nil, logger: logger) { data, _ in
             guard let data = data else {


### PR DESCRIPTION
### Issue #, if available:
https://github.com/aws/amazon-chime-sdk-ios/issues/188
### Description of changes:
Add better handling or url by adding "/" if it is missing as done in Android.
### Testing done:

#### Manual test cases (add more as needed):

- [X] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [ ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
