### PR TITLE
Implement turn uris received callback

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
@@ -107,6 +107,7 @@ class DefaultVideoClientController: NSObject {
         videoConfig.isUsingPixelBufferRenderer = true
         videoConfig.isUsingOptimizedTwoSimulcastStreamTable = true
         videoConfig.isExcludeSelfContentInIndex = true
+        videoConfig.isUsingInbandTurnCreds = true
 
         // Default to idle mode, no video but signaling connection is
         // established for messaging
@@ -116,7 +117,8 @@ class DefaultVideoClientController: NSObject {
                           token: configuration.credentials.joinToken,
                           sending: false,
                           config: videoConfig,
-                          appInfo: DeviceUtils.getDetailedInfo())
+                          appInfo: DeviceUtils.getDetailedInfo(),
+                          signalingUrl: configuration.urls.signalingUrl)
         videoClientState = .started
     }
 }
@@ -235,6 +237,10 @@ extension DefaultVideoClientController: VideoClientDelegate {
                 }
             }
         }
+    }
+    
+    public func videoClientTurnURIsReceived(_ uris: [String]) -> [String] {
+        return uris.map(self.configuration.urlRewriter)
     }
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * **Breaking** `DefaultAudioVideoFacade` init requires a `ContentShareController` instance.
 * Update text of additional options on demo app.
 * `MeetingSessionURLs` and `MeetingSessionCredentials` now conform to `Codable`.
+* Changes that support a speed up of video client initialization. `videoClientRequestTurnCreds` callback will only be invoked as a backup for media layer logic. The signaling url is now passed into video client start. A new callback `videoClientTurnURIsReceived` will be invoked when TURN uris are received by the client. This allows urls to be modified with urlRewriter or customer builder logic.
 
 ## [0.13.1] - 2021-01-08
 
@@ -45,6 +46,7 @@
 * Added `CameraCaptureSource`, `CaptureSourceError`, `CaptureSourceObserver`, `VideoCaptureFormat`, and `VideoCaptureSource` interfaces and enums to facilitate releasing capturers as part of the SDK.
 * Added `DefaultCameraCaptureSource` implementation of `CameraCaptureSource`.
 * Added `listVideoDevices` and `listSupportedVideoCaptureFormats` to `MediaDevice.Companion`.
+* Added TURN uris received callback.
 
 ### Fixed
 * Fixed `DefaultDeviceController` not removing itself as observer from `NotificationCenter` after deallocation and causes crash in Swift demo app.


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
Implement callback that allows modification of TURN uris by builder.
Pass signaling url into video client start since requestTurnCreds will only be called as a backup.
### Testing done:
Joined a meeting with 2 participants and ensured video was sent and received.
#### Manual test cases (add more as needed):

- [x ] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [x ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [x ] See attendee presence
- [x ] Send audio
- [x ] Receive audio
- [x ] Mute self
- [x ] Unmute self
- [x ] See local mute indicator when muted
- [x ] See remote mute indicator when other is muted
- [x ] Enable and disable local video
- [x ] Enable and disable remote video from remote side
- [x ] Send local video
- [x ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [x ] Unit tests pass
- [x ] Build SDK against simulator with release options
- [x ] Build SDK against device with release options
- [x ] Build SDK against simulator with debug options
- [x ] Build SDK against device with debug options
- [x ] Test Demo against simulator with SDK (debug build) in workspace
- [x ] Test Demo against device with SDK (debug build) in workspace
- [x ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [x ] Test DemoObjC against device with SDK (debug build) in workspace
- [x ] Test Demo against simulator with SDK.framework (release build)
- [x ] Test Demo against device with SDK.framework (release build)
- [x ] Test DemoObjC against simulator with SDK.framework (release build)
- [x ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
