### PR TITLE
Fix active speaker observer example in README (caused memory leak)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [unreleased]
+
+### Fixed
+* [Documentation] Fixed active speaker observer example in README which if used caused a memory leak.
+
 ## 2021-05-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -275,8 +275,10 @@ You can use the `activeSpeakerDidDetect` event to enlarge or emphasize the most 
 
 ```swift
 class MyActiveSpeakerObserver: ActiveSpeakerObserver {
+    let activeSpeakerObserverId = UUID().uuidString
+    
     var observerId: String {
-        return UUID().uuidString
+        return activeSpeakerObserverId
     }
     
     func activeSpeakerDidDetect(attendeeInfo: [AttendeeInfo]) {


### PR DESCRIPTION


### Issue #, if available:
#305 
### Description of changes:
Fixes active speaker observer README example that would cause memory leak if used.
### Testing done:
Verified observer not removed when example used. Demo app does not use this example, so does not have memory leak.
#### Manual test cases (add more as needed):

- [x ] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [x ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [x ] See attendee presence
- [x ] Send audio
- [ x] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
