### PR TITLE
Fixed InAppScreenShare restart issue

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/InAppScreenCaptureModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/InAppScreenCaptureModel.swift
@@ -20,6 +20,7 @@ class InAppScreenCaptureModel {
                 return
             }
             if newValue {
+                inAppScreenCaptureSource?.addCaptureSourceObserver(observer: self)
                 inAppScreenCaptureSource?.start()
                 isSharingHandler?(true)
             } else {
@@ -32,7 +33,6 @@ class InAppScreenCaptureModel {
     lazy var inAppScreenCaptureSource: VideoCaptureSource? = {
         if #available(iOS 11.0, *) {
             let source = InAppScreenCaptureSource(logger: logger)
-            source.addCaptureSourceObserver(observer: self)
             return source
         }
         return nil
@@ -61,5 +61,6 @@ extension InAppScreenCaptureModel: CaptureSourceObserver {
         logger.error(msg: "InAppScreenCaptureSource did fail: \(error.description)")
         isSharing = false
         contentShareController.stopContentShare()
+        inAppScreenCaptureSource?.removeCaptureSourceObserver(observer: self)
     }
 }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/InAppScreenCaptureModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/InAppScreenCaptureModel.swift
@@ -32,8 +32,7 @@ class InAppScreenCaptureModel {
 
     lazy var inAppScreenCaptureSource: VideoCaptureSource? = {
         if #available(iOS 11.0, *) {
-            let source = InAppScreenCaptureSource(logger: logger)
-            return source
+            return InAppScreenCaptureSource(logger: logger)
         }
         return nil
     }()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Fixed `CreateMeetingResponse` and `MeetingSessionConfiguration` to have nullable `externalMeetingId` since this is not required.
 * [Demo] Fixed demo application to handle null `externalMeetingId`.
 * [Demo] Fixed demo application where `InAppScreenShare` doesn't restart due to observer not added.
+
 ### Changed
 * Enabled send-side bandwidth estimation in video client, which improves video quality in poor network conditions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Fixed an issue where `MeetingHistoryEvent` did not expose its properties.
 * Fixed `CreateMeetingResponse` and `MeetingSessionConfiguration` to have nullable `externalMeetingId` since this is not required.
 * [Demo] Fixed demo application to handle null `externalMeetingId`.
-
+* [Demo] Fixed demo application where `InAppScreenShare` doesn't restart due to observer not added.
 ### Changed
 * Enabled send-side bandwidth estimation in video client, which improves video quality in poor network conditions.
 


### PR DESCRIPTION
### Issue #, if available:
WTBugs-22703
### Description of changes:
In memory leak fix, we removed the observer, but we didn't add it when restart.
### Testing done:
Did in app screen share multiple times.

#### Manual test cases (add more as needed):

- [X] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [X] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
