### PR TITLE
Fix video flicker due to active speaker changes in demo

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -622,10 +622,7 @@ extension MeetingModel: ActiveSpeakerObserver {
     }
 
     func activeSpeakerDidDetect(attendeeInfo: [AttendeeInfo]) {
-        videoModel.updateRemoteVideoStatesBasedOnActiveSpeakers(activeSpeakers: attendeeInfo)
-        if activeMode == .video {
-            videoModel.videoUpdatedHandler?()
-        }
+        videoModel.updateRemoteVideoStatesBasedOnActiveSpeakers(activeSpeakers: attendeeInfo, inVideoMode: activeMode == .video)
 
         rosterModel.updateActiveSpeakers(attendeeInfo.map { $0.attendeeId })
         if activeMode == .roster {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
@@ -191,8 +191,9 @@ class VideoModel: NSObject {
         return remoteVideoStatesInCurrentPage.contains(where: { $0.0 == tileId })
     }
 
-    func updateRemoteVideoStatesBasedOnActiveSpeakers(activeSpeakers: [AttendeeInfo]) {
+    func updateRemoteVideoStatesBasedOnActiveSpeakers(activeSpeakers: [AttendeeInfo], inVideoMode: Bool = false) {
         let activeSpeakerIds = Set(activeSpeakers.map { $0.attendeeId })
+        var videoTilesOrderUpdated = false
 
         // Cast to NSArray to make sure the sorting implementation is stable
         remoteVideoTileStates = (remoteVideoTileStates as NSArray).sortedArray(options: .stable,
@@ -205,12 +206,17 @@ class VideoModel: NSObject {
             } else if lhsIsActiveSpeaker && !rhsIsActiveSpeaker {
                 return ComparisonResult.orderedAscending
             } else {
+                videoTilesOrderUpdated = true
                 return ComparisonResult.orderedDescending
             }
         }) as? [(Int, VideoTileState)] ?? []
 
         for remoteVideoTileState in remoteVideoStatesNotInCurrentPage {
             audioVideoFacade.pauseRemoteVideoTile(tileId: remoteVideoTileState.0)
+        }
+
+        if videoTilesOrderUpdated && inVideoMode {
+            videoUpdatedHandler?()
         }
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 * [Documentation] Fixed active speaker observer example in README which if used caused a memory leak.
+* [Demo] Fixed video flickering when active speaker updates.
 
 ## 2021-05-10
 


### PR DESCRIPTION
### Description of changes:
Fixes video flicker in demo when active speaker changes
### Testing done:
smoke tested
#### Manual test cases (add more as needed):

- [ x] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [x ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ x] Send audio
- [x ] Receive audio
- [ x] Mute self
- [x ] Unmute self
- [ x] See local mute indicator when muted
- [ x] See remote mute indicator when other is muted
- [x ] Enable and disable local video
- [ x] Enable and disable remote video from remote side
- [ x] Send local video
- [x ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
