### PR TITLE
Fix data message conversion

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
@@ -238,7 +238,7 @@ extension DefaultVideoClientController: VideoClientDelegate {
             }
         }
     }
-    
+
     public func videoClientTurnURIsReceived(_ uris: [String]) -> [String] {
         return uris.map(self.configuration.urlRewriter)
     }
@@ -416,13 +416,10 @@ extension DefaultVideoClientController: VideoClientController {
             if container.count > Constants.dataMessageMaxDataSizeInByte {
                 throw SendDataMessageError.invalidDataLength
             }
-            container.withUnsafeBytes { (bufferRawBufferPointer) -> Void in
-                if let bufferPointer = bufferRawBufferPointer
-                    .baseAddress {
-                    videoClient?.sendDataMessage(topic,
-                                                 data: bufferPointer.assumingMemoryBound(to: Int8.self),
-                                                 lifetimeMs: lifetimeMs)
-                }
+            if let str = String(data: container, encoding: .utf8) {
+                videoClient?.sendDataMessage(topic,
+                                             data: (str as NSString).utf8String,
+                                             lifetimeMs: lifetimeMs)
             }
         } else {
             throw SendDataMessageError.invalidData

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+## Fixed
+* Fixed data message conversion that sometimes does not handle null terminator when converting from string to c-string.
+
 ## [0.14.0] - 2021-01-21
 
 ### Added


### PR DESCRIPTION
### Issue #, if available:
#217 
### Description of changes:
Conversion sometimes doesn't occur properly.
### Testing done:

Tested on iPhone Xs 14.3. Unable to see any extra character.
1. Foreign characters are working fine
2. Emoji is working fine as well.

#### Manual test cases (add more as needed):

- [X] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [X] Leave meeting
- [X] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [X] Send audio
- [X] Receive audio
- [X] Mute self
- [X] Unmute self
- [X] See local mute indicator when muted
- [X] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
