### PR TITLE
Support sending bytes data message

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
+++ b/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 		C4F8B6552580172200D9AE54 /* CMCampleBufferExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F8B6542580172200D9AE54 /* CMCampleBufferExtensions.swift */; };
 		C60D5593246509BA00C2A278 /* Converters.swift in Sources */ = {isa = PBXBuildFile; fileRef = C60D5592246509B900C2A278 /* Converters.swift */; };
 		C60D5596246514B000C2A278 /* ConvertersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C60D5595246514B000C2A278 /* ConvertersTests.swift */; };
+		C61D43222703BD9D00150F03 /* DefaultVideoClientControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C61D43212703BD9D00150F03 /* DefaultVideoClientControllerTests.swift */; };
 		C6C2F106250BF522001678B8 /* DefaultDeviceControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6C2F105250BF522001678B8 /* DefaultDeviceControllerTests.swift */; };
 		C6DA0B2024F5A9EC00028F2B /* DefaultAudioClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DA0B1F24F5A9EC00028F2B /* DefaultAudioClientTests.swift */; };
 		C6DA0B2224F6C63F00028F2B /* DefaultVideoTileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DA0B2124F6C63F00028F2B /* DefaultVideoTileTests.swift */; };
@@ -469,6 +470,7 @@
 		C4F8B6542580172200D9AE54 /* CMCampleBufferExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMCampleBufferExtensions.swift; sourceTree = "<group>"; };
 		C60D5592246509B900C2A278 /* Converters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Converters.swift; sourceTree = "<group>"; };
 		C60D5595246514B000C2A278 /* ConvertersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConvertersTests.swift; sourceTree = "<group>"; };
+		C61D43212703BD9D00150F03 /* DefaultVideoClientControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultVideoClientControllerTests.swift; sourceTree = "<group>"; };
 		C6C2F105250BF522001678B8 /* DefaultDeviceControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultDeviceControllerTests.swift; sourceTree = "<group>"; };
 		C6DA0B1F24F5A9EC00028F2B /* DefaultAudioClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAudioClientTests.swift; sourceTree = "<group>"; };
 		C6DA0B2124F6C63F00028F2B /* DefaultVideoTileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultVideoTileTests.swift; sourceTree = "<group>"; };
@@ -1027,6 +1029,7 @@
 			isa = PBXGroup;
 			children = (
 				5A6F818D24637BA30031AE97 /* VideoClientStateTests.swift */,
+				C61D43212703BD9D00150F03 /* DefaultVideoClientControllerTests.swift */,
 			);
 			path = video;
 			sourceTree = "<group>";
@@ -1542,6 +1545,7 @@
 				0064167F262A26E600626EB8 /* EventSQLiteDaoTests.swift in Sources */,
 				00E198FB259D164C00AD4DAA /* DefaultAudioClientObserverTests.swift in Sources */,
 				5A6F818C24637AB80031AE97 /* AudioClientStateTests.swift in Sources */,
+				C61D43222703BD9D00150F03 /* DefaultVideoClientControllerTests.swift in Sources */,
 				5A2210E524BE577E0038725B /* DefaultMeetingSessionTests.swift in Sources */,
 				00E198E1259BC0CF00AD4DAA /* EventNameTests.swift in Sources */,
 				00E198EF259BCA5A00AD4DAA /* EventAttributeNameTests.swift in Sources */,

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientProtocol.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientProtocol.swift
@@ -19,6 +19,13 @@ import Foundation
                token: String!,
                sending: Bool,
                config: VideoConfiguration!,
+               appInfo: app_detailed_info_t,
+               signalingUrl: String!)
+
+    func start(_ callId: String!,
+               token: String!,
+               sending: Bool,
+               config: VideoConfiguration!,
                appInfo: app_detailed_info_t)
 
     func stop()

--- a/AmazonChimeSDK/AmazonChimeSDK/realtime/RealtimeControllerFacade.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/realtime/RealtimeControllerFacade.swift
@@ -51,7 +51,7 @@ import Foundation
     /// Send arbitrary data to given topic with given lifetime ms (5 mins max)
     ///
     /// - Parameter topic: Topic to send
