### PR TITLE
Stop internal capture source when stopping video client

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
@@ -140,6 +140,8 @@ class DefaultVideoClientController: NSObject {
         logger.info(msg: "Stopping VideoClient")
         videoClient?.stop()
         videoClientState = .stopped
+        // SDK owns the lifecycle of the internal capture source
+        stopInternalCaptureSourceIfRunning()
     }
 
     private func destroyVideoClient() {
@@ -393,13 +395,17 @@ extension DefaultVideoClientController: VideoClientController {
     }
 
     public func startLocalVideo(source: VideoSource) {
+        stopInternalCaptureSourceIfRunning()
+        setVideoSource(source: source)
+
+        logger.info(msg: "Starting local video with custom source")
+    }
+
+    private func stopInternalCaptureSourceIfRunning() {
         if isInternalCaptureSourceRunning {
             internalCaptureSource.stop()
             isInternalCaptureSourceRunning = false
         }
-        setVideoSource(source: source)
-
-        logger.info(msg: "Starting local video with custom source")
     }
 
     private func setVideoSource(source: VideoSource) {
@@ -420,10 +426,7 @@ extension DefaultVideoClientController: VideoClientController {
         }
         logger.info(msg: "Stopping local video")
         videoClient?.setSending(false)
-        if isInternalCaptureSourceRunning {
-            internalCaptureSource.stop()
-            isInternalCaptureSourceRunning = false
-        }
+        stopInternalCaptureSourceIfRunning()
     }
 
     public func startRemoteVideo() {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-## 0.13.0 - 2020-12-17
+## Unreleased
+
+### Fixed
+* Fix a bug that internal capture source was not stopped properly when the video client was being stopped. (Issue [#200](https://github.com/aws/amazon-chime-sdk-ios/issues/200))
+
+## [0.13.0] - 2020-12-17
 
 ### Changed
 * **Breaking** Remove the internal video tile mapping entry not only when the video is *unbound*, but also when the video is *removed*. This fixes [`videoTileDidAdd(tileState)` is sometimes not called issue](https://github.com/aws/amazon-chime-sdk-android/issues/186), and provides better API symmetry so that builders no longer need to call `unbindVideoView(tileId:)` if they did not call `bindVideoView(videoView:tileId:)`.


### PR DESCRIPTION
### Issue #, if available:
#200 

### Description of changes:
When builder calls `startLocalVideo()` (the one without parameter), we start an internal capture source. This internal capture source need to be stopped when we destroy video client. Otherwise, after builder calls `audioVideo.stop()`, the local video will still be on and the camera indicator (the green dot in the status bar) will still show up.

### Testing done:
Tested with the ReactNative demo app. Was able to see the green light turned off after meeting ends.

#### Manual test cases (add more as needed):

- [x] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [x] Rejoin meeting
- [ ] See metrics
- [x] See attendee presence
- [x] Send audio
- [x] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [x] Enable and disable local video
- [x] Enable and disable remote video from remote side
- [x] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [x] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
