### PR TITLE
Enable send-side bandwidth estimation

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/DefaultContentShareVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/DefaultContentShareVideoClientController.swift
@@ -21,6 +21,7 @@ import Foundation
     private let videoConfig: VideoConfiguration = {
         let config = VideoConfiguration()
         config.isUsing16by9AspectRatio = true
+        config.isUsingSendSideBwe = true
         config.isUsingPixelBufferRenderer = true
         config.isContentShare = true
         return config

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
@@ -115,6 +115,7 @@ class DefaultVideoClientController: NSObject {
 
         let videoConfig: VideoConfiguration = VideoConfiguration()
         videoConfig.isUsing16by9AspectRatio = true
+        videoConfig.isUsingSendSideBwe = true
         videoConfig.isUsingPixelBufferRenderer = true
         videoConfig.isUsingOptimizedTwoSimulcastStreamTable = true
         videoConfig.isExcludeSelfContentInIndex = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Fixed a concurrency issue on `DefaultCameraCaptureSource` between `start()` and `stop()` invocations.
 * Fixed an issue where `MeetingHistoryEvent` did not expose its properties.
 
+### Changed
+* Enabled send-side bandwidth estimation in video client, which improves video quality in poor network conditions.
+
 ## [0.16.0] - 2021-02-24
 
 ### Added


### PR DESCRIPTION
### Issue #, if available:
ChimeVideo-984

### Description of changes:
Enabled send-side bandwidth estimation in video client, which improves video quality in poor network conditions.

### Testing done:
- Send-side bandwidth estimation has been enabled in Amazon Chime mobile clients since Jun 23, 2020. We did not see any regression after enabling it. Test results showed that bandwidth estimation improved after we enabled send-side bandwidth estimation.
- Kicked an ad-hoc build and ran sanity tests.

#### Manual test cases (add more as needed):

- [x] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [x] Rejoin meeting
- [ ] See metrics
- [x] See attendee presence
- [x] Send audio
- [x] Receive audio
- [x] Mute self
- [x] Unmute self
- [x] See local mute indicator when muted
- [x] See remote mute indicator when other is muted
- [x] Enable and disable local video
- [x] Enable and disable remote video from remote side
- [x] Send local video
- [x] Pause and resume remote video
- [x] Switch local camera
- [x] Receive remote screen share

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
