### PR TITLE
add live transcription control options for demo app

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo.xcodeproj/project.pbxproj
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		5ACB3E74249AEE7300FC6E1B /* AmazonChimeSDKMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5ACB3E6F249AEE6800FC6E1B /* AmazonChimeSDKMedia.framework */; };
 		5ACB3E75249AEE7300FC6E1B /* AmazonChimeSDKMedia.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5ACB3E6F249AEE6800FC6E1B /* AmazonChimeSDKMedia.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5AE38AE02428747100B234EC /* AmazonChimeSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5AE38AD7242873FD00B234EC /* AmazonChimeSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		ADE3CFCA27050CD800DAC586 /* LiveTranscriptionOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE3CFC927050CD800DAC586 /* LiveTranscriptionOptionsViewController.swift */; };
 		B4FCD85224B9330A00064C9E /* ChatMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4FCD85124B9330A00064C9E /* ChatMessageCell.swift */; };
 		B4FCD85524B9364900064C9E /* ChatModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4FCD85424B9364900064C9E /* ChatModel.swift */; };
 		B4FCD85724B947FC00064C9E /* TimestampConversion.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4FCD85624B947FB00064C9E /* TimestampConversion.swift */; };
@@ -161,6 +162,7 @@
 		5A81417723F2300D00560201 /* RosterTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RosterTableCell.swift; sourceTree = "<group>"; };
 		5ACB3E6F249AEE6800FC6E1B /* AmazonChimeSDKMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AmazonChimeSDKMedia.framework; path = ../AmazonChimeSDK/AmazonChimeSDKMedia.framework; sourceTree = "<group>"; };
 		5AE38AD1242873FD00B234EC /* AmazonChimeSDK.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = AmazonChimeSDK.xcodeproj; path = ../AmazonChimeSDK/AmazonChimeSDK.xcodeproj; sourceTree = "<group>"; };
+		ADE3CFC927050CD800DAC586 /* LiveTranscriptionOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveTranscriptionOptionsViewController.swift; sourceTree = "<group>"; };
 		B4FCD85124B9330A00064C9E /* ChatMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageCell.swift; sourceTree = "<group>"; usesTabs = 0; };
 		B4FCD85424B9364900064C9E /* ChatModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModel.swift; sourceTree = "<group>"; };
 		B4FCD85624B947FB00064C9E /* TimestampConversion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimestampConversion.swift; sourceTree = "<group>"; };
@@ -304,6 +306,7 @@
 				C4A3FFE9259B9AC5007CFABE /* BroadcastScreenCaptureModel.swift */,
 				5A1582C223C40C9D0099F8FA /* Assets.xcassets */,
 				5A1582BF23C40C9B0099F8FA /* Main.storyboard */,
+				ADE3CFC927050CD800DAC586 /* LiveTranscriptionOptionsViewController.swift */,
 				5A1582C423C40C9D0099F8FA /* LaunchScreen.storyboard */,
 				5A1582C723C40C9D0099F8FA /* Info.plist */,
 				C61D436F27050FBF00150F03 /* CaptionsModel.swift */,
@@ -574,6 +577,7 @@
 				003B58AF23E23E9D002493AB /* JoinMeetingResponse.swift in Sources */,
 				C4923C0624BE71D800EE866B /* MeetingModule.swift in Sources */,
 				00F372EA23D9196E008F7CA7 /* MeetingViewController.swift in Sources */,
+				ADE3CFCA27050CD800DAC586 /* LiveTranscriptionOptionsViewController.swift in Sources */,
 				C4923BED24B8CB1B00EE866B /* MeetingModel.swift in Sources */,
 				C42A8A12253E2E4E008419A6 /* CoreImageVideoProcessor.swift in Sources */,
 				C42A8A0E253E2E22008419A6 /* DeviceSelectionViewController.swift in Sources */,

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
@@ -970,12 +970,12 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textField opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HAa-I4-bUz">
+                            <textField opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HAa-I4-bUz">
                                 <rect key="frame" x="30" y="354" width="354" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <textField opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="W4e-99-NSd">
+                            <textField opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="W4e-99-NSd">
                                 <rect key="frame" x="30" y="431" width="354" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
@@ -988,8 +988,8 @@
                                     <action selector="startTranscriptionButton:" destination="oIM-X0-54O" eventType="touchUpInside" id="7Bn-JY-jfD"/>
                                 </connections>
                             </button>
-                            <textField opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="UPV-0s-G4L">
-                                <rect key="frame" x="20" y="286" width="354" height="34"/>
+                            <textField opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="UPV-0s-G4L">
+                                <rect key="frame" x="30" y="286" width="344" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
@@ -1019,7 +1019,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dXg-Dk-uIZ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="2714" y="113"/>
+            <point key="canvasLocation" x="2713.04347826087" y="112.5"/>
         </scene>
         <!--Debug Settings View Controller-->
         <scene sceneID="zQP-fR-VYF">

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -317,7 +317,7 @@
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <prototypes>
                                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="chatMessageCell" rowHeight="150" id="IR1-ov-bzI" customClass="ChatMessageCell" customModule="AmazonChimeSDKDemo" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="28" width="414" height="150"/>
+                                                        <rect key="frame" x="0.0" y="24.333333969116211" width="414" height="150"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="IR1-ov-bzI" id="jwj-GW-jrz">
                                                             <rect key="frame" x="0.0" y="0.0" width="414" height="150"/>
@@ -422,7 +422,7 @@
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="rosterCell" rowHeight="87" id="oOQ-i3-TjW" customClass="RosterTableCell" customModule="AmazonChimeSDKDemo" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="28" width="414" height="87"/>
+                                                <rect key="frame" x="0.0" y="24.333333969116211" width="414" height="87"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="oOQ-i3-TjW" id="yy8-Oi-9EV">
                                                     <rect key="frame" x="0.0" y="0.0" width="414" height="87"/>
@@ -652,7 +652,7 @@
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="metricsCell" rowHeight="87" id="ScO-Sx-PnT" userLabel="metricsCell" customClass="MetricsTableCell" customModule="AmazonChimeSDKDemo" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="28" width="414" height="87"/>
+                                                <rect key="frame" x="0.0" y="24.333333969116211" width="414" height="87"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ScO-Sx-PnT" id="XjQ-XE-b0u">
                                                     <rect key="frame" x="0.0" y="0.0" width="414" height="87"/>
