### PR TITLE
Fix a crash and a background color issue

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/CaptionCell.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/CaptionCell.swift
@@ -20,7 +20,7 @@ class CaptionCell: UITableViewCell {
     }
 
     func updateCell(caption: Caption) {
-        self.contentView.backgroundColor = caption.speakerName.isEmpty ? .lightGray : caption.isPartial ? .yellow : .none
+        self.contentView.backgroundColor = caption.speakerName.isEmpty ? .lightGray : .none
         speakerNameLabel.text = caption.speakerName
         speakerNameLabel.accessibilityIdentifier = caption.speakerName
         captionContentLabel.text = caption.content

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/RosterModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/RosterModel.swift
@@ -22,6 +22,9 @@ class RosterModel: NSObject {
 
     static func convertAttendeeName(from info: AttendeeInfo) -> String {
         let externalUserIdArray = info.externalUserId.components(separatedBy: "#")
+        if externalUserIdArray.isEmpty {
+            return ""
+        }
         let attendeeName: String = externalUserIdArray[1]
         return info.attendeeId.hasSuffix(contentDelimiter) ? "\(attendeeName) \(contentSuffix)" : attendeeName
     }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/RosterModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/RosterModel.swift
@@ -23,7 +23,7 @@ class RosterModel: NSObject {
     static func convertAttendeeName(from info: AttendeeInfo) -> String {
         let externalUserIdArray = info.externalUserId.components(separatedBy: "#")
         if externalUserIdArray.isEmpty {
-            return ""
+            return "<UNKNOWN>"
         }
         let attendeeName: String = externalUserIdArray[1]
         return info.attendeeId.hasSuffix(contentDelimiter) ? "\(attendeeName) \(contentSuffix)" : attendeeName


### PR DESCRIPTION
### Issue #, if available:
WTBugs-25710, WTBugs-25712, WTBugs-25713

### Description of changes:
* Fix a crash caused by empty external user id (this is a known issue on server side)
* Remove partial result highlighting that can cause accessibility issues in dark theme. This also fixes an issue that highlighting doesn't disappear when final results are not received (after stopping transcription in the middle of a sentence for example)

### Testing done:
* Joined a meeting with transcription on and verified the changes
    * Given it's difficult to reproduce empty external user id scenario, had to hard code it to empty in order to verify the change

#### Manual test cases (add more as needed):

- [x] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [x] See attendee presence
- [x] Send audio
- [x] Receive audio
- [x] Mute self
- [x] Unmute self
- [x] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [x] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [x] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
