### PR TITLE
Update broadcast display name and README

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemoBroadcast/Info.plist
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemoBroadcast/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>AmznChimeSDKDemo</string>
+	<string>Demo</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ And review the following guides:
 * [Getting Started](guides/getting_started.md)
 * [Custom Video Sources, Processors, and Sinks](guides/custom_video.md)
 * [Video Pagination with Active Speaker-Based Policy](guides/video_pagination.md)
+* [Content Share](guides/content_share.md)
 
 ## Setup
 
@@ -85,7 +86,8 @@ Deploy the serverless demo from [amazon-chime-sdk-js](https://github.com/aws/ama
 
 ### 4. Update Demo App
 
-Update `AppConfiguration.swift` with the URL and region of the serverless demo
+* Update `AppConfiguration.swift` with the URL and region of the serverless demo.
+* (Optional) Update `AppConfiguration.swift` and `SampleHandler.swift` with the broadcast upload extension bundle ID and App Group ID if you want to test sharing device level screen capture. See [Content Share](guides/content_share.md) for more details.
 
 ### 5. Use Demo App to join meeting
 


### PR DESCRIPTION
### Issue #, if available:
WTBugs-22402

### Description of changes:
Update broadcast display name to be just "Demo"
Update README for broadcast setup and link to guide

### Testing done:

#### Manual test cases (add more as needed):

- [X] Join meeting without CallKit
- [X] Join meeting with CallKit as Incoming
- [X] Join meeting with CallKit as Outgoing
- [X] Leave meeting
- [X] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [X] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [X] Build SDK against simulator with debug options
- [X] Build SDK against device with debug options
- [X] Test Demo against simulator with SDK (debug build) in workspace
- [X] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