@@ -698,7 +698,7 @@
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="captionCell" id="8aS-kd-Jde" customClass="CaptionCell" customModule="AmazonChimeSDKDemo" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="28" width="414" height="39.333332061767578"/>
+                                                <rect key="frame" x="0.0" y="24.333333969116211" width="414" height="39.333332061767578"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8aS-kd-Jde" id="4gI-K8-L7e">
                                                     <rect key="frame" x="0.0" y="0.0" width="414" height="39.333332061767578"/>
@@ -886,7 +886,7 @@
                                 <rect key="frame" x="0.0" y="52" width="414" height="44"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Meeting#" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DdL-aA-lof">
-                                        <rect key="frame" x="15.999999999999993" y="0.0" width="116.33333333333331" height="44"/>
+                                        <rect key="frame" x="16.000000000000007" y="0.0" width="103.66666666666669" height="44"/>
                                         <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <accessibility key="accessibilityConfiguration">
                                             <accessibilityTraits key="traits" staticText="YES" header="YES"/>
@@ -980,7 +980,7 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xQi-rK-PWV">
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xQi-rK-PWV">
                                 <rect key="frame" x="133" y="579" width="128" height="51"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Start Transcription"/>

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
@@ -925,6 +925,7 @@
                         </constraints>
                     </view>
                     <toolbarItems/>