-    /// - Parameter data: Data to send, data can be either a String or JSON serializable object
+    /// - Parameter data: Data to send, data can be a String, a ByteArray, or a JSON serializable object
     /// - Parameter lifetimeMs: Message lifetime in milisecond, 5 mins max, default 0
     /// - Throws: SendDataMessageError
     func realtimeSendDataMessage(topic: String, data: Any, lifetimeMs: Int32) throws

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/video/DefaultVideoClientControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/video/DefaultVideoClientControllerTests.swift
@@ -1,0 +1,92 @@
+//
+//  DefaultVideoClientControllerTests.swift
+//  AmazonChimeSDK
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import AmazonChimeSDK
+import AmazonChimeSDKMedia
+import Mockingbird
+import XCTest
+
+class DefaultVideoClientControllerTests: CommonTestCase {
+    let topic = "topic"
+    let testMessage = "test"
+
+    var videoClientMock: VideoClientProtocolMock!
+    var clientMetricsCollectorMock: ClientMetricsCollectorMock!
+    var eventAnalyticsControllerMock: EventAnalyticsControllerMock!
+
+    var defaultVideoClientController: DefaultVideoClientController!
+
+    override func setUp() {
+        super.setUp()
+
+        videoClientMock = mock(VideoClientProtocol.self)
+        clientMetricsCollectorMock = mock(ClientMetricsCollector.self)
+        eventAnalyticsControllerMock = mock(EventAnalyticsController.self)
+
+        defaultVideoClientController = DefaultVideoClientController(videoClient: videoClientMock,
+                                                                    clientMetricsCollector: clientMetricsCollectorMock,
+                                                                    configuration: meetingSessionConfigurationMock,
+                                                                    logger: loggerMock,
+                                                                    eventAnalyticsController: eventAnalyticsControllerMock)
+    }
+
+    func testSendDataMessage_videoClientNotStarted() {
+        XCTAssertNoThrow(try defaultVideoClientController.sendDataMessage(topic: topic, data: testMessage))
+
+        verify(loggerMock.error(msg: "Cannot send data message because videoClientState=uninitialized")).wasCalled()
+        verify(videoClientMock.sendDataMessage(any(), data: any(), lifetimeMs: any())).wasNeverCalled()
+    }
+
+    func testSendDataMessage_negativeLifetimeMs() {
+        defaultVideoClientController.start()
+        XCTAssertThrowsError(try defaultVideoClientController.sendDataMessage(topic: topic, data: testMessage, lifetimeMs: -1)) { error in
+            XCTAssertEqual(error as? SendDataMessageError, SendDataMessageError.negativeLifetimeParameter)
+        }
+
+        verify(videoClientMock.sendDataMessage(any(), data: any(), lifetimeMs: any())).wasNeverCalled()
+    }
+
+    func testSendDataMessage_invalidTopic() {
+        defaultVideoClientController.start()
+        XCTAssertThrowsError(try defaultVideoClientController.sendDataMessage(topic: "$invalid$", data: testMessage)) { error in
+            XCTAssertEqual(error as? SendDataMessageError, SendDataMessageError.invalidTopic)
+        }
+
+        verify(videoClientMock.sendDataMessage(any(), data: any(), lifetimeMs: any())).wasNeverCalled()
+    }
+
+    func testSendDataMessage_sendString() {
+        defaultVideoClientController.start()
+        XCTAssertNoThrow(try defaultVideoClientController.sendDataMessage(topic: topic, data: testMessage))
+
+        verify(videoClientMock.sendDataMessage(self.topic, data: any(), lifetimeMs: 0)).wasCalled()
+    }
+
+    func testSendDataMessage_sendByteArray() {
+        defaultVideoClientController.start()
+        XCTAssertNoThrow(try defaultVideoClientController.sendDataMessage(topic: topic, data: [116, 101, 115, 116]))
+
+        verify(videoClientMock.sendDataMessage(self.topic, data: any(), lifetimeMs: 0)).wasCalled()
+    }
+
+    func testSendDataMessage_sendJson() {
+        defaultVideoClientController.start()
+        XCTAssertNoThrow(try defaultVideoClientController.sendDataMessage(topic: topic, data: ["key": "value"]))
+
+        verify(videoClientMock.sendDataMessage(self.topic, data: any(), lifetimeMs: 0)).wasCalled()
+    }
+
+    func testSendDataMessage_sendInvalidData() {
+        defaultVideoClientController.start()
+        XCTAssertThrowsError(try defaultVideoClientController.sendDataMessage(topic: topic, data: 0)) { error in
+            XCTAssertEqual(error as? SendDataMessageError, SendDataMessageError.invalidData)
+        }
+
+        verify(videoClientMock.sendDataMessage(self.topic, data: any(), lifetimeMs: 0)).wasNeverCalled()
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unrelrease
+
+### Fixed
+* Fixed an issue where sending a ByteArray through data message fails
+
 ## [0.16.5] - 2021-09-30
 
 ## Changed
@@ -6,7 +11,6 @@
 ### Fixed
 * Fixed an issue where audio session is stopped when switch between bluetooth device and speaker.
 * Fixed an issue on iOS 15 where `DefaultDeviceController` returns a duplicate entry for bluetooth audio device in `listAudioDevices()`.
-
 
 ## [0.16.4] - 2021-07-21
 ### Removed


### PR DESCRIPTION
### Issue #, if available:
WorkTalkBD-1543

### Description of changes:
Support sending bytes data message

### Testing done:
* Added unit tests (due to the fact that the `data` argument in VideoClient.sendDataMessage() is a c string pointer, we are not able to directly verify the arguments in the test cases)
* E2E tested by hijacking demo app to send `[116, 101, 115, 116]` byte array, verified in JS SDK demo app the corresponding string `test` was received

#### Manual test cases (add more as needed):

- [x] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [x] See attendee presence
- [x] Send audio
- [x] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [x] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [x] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
