### PR TITLE
Fix concurrency issue in DefaultCameraCaptureSource

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/capture/DefaultCameraCaptureSource.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/capture/DefaultCameraCaptureSource.swift
@@ -14,6 +14,7 @@ import UIKit
     public var videoContentHint: VideoContentHint = .motion
 
     private let logger: Logger
+    private let cameraLock = NSLock()
     private let deviceType = AVCaptureDevice.DeviceType.builtInWideAngleCamera
     private let sinks = ConcurrentMutableSet()
     private let captureSourceObservers = ConcurrentMutableSet()
@@ -107,6 +108,9 @@ import UIKit
     }
 
     public func start() {
+        cameraLock.lock()
+        defer { cameraLock.unlock() }
+
         session = AVCaptureSession()
         guard let captureDevice = captureDevice else {
             return
@@ -147,6 +151,9 @@ import UIKit
     }
 
     public func stop() {
+        cameraLock.lock()
+        defer { cameraLock.unlock() }
+
         session.stopRunning()
 
         // If the torch was currently on, stopping the sessions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Unreleased
 
 ### Fixed
-* Fixed an issue where `VideoCaptureFormat` and `DefaultModality` are not exposed to ObjC
+* Fixed an issue where `VideoCaptureFormat` and `DefaultModality` are not exposed to ObjC.
+* Fixed a concurrency issue on `DefaultCameraCaptureSource` between `start()` and `stop()` invocations.
 
 ## [0.16.0] - 2021-02-24
 


### PR DESCRIPTION
### Issue #, if available:
#231 
### Description of changes:
Add lock in start and stop of `DefaultCameraCaptureSource`
### Testing done:
Wire up start camera button with 20 start/stop calls, and demo app does not crash.

#### Manual test cases (add more as needed):

- [X] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [X] Leave meeting
- [X] Rejoin meeting
- [X] See metrics
- [X] See attendee presence
- [X] Send audio
- [X] Receive audio
- [X] Mute self
- [X] Unmute self
- [X] See local mute indicator when muted
- [X] See remote mute indicator when other is muted
- [X] Enable and disable local video
- [X] Enable and disable remote video from remote side
- [X] Send local video
- [X] Pause and resume remote video
- [X] Switch local camera
- [X] Receive remote screen share

#### Integration validation (required before release)

- [X] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [X] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [X] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