+                    <navigationItem key="navigationItem" id="11D-ok-UAX"/>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="additionalOptionsButton" destination="Ief-dn-Lr8" id="3PU-5V-JQ7"/>
@@ -960,6 +961,65 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="DDZ-DD-2dd" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1853.6231884057972" y="112.5"/>
+        </scene>
+        <!--Live Transcriptions View Controller-->
+        <scene sceneID="2J4-Kn-Aok">
+            <objects>
+                <viewController storyboardIdentifier="liveTranscription" title="Live Transcriptions View Controller" useStoryboardIdentifierAsRestorationIdentifier="YES" id="oIM-X0-54O" customClass="LiveTranscriptionOptionsViewController" customModule="AmazonChimeSDKDemo" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="ogQ-aQ-X61">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textField opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HAa-I4-bUz">
+                                <rect key="frame" x="30" y="354" width="354" height="34"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <textField opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="W4e-99-NSd">
+                                <rect key="frame" x="30" y="431" width="354" height="34"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xQi-rK-PWV">
+                                <rect key="frame" x="133" y="579" width="128" height="51"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Start Transcription"/>
+                                <connections>
+                                    <action selector="startTranscriptionButton:" destination="oIM-X0-54O" eventType="touchUpInside" id="7Bn-JY-jfD"/>
+                                </connections>
+                            </button>
+                            <textField opaque="NO" contentMode="scaleToFill" misplaced="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="UPV-0s-G4L">
+                                <rect key="frame" x="20" y="286" width="354" height="34"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="7dQ-v6-lgr"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="W4e-99-NSd" firstAttribute="top" secondItem="HAa-I4-bUz" secondAttribute="bottom" constant="10" id="8Qj-3A-ZJq"/>
+                            <constraint firstItem="HAa-I4-bUz" firstAttribute="top" secondItem="UPV-0s-G4L" secondAttribute="bottom" constant="10" id="Iz9-KS-6jk"/>
+                            <constraint firstItem="W4e-99-NSd" firstAttribute="top" secondItem="HAa-I4-bUz" secondAttribute="bottom" constant="124" id="Mhl-c8-RZj"/>
+                            <constraint firstItem="7dQ-v6-lgr" firstAttribute="trailing" secondItem="W4e-99-NSd" secondAttribute="trailing" constant="30" id="Z9i-mE-XBR"/>
+                            <constraint firstItem="W4e-99-NSd" firstAttribute="leading" secondItem="7dQ-v6-lgr" secondAttribute="leading" constant="30" id="joS-3o-6N2"/>
+                            <constraint firstItem="W4e-99-NSd" firstAttribute="top" secondItem="HAa-I4-bUz" secondAttribute="bottom" constant="30" id="o11-4Q-n4C"/>
+                            <constraint firstItem="7dQ-v6-lgr" firstAttribute="bottom" secondItem="W4e-99-NSd" secondAttribute="bottom" constant="350" id="sOv-dF-dyv"/>
+                            <constraint firstItem="7dQ-v6-lgr" firstAttribute="trailing" secondItem="UPV-0s-G4L" secondAttribute="trailing" constant="30" id="tdx-2f-MmU"/>
+                            <constraint firstItem="UPV-0s-G4L" firstAttribute="leading" secondItem="7dQ-v6-lgr" secondAttribute="leading" constant="30" id="tyG-mf-hd8"/>
+                            <constraint firstItem="7dQ-v6-lgr" firstAttribute="trailing" secondItem="HAa-I4-bUz" secondAttribute="trailing" constant="30" id="zGQ-Ug-1V0"/>
+                            <constraint firstItem="HAa-I4-bUz" firstAttribute="leading" secondItem="7dQ-v6-lgr" secondAttribute="leading" constant="30" id="zc6-7g-W3Z"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="engineTextField" destination="UPV-0s-G4L" id="BwK-EG-N6q"/>
+                        <outlet property="languageTextField" destination="HAa-I4-bUz" id="j3N-1M-j6v"/>
+                        <outlet property="regionTextField" destination="W4e-99-NSd" id="w9D-ms-dfG"/>
+                        <outlet property="startTranscriptionButton" destination="xQi-rK-PWV" id="JLq-tz-YFS"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dXg-Dk-uIZ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2714" y="113"/>
         </scene>
         <!--Debug Settings View Controller-->
         <scene sceneID="zQP-fR-VYF">

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/CaptionsModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/CaptionsModel.swift
@@ -11,7 +11,9 @@ import UIKit
 
 class CaptionsModel: NSObject {
     let logger = ConsoleLogger(name: "CaptionsModel")
-
+    
+    var isLiveTranscriptionEnabled = false
+    
     var captions = [Caption]()
     var captionIndices = [String: Int]()    // map resultId to index in captions array
     var refreshCaptionsTableHandler: (() -> Void)?
@@ -19,12 +21,14 @@ class CaptionsModel: NSObject {
     // triggered on main thread, no synchronization needed
     public func addTranscriptEvent(transcriptEvent: TranscriptEvent) {
         if let status = transcriptEvent as? TranscriptionStatus {
+            print("status type \(status.type)")
             let formattedEventTime = TimeStampConversion.formatTimestamp(timestamp: status.eventTimeMs)
             let content = "Live transcription \(status.type) at \(formattedEventTime) in \(status.transcriptionRegion) with configuration: \(status.transcriptionConfiguration)"
             let caption = Caption(speakerName: "",
                                   isPartial: false,
                                   content: content)
             captions.append(caption)
+            isLiveTranscriptionEnabled = status.type == .started
         } else if let transcript = transcriptEvent as? Transcript {
             transcript.results.forEach { result in
                 guard let alternative = result.alternatives.first else {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/CaptionsModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/CaptionsModel.swift
@@ -21,7 +21,6 @@ class CaptionsModel: NSObject {
     // triggered on main thread, no synchronization needed
     public func addTranscriptEvent(transcriptEvent: TranscriptEvent) {
         if let status = transcriptEvent as? TranscriptionStatus {
-            print("status type \(status.type)")
             let formattedEventTime = TimeStampConversion.formatTimestamp(timestamp: status.eventTimeMs)
             let content = "Live transcription \(status.type) at \(formattedEventTime) in \(status.transcriptionRegion) with configuration: \(status.transcriptionConfiguration)"
             let caption = Caption(speakerName: "",

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/CaptionsModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/CaptionsModel.swift
@@ -27,7 +27,9 @@ class CaptionsModel: NSObject {
                                   isPartial: false,
                                   content: content)
             captions.append(caption)
-            isLiveTranscriptionEnabled = status.type == .started
+            if status.type == .started || status.type == .stopped {
+                isLiveTranscriptionEnabled = status.type == .started
+            }
         } else if let transcript = transcriptEvent as? Transcript {
             transcript.results.forEach { result in
                 guard let alternative = result.alternatives.first else {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/LiveTranscriptionOptionsViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/LiveTranscriptionOptionsViewController.swift
@@ -115,10 +115,6 @@ class LiveTranscriptionOptionsViewController: UIViewController {
         }
     }
     
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-    }
-    
     override  func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
     }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/LiveTranscriptionOptionsViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/LiveTranscriptionOptionsViewController.swift
@@ -30,8 +30,43 @@ class LiveTranscriptionOptionsViewController: UIViewController, UITextFieldDeleg
     var languages: [String] = []
     var regions: [String] = []
     
+    let transcribeLanguage = [
+                                "en-US",
+                                "es-US",
+                                "en-GB",
+                                "en-AU",
+                                "fr-CA",
+                                "fr-FR",
+                                "it-IT",
+                                "de-DE",
+                                "pt-BR",
+                                "ja-JP",
+                                "ko-KR",
+                                "zh-CN"
+                               ]
+    let transcribeRegion = [
+                                "ap-northeast-1",
+                                "ap-northeast-2",
+                                "ap-southeast-2",
+                                "ca-central-1",
+                                "eu-central-1",
+                                "eu-west-1",
+                                "eu-west-2",
+                                "sa-east-1",
+                                "us-east-1",
+                                "us-east-2",
+                                "us-west-2"
+                            ]
+    
     let transcribeMedicalLanguage = ["en-US"]
-    let transcribeMedicalRegions = ["ap-southeast-2", "ca-central-1", "eu-west-1", "us-east-1", "us-east-2", "us-west-2"]
+    let transcribeMedicalRegions = [
+                                        "ap-southeast-2",
+                                        "ca-central-1",
+                                        "eu-west-1",
+                                        "us-east-1",
+                                        "us-east-2",
+                                        "us-west-2"
+                                    ]
     
     var enginesDict = [
         "transcribe": "Amazon Transcribe",
@@ -99,9 +134,9 @@ class LiveTranscriptionOptionsViewController: UIViewController, UITextFieldDeleg
         languageSelected = "en-US"
         regionSelected = "us-east-1"
         
-        engineTextField.text = "Amazon Transcribe"
-        languageTextField.text = "US English"
-        regionTextField.text = "United States (N. Virginia)"
+        engineTextField.text = enginesDict[engineSelected]
+        languageTextField.text = languagesDict[languageSelected]
+        regionTextField.text = regionsDict[regionSelected]
         
         enginePickerView.delegate = self
         languagePickerView.delegate = self
@@ -129,10 +164,6 @@ class LiveTranscriptionOptionsViewController: UIViewController, UITextFieldDeleg
                 }
             }
         }
-    }
-    
-    override  func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
     }
 }
 
@@ -186,17 +217,17 @@ extension LiveTranscriptionOptionsViewController: UIPickerViewDataSource, UIPick
             return
         }
         
-        if engineTextField.text == "Amazon Transcribe Medical" && engineSelectedBefore == "transcribe" {
+        if engineSelected == "transcribe_medical" && engineSelectedBefore == "transcribe" {
             languages = transcribeMedicalLanguage
             regions = transcribeMedicalRegions
-            languageTextField.text = "US English"
             languageSelected = "en-US"
-            regionTextField.text = "United States (N. Virginia)"
+            languageTextField.text = languagesDict[languageSelected]
             regionSelected = "us-east-1"
+            regionTextField.text = regionsDict[regionSelected]
         }
-        if engineTextField.text == "Amazon Transcribe" {
-            languages = Array(languagesDict.keys)
-            regions = Array(regionsDict.keys)
+        if engineSelected == "transcribe" {
+            languages = transcribeLanguage
+            regions = transcribeRegion
         }
     }
 }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/LiveTranscriptionOptionsViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/LiveTranscriptionOptionsViewController.swift
@@ -10,7 +10,7 @@ import Foundation
 import AmazonChimeSDK
 import UIKit
 
-class LiveTranscriptionOptionsViewController: UIViewController {
+class LiveTranscriptionOptionsViewController: UIViewController, UITextFieldDelegate {
     var model: MeetingModel?
     var meetingId = ""
     var engineSelected = ""
@@ -22,31 +22,38 @@ class LiveTranscriptionOptionsViewController: UIViewController {
     @IBOutlet var languageTextField: UITextField!
     @IBOutlet var regionTextField: UITextField!
     
-    var engines = ["transcribe_medical", "transcribe"]
-    var languages = ["es-US", "en-US", "en-GB", "en-AU", "fr-CA", "fr-FR", "it-IT", "de-DE", "pt-BR", "ja-JP", "ko-KR", "zh-CN"]
-    var regions = ["us-west-2", "us-east-1", "us-east-2", "sa-east-1", "eu-west-2", "eu-west-1", "eu-central-1", "ca-central-1", "ap-southeast-2", "ap-northeast-2", "ap-northeast-1"]
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        return false
+    }
+    
+    var engines: [String] = []
+    var languages: [String] = []
+    var regions: [String] = []
+    
+    let transcribeMedicalLanguage = ["en-US"]
+    let transcribeMedicalRegions = ["ap-southeast-2", "ca-central-1", "eu-west-1", "us-east-1", "us-east-2", "us-west-2"]
     
     var enginesDict = [
-        "transcribe": "Trancribe",
-        "transcribe_medical": "Transcribe Medical"
+        "transcribe": "Amazon Transcribe",
+        "transcribe_medical": "Amazon Transcribe Medical"
     ]
     
     var languagesDict = [
-        "en-US": "US English",
-        "es-US": "US Spanish",
-        "en-GB": "British English",
-        "en-AU": "Australian English",
-        "fr-CA": "Canadian French",
-        "fr-FR": "French",
-        "it-IT": "Italian",
-        "de-DE": "German",
-        "pt-BR": "Brazilian Portuguese",
-        "ja-JP": "Japanese",
-        "ko-KR": "Korean",
-        "zh-CN": "Mandarin Chinese"
+        "en-US": "US English (en-US)",
+        "es-US": "US Spanish (es-US)",
+        "en-GB": "British English (en-GB)",
+        "en-AU": "Australian English (en-AU)",
+        "fr-CA": "Canadian French (fr-CA)",
+        "fr-FR": "French (fr-FR)",
+        "it-IT": "Italian (it-IT)",
+        "de-DE": "German (de-DE)",
+        "pt-BR": "Brazilian Portuguese (pt-BR)",
+        "ja-JP": "Japanese (ja-JP)",
+        "ko-KR": "Korean (ko-KR)",
+        "zh-CN": "Mandarin Chinese - Mainland (zh-CN)"
     ]
     
-    var regionsDict = [
+    let regionsDict = [
         "ap-northeast-1": "Japan (Tokyo)",
         "ap-northeast-2": "South Korea (Seoul)",
         "ap-southeast-2": "Australia (Sydney)",
@@ -66,12 +73,21 @@ class LiveTranscriptionOptionsViewController: UIViewController {
     
     private func notify(msg: String) {
         DispatchQueue.main.async {
-            self.view?.makeToast("Transcription failed", duration: 2.0, position: .top)
+            self.view?.makeToast(msg, duration: 2.0, position: .top)
         }
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        self.engines = Array(enginesDict.keys)
+        self.languages = Array(languagesDict.keys)
+        self.regions = Array(regionsDict.keys)
+
+        
+        self.engineTextField.delegate = self
+        self.languageTextField.delegate = self
+        self.regionTextField.delegate = self
         
         guard let meetingId = self.model?.meetingId else {return MeetingModule.shared().dismissTranscription(self)}
         self.meetingId = meetingId
@@ -83,9 +99,9 @@ class LiveTranscriptionOptionsViewController: UIViewController {
         languageSelected = "en-US"
         regionSelected = "us-east-1"
         
-        engineTextField.text = "transcribe"
-        languageTextField.text = "en-US"
-        regionTextField.text = "us-east-1"
+        engineTextField.text = "Amazon Transcribe"
+        languageTextField.text = "US English"
+        regionTextField.text = "United States (N. Virginia)"
         
         enginePickerView.delegate = self
         languagePickerView.delegate = self
@@ -152,35 +168,35 @@ extension LiveTranscriptionOptionsViewController: UIPickerViewDataSource, UIPick
     }
     
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-        var engineSelectedBefore = engineSelected
+        let engineSelectedBefore = engineSelected
         switch pickerView.tag {
         case 1:
-            engineTextField.text = engines[row]
+            engineTextField.text = enginesDict[engines[row]]
             engineSelected = engines[row]
             engineTextField.resignFirstResponder()
         case 2:
-            languageTextField.text = languages[row]
+            languageTextField.text = languagesDict[languages[row]]
             languageSelected = languages[row]
             languageTextField.resignFirstResponder()
         case 3:
-            regionTextField.text = regions[row]
+            regionTextField.text = regionsDict[regions[row]]
             regionSelected = regions[row]
             regionTextField.resignFirstResponder()
         default:
             return
         }
         
-        if engineTextField.text == "transcribe_medical" && engineSelectedBefore == "transcribe" {
-            languages = ["en-US"]
-            regions = ["ap-southeast-2", "ca-central-1", "eu-west-1", "us-east-1", "us-east-2", "us-west-2"]
-            languageTextField.text = "en-US"
+        if engineTextField.text == "Amazon Transcribe Medical" && engineSelectedBefore == "transcribe" {
+            languages = transcribeMedicalLanguage
+            regions = transcribeMedicalRegions
+            languageTextField.text = "US English"
             languageSelected = "en-US"
-            regionTextField.text = "us-east-1"
+            regionTextField.text = "United States (N. Virginia)"
             regionSelected = "us-east-1"
         }
-        if engineTextField.text == "transcribe" {
-            languages = ["es-US", "en-US", "en-GB", "en-AU", "fr-CA", "fr-FR", "it-IT", "de-DE", "pt-BR", "ja-JP", "ko-KR", "zh-CN"]
-            regions = ["us-west-2", "us-east-1", "us-east-2", "sa-east-1", "eu-west-2", "eu-west-1", "eu-central-1", "ca-central-1", "ap-southeast-2", "ap-northeast-2", "ap-northeast-1"]
+        if engineTextField.text == "Amazon Transcribe" {
+            languages = Array(languagesDict.keys)
+            regions = Array(regionsDict.keys)
         }
     }
 }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/LiveTranscriptionOptionsViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/LiveTranscriptionOptionsViewController.swift
@@ -12,15 +12,15 @@ import UIKit
 
 class LiveTranscriptionOptionsViewController: UIViewController {
     var model: MeetingModel?
-    var meetingID = ""
+    var meetingId = ""
     var engineSelected = ""
     var languageSelected = ""
     var regionSelected = ""
     
-    @IBOutlet weak var startTranscriptionButton: UIButton!
-    @IBOutlet weak var engineTextField: UITextField!
-    @IBOutlet weak var languageTextField: UITextField!
-    @IBOutlet weak var regionTextField: UITextField!
+    @IBOutlet var startTranscriptionButton: UIButton!
+    @IBOutlet var engineTextField: UITextField!
+    @IBOutlet var languageTextField: UITextField!
+    @IBOutlet var regionTextField: UITextField!
     
     var engines = ["transcribe_medical", "transcribe"]
     var languages = ["es-US", "en-US", "en-GB", "en-AU", "fr-CA", "fr-FR", "it-IT", "de-DE", "pt-BR", "ja-JP", "ko-KR", "zh-CN"]
@@ -33,14 +33,22 @@ class LiveTranscriptionOptionsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        meetingID = self.model!.meetingId
+        meetingId = self.model!.meetingId
         engineTextField.inputView = enginePickerView
         languageTextField.inputView = languagePickerView
         regionTextField.inputView = regionPickerView
         
-        engineTextField.placeholder = "Select Engine"
-        languageTextField.placeholder = "Select Language"
-        regionTextField.placeholder = "Select Region"
+//        engineTextField.placeholder = "Select Engine"
+//        languageTextField.placeholder = "Select Language"
+//        regionTextField.placeholder = "Select Region"
+        
+        engineSelected = "transcribe"
+        languageSelected = "en-US"
+        regionSelected = "us-east-1"
+        
+        engineTextField.text = "transcribe"
+        languageTextField.text = "en-US"
+        regionTextField.text = "us-east-1"
         
         engineTextField.textAlignment = .center
         languageTextField.textAlignment = .center
@@ -61,7 +69,7 @@ class LiveTranscriptionOptionsViewController: UIViewController {
         var url = AppConfiguration.url
         url = url.hasSuffix("/") ? url : "\(url)/"
         let encodedURL = HttpUtils.encodeStrForURL(
-            str: "\(url)start_transcription?title=\(meetingID)&language=\(languageSelected)&region=\(regionSelected)&engine=\(engineSelected)")
+            str: "\(url)start_transcription?title=\(meetingId)&language=\(languageSelected)&region=\(regionSelected)&engine=\(engineSelected)")
         HttpUtils.postRequest(url: encodedURL, jsonData: nil) {_,_ in
 
             }
@@ -124,10 +132,6 @@ extension LiveTranscriptionOptionsViewController: UIPickerViewDataSource, UIPick
             regionTextField.resignFirstResponder()
         default:
             return
-        }
-        
-        if engineTextField.text != "" && languageTextField.text != "" && regionTextField.text != "" {
-            startTranscriptionButton.isEnabled = true
         }
         
         if engineTextField.text == "transcribe_medical" {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/LiveTranscriptionOptionsViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/LiveTranscriptionOptionsViewController.swift
@@ -38,10 +38,6 @@ class LiveTranscriptionOptionsViewController: UIViewController {
         languageTextField.inputView = languagePickerView
         regionTextField.inputView = regionPickerView
         
-//        engineTextField.placeholder = "Select Engine"
-//        languageTextField.placeholder = "Select Language"
-//        regionTextField.placeholder = "Select Region"
-        
         engineSelected = "transcribe"
         languageSelected = "en-US"
         regionSelected = "us-east-1"
@@ -49,10 +45,6 @@ class LiveTranscriptionOptionsViewController: UIViewController {
         engineTextField.text = "transcribe"
         languageTextField.text = "en-US"
         regionTextField.text = "us-east-1"
-        
-        engineTextField.textAlignment = .center
-        languageTextField.textAlignment = .center
-        regionTextField.textAlignment = .center
         
         enginePickerView.delegate = self
         languagePickerView.delegate = self

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/LiveTranscriptionOptionsViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/LiveTranscriptionOptionsViewController.swift
@@ -1,0 +1,138 @@
+//
+//  LiveTranscriptionOptionsViewController.swift
+//  AmazonChimeSDKDemo
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import AmazonChimeSDK
+import UIKit
+
+class LiveTranscriptionOptionsViewController: UIViewController {
+    var model: MeetingModel?
+    var meetingID = ""
+    var engineSelected = ""
+    var languageSelected = ""
+    var regionSelected = ""
+    
+    @IBOutlet weak var startTranscriptionButton: UIButton!
+    @IBOutlet weak var engineTextField: UITextField!
+    @IBOutlet weak var languageTextField: UITextField!
+    @IBOutlet weak var regionTextField: UITextField!
+    
+    var engines = ["transcribe_medical", "transcribe"]
+    var languages = ["es-US", "en-US", "en-GB", "en-AU", "fr-CA", "fr-FR", "it-IT", "de-DE", "pt-BR", "ja-JP", "ko-KR", "zh-CN"]
+    var regions = ["us-west-2", "us-east-1", "us-east-2", "sa-east-1", "eu-west-2", "eu-west-1", "eu-central-1", "ca-central-1", "ap-southeast-2", "ap-northeast-2", "ap-northeast-1"]
+    
+    var enginePickerView = UIPickerView()
+    var languagePickerView = UIPickerView()
+    var regionPickerView = UIPickerView()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        meetingID = self.model!.meetingId
+        engineTextField.inputView = enginePickerView
+        languageTextField.inputView = languagePickerView
+        regionTextField.inputView = regionPickerView
+        
+        engineTextField.placeholder = "Select Engine"
+        languageTextField.placeholder = "Select Language"
+        regionTextField.placeholder = "Select Region"
+        
+        engineTextField.textAlignment = .center
+        languageTextField.textAlignment = .center
+        regionTextField.textAlignment = .center
+        
+        enginePickerView.delegate = self
+        languagePickerView.delegate = self
+        regionPickerView.delegate = self
+        enginePickerView.dataSource = self
+        languagePickerView.dataSource = self
+        regionPickerView.dataSource = self
+        
+        enginePickerView.tag = 1
+        languagePickerView.tag = 2
+        regionPickerView.tag = 3
+    }
+    @IBAction func startTranscriptionButton(_ sender: UIButton) {
+        var url = AppConfiguration.url
+        url = url.hasSuffix("/") ? url : "\(url)/"
+        let encodedURL = HttpUtils.encodeStrForURL(
+            str: "\(url)start_transcription?title=\(meetingID)&language=\(languageSelected)&region=\(regionSelected)&engine=\(engineSelected)")
+        HttpUtils.postRequest(url: encodedURL, jsonData: nil) {_,_ in
+
+            }
+        MeetingModule.shared().dismissTranscription(self)
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+    }
+    
+    override  func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+    }
+}
+
+extension LiveTranscriptionOptionsViewController: UIPickerViewDataSource, UIPickerViewDelegate {
+    func numberOfComponents(in pickerView: UIPickerView) -> Int {
+        return 1
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+        switch pickerView.tag {
+        case 1:
+            return engines.count
+        case 2:
+            return languages.count
+        case 3:
+            return regions.count
+        default:
+            return 1
+        }
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        switch pickerView.tag {
+        case 1:
+            return engines[row]
+        case 2:
+            return languages[row]
+        case 3:
+            return regions[row]
+        default:
+            return "Data not found"
+        }
+    }
+    
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        switch pickerView.tag {
+        case 1:
+            engineTextField.text = engines[row]
+            engineSelected = engines[row]
+            engineTextField.resignFirstResponder()
+        case 2:
+            languageTextField.text = languages[row]
+            languageSelected = languages[row]
+            languageTextField.resignFirstResponder()
+        case 3:
+            regionTextField.text = regions[row]
+            regionSelected = regions[row]
+            regionTextField.resignFirstResponder()
+        default:
+            return
+        }
+        
+        if engineTextField.text != "" && languageTextField.text != "" && regionTextField.text != "" {
+            startTranscriptionButton.isEnabled = true
+        }
+        
+        if engineTextField.text == "transcribe_medical" {
+            languages = ["en-US"]
+            regions = ["ap-southeast-2", "ca-central-1", "eu-west-1", "us-east-1", "us-east-2", "us-west-2"]
+        }
+    }
+}

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/LiveTranscriptionOptionsViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/LiveTranscriptionOptionsViewController.swift
@@ -30,7 +30,7 @@ class LiveTranscriptionOptionsViewController: UIViewController, UITextFieldDeleg
     var languages: [String] = []
     var regions: [String] = []
     
-    let transcribeLanguage = [
+    let transcribeLanguages = [
                                 "en-US",
                                 "es-US",
                                 "en-GB",
@@ -44,7 +44,7 @@ class LiveTranscriptionOptionsViewController: UIViewController, UITextFieldDeleg
                                 "ko-KR",
                                 "zh-CN"
                                ]
-    let transcribeRegion = [
+    let transcribeRegions = [
                                 "ap-northeast-1",
                                 "ap-northeast-2",
                                 "ap-southeast-2",
@@ -58,7 +58,7 @@ class LiveTranscriptionOptionsViewController: UIViewController, UITextFieldDeleg
                                 "us-west-2"
                             ]
     
-    let transcribeMedicalLanguage = ["en-US"]
+    let transcribeMedicalLanguages = ["en-US"]
     let transcribeMedicalRegions = [
                                         "ap-southeast-2",
                                         "ca-central-1",
@@ -124,7 +124,9 @@ class LiveTranscriptionOptionsViewController: UIViewController, UITextFieldDeleg
         self.languageTextField.delegate = self
         self.regionTextField.delegate = self
         
-        guard let meetingId = self.model?.meetingId else {return MeetingModule.shared().dismissTranscription(self)}
+        guard let meetingId = self.model?.meetingId else {
+            return MeetingModule.shared().dismissTranscription(self)
+        }
         self.meetingId = meetingId
         engineTextField.inputView = enginePickerView
         languageTextField.inputView = languagePickerView
@@ -218,7 +220,7 @@ extension LiveTranscriptionOptionsViewController: UIPickerViewDataSource, UIPick
         }
         
         if engineSelected == "transcribe_medical" && engineSelectedBefore == "transcribe" {
-            languages = transcribeMedicalLanguage
+            languages = transcribeMedicalLanguages
             regions = transcribeMedicalRegions
             languageSelected = "en-US"
             languageTextField.text = languagesDict[languageSelected]
@@ -226,8 +228,8 @@ extension LiveTranscriptionOptionsViewController: UIPickerViewDataSource, UIPick
             regionTextField.text = regionsDict[regionSelected]
         }
         if engineSelected == "transcribe" {
-            languages = transcribeLanguage
-            regions = transcribeRegion
+            languages = transcribeLanguages
+            regions = transcribeRegions
         }
     }
 }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/LiveTranscriptionOptionsViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/LiveTranscriptionOptionsViewController.swift
@@ -26,6 +26,40 @@ class LiveTranscriptionOptionsViewController: UIViewController {
     var languages = ["es-US", "en-US", "en-GB", "en-AU", "fr-CA", "fr-FR", "it-IT", "de-DE", "pt-BR", "ja-JP", "ko-KR", "zh-CN"]
     var regions = ["us-west-2", "us-east-1", "us-east-2", "sa-east-1", "eu-west-2", "eu-west-1", "eu-central-1", "ca-central-1", "ap-southeast-2", "ap-northeast-2", "ap-northeast-1"]
     
+    var enginesDict = [
+        "transcribe": "Trancribe",
+        "transcribe_medical": "Transcribe Medical"
+    ]
+    
+    var languagesDict = [
+        "en-US": "US English",
+        "es-US": "US Spanish",
+        "en-GB": "British English",
+        "en-AU": "Australian English",
+        "fr-CA": "Canadian French",
+        "fr-FR": "French",
+        "it-IT": "Italian",
+        "de-DE": "German",
+        "pt-BR": "Brazilian Portuguese",
+        "ja-JP": "Japanese",
+        "ko-KR": "Korean",
+        "zh-CN": "Mandarin Chinese"
+    ]
+    
+    var regionsDict = [
+        "ap-northeast-1": "Japan (Tokyo)",
+        "ap-northeast-2": "South Korea (Seoul)",
+        "ap-southeast-2": "Australia (Sydney)",
+        "ca-central-1": "Canada",
+        "eu-central-1": "Germany (Frankfurt)",
+        "eu-west-1": "Ireland",
+        "eu-west-2": "United Kingdom (London)",
+        "sa-east-1": "Brazil (São Paulo)",
+        "us-east-1": "United States (N. Virginia)",
+        "us-east-2": "United States (Ohio)",
+        "us-west-2": "United States (Oregon)"
+    ]
+    
     var enginePickerView = UIPickerView()
     var languagePickerView = UIPickerView()
     var regionPickerView = UIPickerView()
@@ -111,11 +145,11 @@ extension LiveTranscriptionOptionsViewController: UIPickerViewDataSource, UIPick
     func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
         switch pickerView.tag {
         case 1:
-            return engines[row]
+            return enginesDict[engines[row]]
         case 2:
-            return languages[row]
+            return languagesDict[languages[row]]
         case 3:
-            return regions[row]
+            return regionsDict[regions[row]]
         default:
             return "Data not found"
         }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/LiveTranscriptionOptionsViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/LiveTranscriptionOptionsViewController.swift
@@ -39,7 +39,8 @@ class LiveTranscriptionOptionsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        meetingId = self.model!.meetingId
+        guard let meetingId = self.model?.meetingId else {return MeetingModule.shared().dismissTranscription(self)}
+        self.meetingId = meetingId
         engineTextField.inputView = enginePickerView
         languageTextField.inputView = languagePickerView
         regionTextField.inputView = regionPickerView
@@ -121,6 +122,7 @@ extension LiveTranscriptionOptionsViewController: UIPickerViewDataSource, UIPick
     }
     
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        var engineSelectedBefore = engineSelected
         switch pickerView.tag {
         case 1:
             engineTextField.text = engines[row]
@@ -138,7 +140,7 @@ extension LiveTranscriptionOptionsViewController: UIPickerViewDataSource, UIPick
             return
         }
         
-        if engineTextField.text == "transcribe_medical" {
+        if engineTextField.text == "transcribe_medical" && engineSelectedBefore == "transcribe" {
             languages = ["en-US"]
             regions = ["ap-southeast-2", "ca-central-1", "eu-west-1", "us-east-1", "us-east-2", "us-west-2"]
             languageTextField.text = "en-US"

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -205,9 +205,7 @@ class MeetingModel: NSObject {
         url = url.hasSuffix("/") ? url : "\(url)/"
         let encodedURL = HttpUtils.encodeStrForURL(
                 str: "\(url)stop_transcription?title=\(meetingId)")
-        HttpUtils.postRequest(url: encodedURL, jsonData: nil) {_,_ in
-
-            }
+        HttpUtils.postRequest(url: encodedURL, jsonData: nil) {_,_ in }
         }
 
     func getVideoTileDisplayName(for indexPath: IndexPath) -> String {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -185,6 +185,30 @@ class MeetingModel: NSObject {
     func isVoiceFocusEnabled() -> Bool {
         return currentMeetingSession.audioVideo.realtimeIsVoiceFocusEnabled()
     }
+    
+    func setLiveTranscriptionEnabled(enabled: Bool) {
+        let action = enabled ? "enable" : "disable"
+        startOrStopTranscription(action: action)
+    }
+    
+    func startOrStopTranscription(action: String) {
+        if action == "enable" {
+            MeetingModule.shared().liveTranscriptionOptionsSelected(self)
+        } else {
+            postStopTranscriptionRequest()
+        }
+    }
+    
+    func postStopTranscriptionRequest() {
+        notify(msg: "Live Transcription Disabled")
+            var url = AppConfiguration.url
+            url = url.hasSuffix("/") ? url : "\(url)/"
+            let encodedURL = HttpUtils.encodeStrForURL(
+                str: "\(url)stop_transcription?title=\(meetingId)"            )
+        HttpUtils.postRequest(url: encodedURL, jsonData: nil) {_,_ in
+
+            }
+        }
 
     func getVideoTileDisplayName(for indexPath: IndexPath) -> String {
         var displayName = ""

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -205,8 +205,14 @@ class MeetingModel: NSObject {
         url = url.hasSuffix("/") ? url : "\(url)/"
         let encodedURL = HttpUtils.encodeStrForURL(
                 str: "\(url)stop_transcription?title=\(meetingId)")
-        HttpUtils.postRequest(url: encodedURL, jsonData: nil) {_,_ in }
+        HttpUtils.postRequest(url: encodedURL, jsonData: nil) {_,error in
+            if error != nil {
+                DispatchQueue.main.async {
+                    self.notify(msg: "Transcription failed to stop, please try again!")
+                }
+            }
         }
+    }
 
     func getVideoTileDisplayName(for indexPath: IndexPath) -> String {
         var displayName = ""

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -201,10 +201,10 @@ class MeetingModel: NSObject {
     
     func postStopTranscriptionRequest() {
         notify(msg: "Live Transcription Disabled")
-            var url = AppConfiguration.url
-            url = url.hasSuffix("/") ? url : "\(url)/"
-            let encodedURL = HttpUtils.encodeStrForURL(
-                str: "\(url)stop_transcription?title=\(meetingId)"            )
+        var url = AppConfiguration.url
+        url = url.hasSuffix("/") ? url : "\(url)/"
+        let encodedURL = HttpUtils.encodeStrForURL(
+                str: "\(url)stop_transcription?title=\(meetingId)")
         HttpUtils.postRequest(url: encodedURL, jsonData: nil) {_,_ in
 
             }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -187,12 +187,7 @@ class MeetingModel: NSObject {
     }
     
     func setLiveTranscriptionEnabled(enabled: Bool) {
-        let action = enabled ? "enable" : "disable"
-        startOrStopTranscription(action: action)
-    }
-    
-    func startOrStopTranscription(action: String) {
-        if action == "enable" {
+        if enabled {
             MeetingModule.shared().liveTranscriptionOptionsSelected(self)
         } else {
             postStopTranscriptionRequest()

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModule.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModule.swift
@@ -101,6 +101,17 @@ class MeetingModule {
             self.meetingPresenter.showMeetingView(meetingModel: activeMeeting) { _ in }
         }
     }
+    
+    func liveTranscriptionOptionsSelected(_ meetingModel: MeetingModel) {
+        guard let activeMeeting = activeMeeting else {
+            return
+        }
+        self.meetingPresenter.showLiveTranscriptionView(meetingModel: activeMeeting) { _ in }
+    }
+    
+    func dismissTranscription(_ liveTranscriptionVC: LiveTranscriptionOptionsViewController) {
+        self.meetingPresenter.dismissLiveTranscriptionView(liveTranscriptionVC) { _ in }
+    }
 
     func joinMeeting(_ meeting: MeetingModel, completion: @escaping (Bool) -> Void) {
         endActiveMeeting {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingPresenter.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingPresenter.swift
@@ -61,7 +61,7 @@ class MeetingPresenter {
             completion(false)
             return
         }
-        liveTranscriptionVC.modalPresentationStyle = .fullScreen
+        liveTranscriptionVC.modalPresentationStyle = .pageSheet
         liveTranscriptionVC.model = meetingModel
         rootViewController.present(liveTranscriptionVC, animated: true) {
             completion(true)
@@ -69,7 +69,6 @@ class MeetingPresenter {
     }
     
     func dismissLiveTranscriptionView(_ liveTranscriptionVC: LiveTranscriptionOptionsViewController, completion: @escaping (Bool) -> Void) {
-        liveTranscriptionVC.dismiss(animated: true) {
-        }
+        liveTranscriptionVC.dismiss(animated: true) {}
     }
 }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingPresenter.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingPresenter.swift
@@ -54,4 +54,22 @@ class MeetingPresenter {
             completion(true)
         }
     }
+    
+    func showLiveTranscriptionView(meetingModel: MeetingModel, completion: @escaping (Bool) -> Void) {
+        guard let liveTranscriptionVC = mainStoryboard.instantiateViewController(withIdentifier: "liveTranscription")
+                as? LiveTranscriptionOptionsViewController, let rootViewController = self.activeMeetingViewController else {
+            completion(false)
+            return
+        }
+        liveTranscriptionVC.modalPresentationStyle = .fullScreen
+        liveTranscriptionVC.model = meetingModel
+        rootViewController.present(liveTranscriptionVC, animated: true) {
+            completion(true)
+        }
+    }
+    
+    func dismissLiveTranscriptionView(_ liveTranscriptionVC: LiveTranscriptionOptionsViewController, completion: @escaping (Bool) -> Void) {
+        liveTranscriptionVC.dismiss(animated: true) {
+        }
+    }
 }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -67,7 +67,6 @@ class MeetingViewController: UIViewController {
 
     // Local var
     private let logger = ConsoleLogger(name: "MeetingViewController")
-    private var isLiveTranscriptionOn = false
     
     // MARK: Override functions
 
@@ -401,7 +400,6 @@ class MeetingViewController: UIViewController {
                                              handler: { _ in
                                                 meetingModel.setLiveTranscriptionEnabled(enabled: !isLiveTranscriptionEnabled)
                                              })
-        isLiveTranscriptionOn = !isLiveTranscriptionEnabled
         optionMenu.addAction(liveTranscriptionAction)
         
         // We can only access torch and apply filter on external video source

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -67,7 +67,7 @@ class MeetingViewController: UIViewController {
 
     // Local var
     private let logger = ConsoleLogger(name: "MeetingViewController")
-    private var liveTranscription = false
+    private var isLiveTranscriptionOn = false
     
     // MARK: Override functions
 
@@ -401,7 +401,7 @@ class MeetingViewController: UIViewController {
                                              handler: { _ in
                                                 meetingModel.setLiveTranscriptionEnabled(enabled: !isLiveTranscriptionEnabled)
                                              })
-        liveTranscription = !isLiveTranscriptionEnabled
+        isLiveTranscriptionOn = !isLiveTranscriptionEnabled
         optionMenu.addAction(liveTranscriptionAction)
         
         // We can only access torch and apply filter on external video source

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -50,7 +50,7 @@ class MeetingViewController: UIViewController {
 
     // Metrics
     @IBOutlet var metricsTable: UITableView!
-
+    
     // Chat View
     @IBOutlet var chatView: UIView!
     @IBOutlet var chatMessageTable: UITableView!
@@ -67,7 +67,8 @@ class MeetingViewController: UIViewController {
 
     // Local var
     private let logger = ConsoleLogger(name: "MeetingViewController")
-
+    private var liveTranscription = false
+    
     // MARK: Override functions
 
     override func viewDidLoad() {
@@ -392,7 +393,17 @@ class MeetingViewController: UIViewController {
                                                 meetingModel.setVoiceFocusEnabled(enabled: !isVoiceFocusEnabled)
                                              })
         optionMenu.addAction(voiceFocusAction)
-
+        
+        let isLiveTranscriptionEnabled = meetingModel.captionsModel.isLiveTranscriptionEnabled
+        let nextLiveTranscriptionStatus = nextOnOrOff(current: isLiveTranscriptionEnabled)
+        let liveTranscriptionAction = UIAlertAction(title: "Turn \(nextLiveTranscriptionStatus) Live Transcription",
+                                             style: .default,
+                                             handler: { _ in
+                                                meetingModel.setLiveTranscriptionEnabled(enabled: !isLiveTranscriptionEnabled)
+                                             })
+        liveTranscription = !isLiveTranscriptionEnabled
+        optionMenu.addAction(liveTranscriptionAction)
+        
         // We can only access torch and apply filter on external video source
         if meetingModel.videoModel.isUsingExternalVideoSource {
             let isTorchOn = meetingModel.videoModel.customSource.torchEnabled


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
Added control options in the demo app to give users the option to start and stop live transcription.
### Testing done:
Manually tested live transcription in iOS app
Joined a meeting with Live Transcription enabled on JS App
Verified transcripts appearing on both JS App and iOS app (in Captions sections)
Verified ending a meeting on iOS started on the JS App
Verified starting a meeting on JS App and transcripts appearing on iOS app
#### Manual test cases (add more as needed):

- [X] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [X] Leave meeting
- [X] Rejoin meeting
- [X] See metrics
- [X] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [X] Mute self
- [X] Unmute self
- [X] See local mute indicator when muted
- [X] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share
- [X] Start/Stop Transcription from iOS App
- [X] Start/Stop Transcription from JS App 
- [X] Select Transcribe engine: select regions and language specific to just Transcribe and change engine settings
- [X] Alternate between different engine, language and region settins
- [X] Start/Stop calls failing, notify messages showing

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

<img width="510" alt="Screen Shot 2021-10-05 at 3 42 19 PM" src="https://user-images.githubusercontent.com/83673947/136112803-c670440c-b0f8-4198-8e72-7be9e86a8627.png">

<img width="544" alt="Screen Shot 2021-10-05 at 3 42 37 PM" src="https://user-images.githubusercontent.com/83673947/136112819-4cda319b-1bd6-41fd-8fd9-adccbae04cb7.png">

<img width="514" alt="Screen Shot 2021-10-05 at 3 42 46 PM" src="https://user-images.githubusercontent.com/83673947/136112830-0f394592-c68f-45b4-b48c-d9139acf2f9a.png">

<img width="499" alt="Screen Shot 2021-10-05 at 3 43 11 PM" src="https://user-images.githubusercontent.com/83673947/136112846-7bb85ffa-eb1a-4f7a-9990-de80dd281b4b.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
