### PR TITLE
Add support for AVAudioSession videoChat mode, default to it to support AirPlay in demo app

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModule.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModule.swift
@@ -193,8 +193,8 @@ class MeetingModule {
                                              options: AVAudioSession.CategoryOptions.allowBluetooth)
                 try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
             }
-            if audioSession.mode != .voiceChat {
-                try audioSession.setMode(.voiceChat)
+            if audioSession.mode != .videoChat {
+                try audioSession.setMode(.videoChat)
             }
         } catch {
             logger.error(msg: "Error configuring AVAudioSession: \(error.localizedDescription)")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Changed
 * Disabled simulcast for P2P calls, which helps improving video quality of two-party meetings.
+* [Demo] Added support for AVAudioSession videoChat mode, which enables AirPlay mirroring in demo app
 
 ## [0.16.1] - 2021-03-04
 


### PR DESCRIPTION

### Issue #, if available:

### Description of changes:
Added support for AVAudioSession videoChat mode in Media. 
This change defaults AVAudioSession.mode to videoChat to allow AirPlay screen mirroring in the demo app. 

### Testing done:
1. With videoChat mode in demo app, AirPlay enabled device(s) are present in the device list while enabling screen mirror on iOS device.
2. With videoChat mode in demo app, audio will be played via AirPlay enabled device when mirroring screen on iOS device.

Regression tests performed to make sure this change does not break any existing functionalities.
  Tested on iOS device with incoming/outgoing call
  Tested when app is in background/foreground/lock screen
  Tested with and without Callkit enabled

#### Manual test cases (add more as needed):

- [x] Join meeting without CallKit
- [x] Join meeting with CallKit as Incoming
- [x] Join meeting with CallKit as Outgoing
- [ ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share
- [x] Enable screen mirror during a meeting

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
