### PR TITLE
Disable simulcast for P2P calls

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/DefaultContentShareVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/DefaultContentShareVideoClientController.swift
@@ -22,6 +22,7 @@ import Foundation
         let config = VideoConfiguration()
         config.isUsing16by9AspectRatio = true
         config.isUsingSendSideBwe = true
+        config.isDisablingSimulcastP2P = true
         config.isUsingPixelBufferRenderer = true
         config.isContentShare = true
         return config

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
@@ -116,6 +116,7 @@ class DefaultVideoClientController: NSObject {
         let videoConfig: VideoConfiguration = VideoConfiguration()
         videoConfig.isUsing16by9AspectRatio = true
         videoConfig.isUsingSendSideBwe = true
+        videoConfig.isDisablingSimulcastP2P = true
         videoConfig.isUsingPixelBufferRenderer = true
         videoConfig.isUsingOptimizedTwoSimulcastStreamTable = true
         videoConfig.isExcludeSelfContentInIndex = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+### Changed
+* Disabled simulcast for P2P calls, which helps improving video quality of two-party meetings.
+
 ## [0.16.1] - 2021-03-04
 
 ### Added


### PR DESCRIPTION
### Issue #, if available:
ChimeVideo-1080

### Description of changes:
Disabled simulcast for P2P calls, which helps improving video quality of two-party meetings.

### Testing done:
Built an ad-hoc build and verified that simulcast was disabled for P2P calls, and we were sending the single video stream with higher resolution.

#### Manual test cases (add more as needed):

- [x] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [x] Rejoin meeting
- [ ] See metrics
- [x] See attendee presence
- [x] Send audio
- [x] Receive audio
- [x] Mute self
- [x] Unmute self
- [x] See local mute indicator when muted
- [x] See remote mute indicator when other is muted
- [x] Enable and disable local video
- [x] Enable and disable remote video from remote side
- [x] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [x] Receive remote screen share

### Screenshots, if available:
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
