### PR TITLE
Expose MeetingHistoryEvent properties

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/analytics/MeetingHistoryEvent.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/analytics/MeetingHistoryEvent.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 @objcMembers public class MeetingHistoryEvent: NSObject {
-    private let meetingHistoryEventName: MeetingHistoryEventName
-    private let timestampMs: Int64
+    public let meetingHistoryEventName: MeetingHistoryEventName
+    public let timestampMs: Int64
 
     public init(meetingHistoryEventName: MeetingHistoryEventName, timestampMs: Int64) {
         self.meetingHistoryEventName = meetingHistoryEventName

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 * Fixed an issue where `VideoCaptureFormat` and `DefaultModality` are not exposed to ObjC.
 * Fixed a concurrency issue on `DefaultCameraCaptureSource` between `start()` and `stop()` invocations.
+* Fixed an issue where `MeetingHistoryEvent` did not expose its properties.
 
 ## [0.16.0] - 2021-02-24
 


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
Expose meeting history event properties
### Testing done:

#### Manual test cases (add more as needed):

- [X] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [X] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
