### PR TITLE
Clean up unused internal code paths

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/device/MediaDevice.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/device/MediaDevice.swift
@@ -28,12 +28,6 @@ import Foundation
         return MediaDevice(label: port.portName, port: port)
     }
 
-    /// Create `MediaDevice` for video from  `VideoDevice`.
-    /// - Parameter device: Video device that contains information about device
-    static func fromVideoDevice(device: VideoDevice?) -> MediaDevice {
-        return MediaDevice(label: device?.name ?? "unknown", videoDevice: device)
-    }
-
     /// List available video capture devices from the hardware
     public static func listVideoDevices() -> [MediaDevice] {
         let discoverySession = AVCaptureDevice.DiscoverySession(deviceTypes: [.builtInWideAngleCamera],
@@ -89,19 +83,10 @@ import Foundation
         self.port = nil
     }
 
-    public init(label: String, port: AVAudioSessionPortDescription? = nil, videoDevice: VideoDevice? = nil) {
+    public init(label: String, port: AVAudioSessionPortDescription? = nil) {
         self.label = label
         self.port = port
-        if let videoDevice = videoDevice {
-            let nameLowercased = videoDevice.name.lowercased()
-            if nameLowercased.contains("front") {
-                type = .videoFrontCamera
-            } else if nameLowercased.contains("back") {
-                type = .videoBackCamera
-            } else {
-                type = .other
-            }
-        } else if let port = port {
+        if let port = port {
             switch port.portType {
             case .bluetoothLE, .bluetoothHFP, .bluetoothA2DP:
                 type = .audioBluetooth

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
@@ -57,10 +57,6 @@ class DefaultVideoClientController: NSObject {
         }
     }
 
-    func isDeviceFrontFacing(videoDevice: VideoDevice) -> Bool {
-        return MediaDevice.fromVideoDevice(device: videoDevice).type == .videoFrontCamera
-    }
-
     private func stopVideoClient() {
         logger.info(msg: "Stopping VideoClient")
         videoClient?.stop()
@@ -75,24 +71,6 @@ class DefaultVideoClientController: NSObject {
         videoClient?.delegate = nil
         videoClient = nil
         videoClientState = .uninitialized
-    }
-
-    func setFrontCameraAsCurrentDevice() {
-        guard videoClientState != .uninitialized else {
-            logger.error(msg: "Cannot set front camera as current device because videoClientState=\(videoClientState)")
-            return
-        }
-
-        logger.info(msg: "Setting front camera as current device")
-
-        let currentDevice = VideoClient.currentDevice()
-        if currentDevice == nil || !isDeviceFrontFacing(videoDevice: currentDevice!) {
-            if let devices = (VideoClient.devices() as? [VideoDevice]) {
-                if let frontDevice = devices.first(where: isDeviceFrontFacing) {
-                    videoClient?.setCurrentDevice(frontDevice)
-                }
-            }
-        }
     }
 
     func initialize() {

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientProtocol.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientProtocol.swift
@@ -15,12 +15,6 @@ import Foundation
 
     static func globalInitialize()
 
-    static func setMediaClientConfig(_ configStr: String!)
-
-    static func devices() -> [Any]!
-
-    static func currentDevice() -> VideoDevice!
-
     func start(_ callId: String!,
                token: String!,
                sending: Bool,
@@ -35,15 +29,9 @@ import Foundation
 
     func setExternalVideoSource(_ source: VideoSourceInternal!)
 
-    func stateString() -> String!
-
     func getServiceType() -> video_client_service_type_t
 
     func setRemotePause(_ video_id: UInt32, pause: Bool)
-
-    func activeTracks() -> [Any]!
-
-    func setCurrentDevice(_ captureDevice: VideoDevice!)
 
     func videoLogCallBack(_ logLevel: video_client_loglevel_t, msg: String!)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Removed
+* **Breaking (internal APIs)** Removed unused and incorrect `isDeviceFrontFacing` and `setFrontCameraAsCurrentDevice` from internal `VideoClientController`.  Removed internal `VideoDevice` constructors for `MediaDevice`.
+
 ## [0.16.3] - 2021-06-24
 
 ### Added


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
See title.  These were all unused, and would have been silly to have been used externally.

### Testing done:
Smoke tested against browser demo.

#### Manual test cases (add more as needed):

- [x] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [x] Rejoin meeting
- [x] See metrics
- [x] See attendee presence
- [x] Send audio
- [x] Receive audio
- [x] Mute self
- [x] Unmute self
- [x] See local mute indicator when muted
- [x] See remote mute indicator when other is muted
- [x] Enable and disable local video
- [x] Enable and disable remote video from remote side
- [x] Send local video
- [x] Pause and resume remote video
- [x] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
