### PR TITLE
Remove limit number of remote video tiles

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -537,20 +537,16 @@ extension MeetingModel: VideoTileObserver {
                     videoModel.localVideoUpdatedHandler?()
                 }
             } else {
-                videoModel.addRemoteVideoTileState(tileState, completion: { success in
-                    if success {
-                        if self.activeMode == .video {
-                            // If the video is not currently being displayed, pause it
-                            if !self.videoModel.isRemoteVideoDisplaying(tileId: tileState.tileId) {
-                                self.currentMeetingSession.audioVideo.pauseRemoteVideoTile(tileId: tileState.tileId)
-                            }
-                            self.videoModel.videoUpdatedHandler?()
-                        } else {
-                            // Currently not in the video view, no need to render the video tile
+                videoModel.addRemoteVideoTileState(tileState, completion: {
+                    if self.activeMode == .video {
+                        // If the video is not currently being displayed, pause it
+                        if !self.videoModel.isRemoteVideoDisplaying(tileId: tileState.tileId) {
                             self.currentMeetingSession.audioVideo.pauseRemoteVideoTile(tileId: tileState.tileId)
                         }
+                        self.videoModel.videoUpdatedHandler?()
                     } else {
-                        self.logger.info(msg: "Cannot add more video tile tileId: \(tileState.tileId)")
+                        // Currently not in the video view, no need to render the video tile
+                        self.currentMeetingSession.audioVideo.pauseRemoteVideoTile(tileId: tileState.tileId)
                     }
                 })
             }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
@@ -10,7 +10,6 @@ import AmazonChimeSDK
 import UIKit
 
 class VideoModel: NSObject {
-    private let maxRemoteVideoTileCount = 16
     private let remoteVideoTileCountPerPage = 6
 
     private var currentRemoteVideoPageIndex = 0
@@ -146,10 +145,6 @@ class VideoModel: NSObject {
         return remoteVideoStatesInCurrentPage.count
     }
 
-    private var isMaximumRemoteVideoReached: Bool {
-        return currentRemoteVideoCount >= maxRemoteVideoTileCount
-    }
-
     private func startLocalVideo() {
         MeetingModule.shared().requestVideoPermission { success in
             if success {
@@ -224,13 +219,9 @@ class VideoModel: NSObject {
         selfVideoTileState = videoTileState
     }
 
-    func addRemoteVideoTileState(_ videoTileState: VideoTileState, completion: @escaping (Bool) -> Void) {
-        if isMaximumRemoteVideoReached {
-            completion(false)
-            return
-        }
+    func addRemoteVideoTileState(_ videoTileState: VideoTileState, completion: @escaping () -> Void) {
         remoteVideoTileStates.append((videoTileState.tileId, videoTileState))
-        completion(true)
+        completion()
     }
 
     func removeRemoteVideoTileState(_ videoTileState: VideoTileState, completion: @escaping (Bool) -> Void) {


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:

### Testing done:
Tested by QA for 25 video tiles. Verify with the team as well. 

#### Manual test cases (add more as needed):

- [x] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [x] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [x] Mute self
- [x] Unmute self
- [ ] See local mute indicator when muted
- [x] See remote mute indicator when other is muted
- [x] Enable and disable local video
- [x] Enable and disable remote video from remote side
- [ ] Send local video
- [x] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
