### PR TITLE
Fix keyboard cannot be dismissed issue in debug settings view

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DebugSettingsViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DebugSettingsViewController.swift
@@ -11,18 +11,25 @@ import UIKit
 class DebugSettingsViewController: UIViewController, UITextFieldDelegate {
     @IBOutlet var serverEndpointUrlTextField: UITextField!
     @IBOutlet var saveButton: UIButton!
-    
+
     var model: DebugSettingsModel?
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        setupHideKeyboardOnTap()
         serverEndpointUrlTextField.delegate = self
         serverEndpointUrlTextField.text = model?.endpointUrl
     }
-    
+
     @IBAction func saveButtonClicked(_: UIButton) {
         let endpointUrl = serverEndpointUrlTextField.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         model?.endpointUrl = endpointUrl
         self.dismiss(animated: true, completion: nil)
+    }
+
+	func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
     }
 }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/JoiningViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/JoiningViewController.swift
@@ -50,7 +50,7 @@ class JoiningViewController: UIViewController, UITextFieldDelegate {
     @IBAction func joinAsOutgoingCallButton(_: UIButton) {
         joinMeeting(callKitOption: .outgoing)
     }
-    
+
     @IBAction func debugSettingsButtonClicked (_: UIButton) {
         guard let debugSettingsVC = mainStoryboard.instantiateViewController(withIdentifier: "debugSettings")
             as? DebugSettingsViewController else {


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
Fix the issue that keyboard cannot be dismissed after typing of endpoint url in debug settings view

### Testing done:

1. Join a meeting without changing meeting endpoint url
2. Join a meeting with an overridden meeting endpoint url
3. Join a meeting with an overridden url which contains leading or trailing spaces
4. Join a meeting with an empty overridden url
5. Join a meeting with an url without suffix "/"


#### Manual test cases (add more as needed):

- [x] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
