### PR TITLE
Pass App Info to AudioClient

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
@@ -74,7 +74,7 @@ extension DefaultAudioClientController: AudioClientController {
             observer.audioSessionDidStartConnecting(reconnecting: false)
         }
         eventAnalyticsController.publishEvent(name: .meetingStartRequested)
-
+        let appInfo = DeviceUtils.getAppInfo()
         let status = audioClient.startSession(host,
                                               basePort: port,
                                               callId: meetingId,
@@ -84,7 +84,9 @@ extension DefaultAudioClientController: AudioClientController {
                                               isPresenter: defaultPresenter,
                                               sessionToken: joinToken,
                                               audioWsUrl: audioFallbackUrl,
-                                              callKitEnabled: callKitEnabled)
+                                              callKitEnabled: callKitEnabled,
+                                              appInfo: appInfo)
+
         if status == AUDIO_CLIENT_OK {
             Self.state = .started
         } else {

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientProtocol.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientProtocol.swift
@@ -20,6 +20,18 @@ import Foundation
                       isPresenter presenter: Bool,
                       sessionToken tokenString: String!,
                       audioWsUrl: String!,
+                      callKitEnabled: Bool,
+                      appInfo: AppInfo!) -> audio_client_status_t
+
+    func startSession(_ host: String!,
+                      basePort port: Int,
+                      callId: String!,
+                      profileId: String!,
+                      microphoneMute mic_mute: Bool,
+                      speakerMute spk_mute: Bool,
+                      isPresenter presenter: Bool,
+                      sessionToken tokenString: String!,
+                      audioWsUrl: String!,
                       callKitEnabled: Bool) -> audio_client_status_t
 
     func stopSession() -> Int

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/utils/DeviceUtils.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/utils/DeviceUtils.swift
@@ -31,18 +31,35 @@ import UIKit
     }
 
     static public func getDetailedInfo() -> app_detailed_info_t {
+        let info = getAppInfo()
         var appInfo = app_detailed_info_t.init()
 
-        appInfo.platform_version = UnsafePointer<Int8>((UIDevice.current.systemVersion as NSString).utf8String)
-        if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] {
-            appInfo.app_version_name = UnsafePointer<Int8>(("\(osName) \(appVersion)" as NSString).utf8String)
-            appInfo.app_version_code = UnsafePointer<Int8>(("\(appVersion)" as NSString).utf8String)
+        if (Bundle.main.infoDictionary?["CFBundleShortVersionString"]) != nil {
+            appInfo.app_version_name = UnsafePointer<Int8>((info.appVersionName as NSString).utf8String)
+            appInfo.app_version_code = UnsafePointer<Int8>((info.appVersionCode as NSString).utf8String)
         }
-        appInfo.device_model = UnsafePointer<Int8>((getModelInfo() as NSString).utf8String)
-        appInfo.platform_name = UnsafePointer<Int8>((osName as NSString).utf8String)
-        appInfo.device_make = UnsafePointer<Int8>(("apple" as NSString).utf8String)
-        appInfo.client_source = UnsafePointer<Int8>(("amazon-chime-sdk" as NSString).utf8String)
-        appInfo.chime_sdk_version = UnsafePointer<Int8>((Versioning.sdkVersion() as NSString).utf8String)
+        appInfo.device_make = UnsafePointer<Int8>((info.deviceMake as NSString).utf8String)
+        appInfo.device_model = UnsafePointer<Int8>((info.deviceModel as NSString).utf8String)
+        appInfo.platform_name = UnsafePointer<Int8>((info.platformName as NSString).utf8String)
+        appInfo.platform_version = UnsafePointer<Int8>((info.platformVersion as NSString).utf8String)
+        appInfo.client_source = UnsafePointer<Int8>((info.clientSource as NSString).utf8String)
+        appInfo.chime_sdk_version = UnsafePointer<Int8>((info.chimeSdkVersion as NSString).utf8String)
+        return appInfo
+    }
+
+    static public func getAppInfo() -> AppInfo {
+        let appInfo = AppInfo()
+
+        appInfo.platformVersion = UIDevice.current.systemVersion
+        if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] {
+            appInfo.appVersionName = "\(osName) \(appVersion)"
+            appInfo.appVersionCode = "\(appVersion)"
+        }
+        appInfo.deviceModel = getModelInfo()
+        appInfo.platformName = osName
+        appInfo.deviceMake = "apple"
+        appInfo.clientSource = "amazon-chime-sdk"
+        appInfo.chimeSdkVersion = Versioning.sdkVersion()
         return appInfo
     }
 

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientControllerTests.swift
@@ -111,7 +111,8 @@ class DefaultAudioClientControllerTests: CommonTestCase {
                                            isPresenter: any(),
                                            sessionToken: any(),
                                            audioWsUrl: any(),
-                                           callKitEnabled: any())).willReturn(AUDIO_CLIENT_OK)
+                                           callKitEnabled: any(),
+                                           appInfo: any())).willReturn(AUDIO_CLIENT_OK)
 
         XCTAssertNoThrow(try defaultAudioClientController.start(audioFallbackUrl: audioFallbackUrl,
                                                                 audioHostUrl: audioHostUrlWithPort,
@@ -130,7 +131,8 @@ class DefaultAudioClientControllerTests: CommonTestCase {
                                             isPresenter: true,
                                             sessionToken: self.joinToken,
                                             audioWsUrl: self.audioFallbackUrl,
-                                            callKitEnabled: false)).wasCalled()
+                                            callKitEnabled: false,
+                                            appInfo: any())).wasCalled()
         verify(eventAnalyticsControllerMock.publishEvent(name: .meetingStartRequested)).wasCalled()
         XCTAssertEqual(.started, DefaultAudioClientController.state)
         verify(audioLockMock.unlock()).wasCalled()
