### PR TITLE
Revert "Add support for AVAudioSession videoChat mode, default to it …

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModule.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModule.swift
@@ -193,8 +193,8 @@ class MeetingModule {
                                              options: AVAudioSession.CategoryOptions.allowBluetooth)
                 try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
             }
-            if audioSession.mode != .videoChat {
-                try audioSession.setMode(.videoChat)
+            if audioSession.mode != .voiceChat {
+                try audioSession.setMode(.voiceChat)
             }
         } catch {
             logger.error(msg: "Error configuring AVAudioSession: \(error.localizedDescription)")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ### Changed
 * Disabled simulcast for P2P calls, which helps improving video quality of two-party meetings.
-* [Demo] Added support for AVAudioSession videoChat mode, which enables AirPlay mirroring in demo app
 
 ## [0.16.1] - 2021-03-04
 


### PR DESCRIPTION
…to enable AirPlay mirroring in demo app (#270)"

This reverts commit 7e599b8f3ff2f1c36e2f3b5c33084607f8be268d.



### Issue #, if available:

### Description of changes:
This reverts the setting to voicechat so it has no discrepancy as previous app.

### Testing done:

#### Manual test cases (add more as needed):

- [ ] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [ ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
