### PR TITLE
Fix audio disconnecting issue by changing weakly-referenced self back to strong reference

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
@@ -91,16 +91,15 @@ extension DefaultAudioClientController: AudioClientController {
             return
         }
 
-        DispatchQueue.global().async { [weak self] in
-            guard let strongSelf = self else { return }
-            strongSelf.audioLock.lock()
-            let audioClientStatusCode = strongSelf.audioClient.stopSession()
+        DispatchQueue.global().async {
+            self.audioLock.lock()
+            let audioClientStatusCode = self.audioClient.stopSession()
             Self.state = .stopped
             let meetingSessionStatusCode = Converters.AudioClientStatus.toMeetingSessionStatusCode(
                 rawValue: UInt32(audioClientStatusCode)
             )
-            strongSelf.audioLock.unlock()
-            strongSelf.audioClientObserver.notifyAudioClientObserver { (observer: AudioVideoObserver) in
+            self.audioLock.unlock()
+            self.audioClientObserver.notifyAudioClientObserver { (observer: AudioVideoObserver) in
                 observer.audioSessionDidStopWithStatus(
                     sessionStatus: MeetingSessionStatus(statusCode: meetingSessionStatusCode)
                 )

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientObserver.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientObserver.swift
@@ -269,13 +269,12 @@ class DefaultAudioClientObserver: NSObject, AudioClientDelegate {
             return
         }
 
-        DispatchQueue.global().async { [weak self] in
-            guard let strongSelf = self else { return }
-            strongSelf.audioLock.lock()
-            strongSelf.audioClient.stopSession()
+        DispatchQueue.global().async {
+            self.audioLock.lock()
+            self.audioClient.stopSession()
             DefaultAudioClientController.state = .stopped
-            strongSelf.audioLock.unlock()
-            strongSelf.notifyAudioClientObserver { (observer: AudioVideoObserver) in
+            self.audioLock.unlock()
+            self.notifyAudioClientObserver { (observer: AudioVideoObserver) in
                 observer.audioSessionDidStopWithStatus(sessionStatus: MeetingSessionStatus(statusCode: newAudioStatus))
             }
         }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
@@ -369,16 +369,15 @@ extension DefaultVideoClientController: VideoClientController {
     // MARK: - Lifecycle: stop and destroy
 
     public func stopAndDestroy() {
-        DispatchQueue.global().async { [weak self] in
-            guard let strongSelf = self else { return }
-            switch strongSelf.videoClientState {
+        DispatchQueue.global().async {
+            switch self.videoClientState {
             case .uninitialized:
-                strongSelf.logger.info(msg: "VideoClient is uninitialized so cannot be stopped and destroyed")
+                self.logger.info(msg: "VideoClient is uninitialized so cannot be stopped and destroyed")
             case .started:
-                strongSelf.stopVideoClient()
-                strongSelf.destroyVideoClient()
+                self.stopVideoClient()
+                self.destroyVideoClient()
             case .initialized, .stopped:
-                strongSelf.destroyVideoClient()
+                self.destroyVideoClient()
             }
         }
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 * Fix a bug that internal capture source was not stopped properly when the video client was being stopped. (Issue [#200](https://github.com/aws/amazon-chime-sdk-ios/issues/200))
+* Fix a bug that `self` was weakly-referenced incorrectly in several closures and caused `audioClient.stopSession()` not being called as expected. (Issue [#193](https://github.com/aws/amazon-chime-sdk-ios/issues/193))
 
 ## [0.13.0] - 2020-12-17
 


### PR DESCRIPTION
### Issue #, if available:
#193 

### Description of changes:
Fix audio disconnecting issue by changing weakly-referenced `self`s back to strong reference in `DefaultAudioClientController`. Also made similar change to `DefaultAudioClientObserver` and `DefaultVideoClientController` to prevent similar issues and make sure the DispatchQueue async closures are executed as expected.

### Testing done:
Tested in the ReactNative demo app. The audio client can be disconnected successfully after calling `audioVideo.stop()`.

#### Manual test cases (add more as needed):

- [x] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [x] Rejoin meeting
- [ ] See metrics
- [x] See attendee presence
- [x] Send audio
- [x] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [x] Enable and disable local video
- [x] Enable and disable remote video from remote side
- [x] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [x] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
