### PR TITLE
Fix DefaultCameraCaptureSource device orientation updates.

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/capture/DefaultCameraCaptureSource.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/capture/DefaultCameraCaptureSource.swift
@@ -25,7 +25,7 @@ import UIKit
                                                                  maxFrameRate: Constants.maxSupportedVideoFrameRate)
 
     private var session = AVCaptureSession()
-    private var orientation = UIDeviceOrientation.portrait
+    private var orientation = UIInterfaceOrientation.portrait
     private var captureDevice: AVCaptureDevice?
     private var eventAnalyticsController: EventAnalyticsController?
 
@@ -189,20 +189,22 @@ import UIKit
         guard let connection = output.connection(with: AVMediaType.video) else {
             return
         }
-        orientation = UIDevice.current.orientation
 
-        switch orientation {
-        case .portrait, .unknown:
-            connection.videoOrientation = .portrait
-        case .landscapeLeft:
-            connection.videoOrientation = .landscapeRight
-        case .portraitUpsideDown:
-            connection.videoOrientation = .portraitUpsideDown
-        case .landscapeRight:
-            connection.videoOrientation = .landscapeLeft
-        default:
-            // Do not update videoOrientation when the device is laying flat
-            return
+        DispatchQueue.main.async {
+            self.orientation = UIApplication.shared.statusBarOrientation
+
+            switch self.orientation {
+            case .portrait, .unknown:
+                connection.videoOrientation = .portrait
+            case .portraitUpsideDown:
+                connection.videoOrientation = .portraitUpsideDown
+            case .landscapeLeft:
+                connection.videoOrientation = .landscapeLeft
+            case .landscapeRight:
+                connection.videoOrientation = .landscapeRight
+            @unknown default:
+                break
+            }
         }
     }
 


### PR DESCRIPTION
### Issue #, if available:
#88 

### Description of changes:
- Using `UIInterfaceOrientation` instead of `UIDeviceOrientation` when handling videoOrientation updates. `UIInterfaceOrientation` will incorrectly return `.unknown` state first time when the app is launched in the landscape mode (see [issue description](https://github.com/aws/amazon-chime-sdk-ios/issues/88#issuecomment-829582271)).

### Testing done:

#### Manual test cases (add more as needed):

- [ ] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [ ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
