### PR TITLE
Reset remote VideoRenderView when remote video tile was removed

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemoObjC/ViewControllerObjC.m
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemoObjC/ViewControllerObjC.m
@@ -355,6 +355,9 @@
 - (void)videoTileDidRemoveWithTileState:(VideoTileState *)tileState {
     [self.logger infoWithMsg:[NSString stringWithFormat:@"Removing Video Tile tileId: %ld, attendeeId: %@", (long)tileState.tileId, tileState.attendeeId]];
     [self.meetingSession.audioVideo unbindVideoViewWithTileId:tileState.tileId];
+    if (![tileState isLocalTile]) {
+        [self.remoteVideoView resetImage];
+    }
 }
 
 - (void)videoTileDidPauseWithTileState:(VideoTileState *)tileState {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Fixed
 * Fix the demo application bug that front camera video was not mirrored without selecting video device on the video preview page.
+* Fix the ObjC demo application issue that remote VideoRenderView was not cleared when remote video tile was removed.
 
 ### Changed
 * **Breaking** `AudioVideoFacade` now also implements `ContentShareController`.


### PR DESCRIPTION
### Issue #, if available:
WTBugs-22468

### Description of changes:
Fix a bug in the ObjC demo app. In the `videoTileDidRemoveWithTileState:` callback, we reset the image in remote `VideoRenderView` when the video tile was removed.

### Testing done:
Manual test:
- UserA joined meeting via ObjC demo.
- UserB joined meeting via web client and enabled video.
- UserA is able to see UserB's video.
- UserB disabled video.
- UserB's tile was removed from UserA.

#### Manual test cases (add more as needed):

- [x] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [x] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [x] Send audio
- [x] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [x] Enable local video
- [x] Enable and disable remote video from remote side
- [x] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
