### PR TITLE
Expose VideoCaptureFormat and DefaultModality to ObjC

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/capture/VideoCaptureFormat.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/capture/VideoCaptureFormat.swift
@@ -11,7 +11,7 @@ import AVFoundation
 
 /// `VideoCaptureFormat`describes a given capture format that may be possible to apply to a `VideoCaptureSource`.
 /// Note that `VideoCaptureSource` implementations may ignore or adjust unsupported values.
-@objc public class VideoCaptureFormat: NSObject {
+@objcMembers public class VideoCaptureFormat: NSObject {
     /// Capture width in pixels.
     public let width: Int
 

--- a/AmazonChimeSDK/AmazonChimeSDK/session/URLRewriter.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/session/URLRewriter.swift
@@ -15,9 +15,9 @@ import Foundation
 public typealias URLRewriter = (_ url: String) -> String
 
 /// `URLRewriterUtils` is class that defines default Url rewrite behavior
-@objc public class URLRewriterUtils: NSObject {
+@objcMembers public class URLRewriterUtils: NSObject {
     /// The default implementation returns the original URL unchanged.
-    @objc public static let defaultUrlRewriter: URLRewriter = { url in
+    public static let defaultUrlRewriter: URLRewriter = { url in
         url
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/utils/DefaultModality.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/utils/DefaultModality.swift
@@ -19,7 +19,7 @@ import Foundation
 /// `DefaultModality(id: contentAttendeeId).base`: "abcdefg"
 /// `DefaultModality(id: contentAttendeeId).modality`: "content"
 /// `DefaultModality(id: contentAttendeeId).isOfType(type: .content)`: true
-@objc public class DefaultModality: NSObject {
+@objcMembers public class DefaultModality: NSObject {
     public let id: String
     public let base: String
     public let modality: String?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Fixed
+* Fixed an issue where `VideoCaptureFormat` and `DefaultModality` are not exposed to ObjC
+
 ## [0.16.0] - 2021-02-24
 
 ### Added


### PR DESCRIPTION
### Issue #, if available:
#240 
### Description of changes:
Use @objcMembers instead of @objc on class
### Testing done:
Creating VideoCaptureFormat, DefaultModality and URLRewriterUtils objects in ViewControllerObjC.m and access public properties
#### Manual test cases (add more as needed):

- [ ] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [ ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