@@ -148,7 +150,8 @@ class DefaultAudioClientControllerTests: CommonTestCase {
                                            isPresenter: any(),
                                            sessionToken: any(),
                                            audioWsUrl: any(),
-                                           callKitEnabled: any())).willReturn(AUDIO_CLIENT_ERR)
+                                           callKitEnabled: any(),
+                                           appInfo: any())).willReturn(AUDIO_CLIENT_ERR)
 
         XCTAssertThrowsError(try defaultAudioClientController.start(audioFallbackUrl: audioFallbackUrl,
                                                                     audioHostUrl: audioHostUrlWithPort,
@@ -167,7 +170,8 @@ class DefaultAudioClientControllerTests: CommonTestCase {
                                             isPresenter: true,
                                             sessionToken: self.joinToken,
                                             audioWsUrl: self.audioFallbackUrl,
-                                            callKitEnabled: false)).wasCalled()
+                                            callKitEnabled: false,
+                                            appInfo: any())).wasCalled()
         XCTAssertEqual(.initialized, DefaultAudioClientController.state)
         verify(audioLockMock.unlock()).wasCalled()
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Added
+* Pass SDK metadata to Media AudioClient for metrics.
+
 ## [0.15.0] - 2021-02-04
 
 ### Added


### PR DESCRIPTION
### Issue #, if available:
Chime-34444

### Description of changes:
Pass app and sdk info to Media AudioClient

### Testing done:

#### Manual test cases (add more as needed):

- [X] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [X] Leave meeting
- [X] Rejoin meeting
- [X] See metrics
- [X] See attendee presence
- [X] Send audio
- [X] Receive audio
- [X] Mute self
- [X] Unmute self
- [X] See local mute indicator when muted
- [X] See remote mute indicator when other is muted
- [X] Enable and disable local video
- [X] Enable and disable remote video from remote side
- [X] Send local video
- [X] Pause and resume remote video
- [X] Switch local camera
- [X] Receive remote screen share

#### Integration validation (required before release)

- [X] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [X] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [X] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [X] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
