### PR TITLE
Fix location of getActiveAudioDevice

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
@@ -161,6 +161,10 @@ import Foundation
         return deviceController.getActiveCamera()
     }
 
+    public func getActiveAudioDevice() -> MediaDevice? {
+        return deviceController.getActiveAudioDevice()
+    }
+
     // MARK: VideoTileController
 
     public func bindVideoView(videoView: VideoRenderView, tileId: Int) {
@@ -198,10 +202,6 @@ import Foundation
     }
 
     public func hasBandwidthPriorityCallback(hasBandwidthPriority: Bool) {}
-
-    public func getActiveAudioDevice() -> MediaDevice? {
-        return deviceController.getActiveAudioDevice()
-    }
 
     // MARK: ContentShareController
 


### PR DESCRIPTION
### Issue #, if available:
https://github.com/aws/amazon-chime-sdk-ios/issues/329
### Description of changes:
Just change the location of the code to be in under 

### Testing done:
Checked that doc created is in the right position.


### Screenshots, if available:
![Screen Shot 2021-07-28 at 4 57 04 PM](https://user-images.githubusercontent.com/57926812/127411071-3b2d67a8-a422-4ec1-97df-fae741654332.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
