### PR TITLE
Add APIs to support Audio/Video Configuration for Join Without Audio

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
+++ b/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
@@ -180,6 +180,11 @@
 		7CE107652421CC7B00E209D1 /* ActiveSpeakerPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CE107612421CC7B00E209D1 /* ActiveSpeakerPolicyTests.swift */; };
 		7CE107662421CC7B00E209D1 /* SchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CE107632421CC7B00E209D1 /* SchedulerTests.swift */; };
 		AC865DC0271F9B4600D6A0D8 /* MockedAudioSessionPortDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC865DBF271F9B4600D6A0D8 /* MockedAudioSessionPortDescription.swift */; };
+		8278478927188CA00071E7BE /* AudioMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8278478827188CA00071E7BE /* AudioMode.swift */; };
+		8278478D27188D110071E7BE /* AudioVideoConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8278478C27188D110071E7BE /* AudioVideoConfiguration.swift */; };
+		827847BF271D13A90071E7BE /* AudioModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827847BE271D13A90071E7BE /* AudioModeTests.swift */; };
+		827847C3271D15B20071E7BE /* AudioVideoConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827847C2271D15B20071E7BE /* AudioVideoConfigurationTests.swift */; };
+		827847C7271D16E20071E7BE /* DefaultAudioVideoFacadeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827847C6271D16E20071E7BE /* DefaultAudioVideoFacadeTests.swift */; };
 		B418163024B79C0600FA62BF /* DataMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B418162F24B79C0600FA62BF /* DataMessage.swift */; };
 		B418163224B79CF100FA62BF /* DataMessageObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B418163124B79CF100FA62BF /* DataMessageObserver.swift */; };
 		B418164724B7EDA800FA62BF /* SendDataMessageError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B418164624B7EDA800FA62BF /* SendDataMessageError.swift */; };
@@ -419,7 +424,7 @@
 		5AE76F33242049E0009C41FD /* MediaDeviceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDeviceType.swift; sourceTree = "<group>"; };
 		5AE76F3524204A03009C41FD /* MediaDeviceTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDeviceTypeTests.swift; sourceTree = "<group>"; };
 		5AF7E00D245B6E86006C7C86 /* VersioningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersioningTests.swift; sourceTree = "<group>"; };
-		5E7CEAE89DD08E6E863FC8BE /* AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = "AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift"; path = "MockingbirdMocks/AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift"; sourceTree = "<group>"; };
+		5E7CEAE89DD08E6E863FC8BE /* AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; lastKnownFileType = sourcecode.swift; name = "AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift"; path = "MockingbirdMocks/AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift"; sourceTree = "<group>"; };
 		6A01CAE423F8FCAF005C5193 /* ClientMetricsCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientMetricsCollectorTests.swift; sourceTree = "<group>"; };
 		6A68E79E24196773004F5A56 /* VideoPauseState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPauseState.swift; sourceTree = "<group>"; };
 		6AA9F93E2522438F00EB0644 /* VideoSourceAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoSourceAdapter.swift; sourceTree = "<group>"; };
@@ -444,6 +449,11 @@
 		7CE107612421CC7B00E209D1 /* ActiveSpeakerPolicyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActiveSpeakerPolicyTests.swift; sourceTree = "<group>"; };
 		7CE107632421CC7B00E209D1 /* SchedulerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SchedulerTests.swift; sourceTree = "<group>"; };
 		AC865DBF271F9B4600D6A0D8 /* MockedAudioSessionPortDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockedAudioSessionPortDescription.swift; sourceTree = "<group>"; };
+		8278478827188CA00071E7BE /* AudioMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioMode.swift; sourceTree = "<group>"; };
+		8278478C27188D110071E7BE /* AudioVideoConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioVideoConfiguration.swift; sourceTree = "<group>"; };
+		827847BE271D13A90071E7BE /* AudioModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioModeTests.swift; sourceTree = "<group>"; };
+		827847C2271D15B20071E7BE /* AudioVideoConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioVideoConfigurationTests.swift; sourceTree = "<group>"; };
+		827847C6271D16E20071E7BE /* DefaultAudioVideoFacadeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAudioVideoFacadeTests.swift; sourceTree = "<group>"; };
 		B418162F24B79C0600FA62BF /* DataMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMessage.swift; sourceTree = "<group>"; };
 		B418163124B79CF100FA62BF /* DataMessageObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMessageObserver.swift; sourceTree = "<group>"; };
 		B418164624B7EDA800FA62BF /* SendDataMessageError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendDataMessageError.swift; sourceTree = "<group>"; };
@@ -828,6 +838,7 @@
 				5A175AB623CFD28A00121924 /* DefaultAudioVideoFacade.swift */,
 				F82D50C223FC732300D8F18C /* SignalStrength.swift */,
 				F82D50C323FC732300D8F18C /* VolumeLevel.swift */,
+				8278478C27188D110071E7BE /* AudioVideoConfiguration.swift */,
 			);
 			path = audiovideo;
 			sourceTree = "<group>";
@@ -838,6 +849,7 @@
 				5A631A4124297C9600C8DAF3 /* activespeakerdetector */,
 				5A631A4224297CC200C8DAF3 /* activespeakerpolicy */,
 				7C0D1BCA241ACC7B00280031 /* scheduler */,
+				8278478827188CA00071E7BE /* AudioMode.swift */,
 			);
 			path = audio;
 			sourceTree = "<group>";
@@ -976,6 +988,8 @@
 				5AE76F2424203AA2009C41FD /* SignalStrengthTests.swift */,
 				5AE76F2624203AAA009C41FD /* VolumeLevelTests.swift */,
 				C6DA0B6124F961AA00028F2B /* DefaultAudioVideoControllerTests.swift */,
+				827847C2271D15B20071E7BE /* AudioVideoConfigurationTests.swift */,
+				827847C6271D16E20071E7BE /* DefaultAudioVideoFacadeTests.swift */,
 			);
 			path = audiovideo;
 			sourceTree = "<group>";
@@ -994,6 +1008,7 @@
 				7CE107602421CC7B00E209D1 /* ActiveSpeakerDetectorTests.swift */,
 				7CE107612421CC7B00E209D1 /* ActiveSpeakerPolicyTests.swift */,
 				7CE107632421CC7B00E209D1 /* SchedulerTests.swift */,
+				827847BE271D13A90071E7BE /* AudioModeTests.swift */,
 			);
 			path = audio;
 			sourceTree = "<group>";
@@ -1498,6 +1513,7 @@
 				F8E42DEE247F9464004C8400 /* ConcurrentDictionary.swift in Sources */,
 				B4980CB523E78D1800D2DB64 /* DefaultDeviceController.swift in Sources */,
 				C67E9B7126F4F9820084C9B4 /* TranscriptItemType.swift in Sources */,
+				8278478D27188D110071E7BE /* AudioVideoConfiguration.swift in Sources */,
 				0064166A26295EBF00626EB8 /* MeetingEventItem.swift in Sources */,
 				002C1FAC2641C50000C9B919 /* EventAttributesUtils.swift in Sources */,
 				00D12B8B265F02130059461B /* NoopEventReporterFactory.swift in Sources */,
@@ -1547,6 +1563,7 @@
 				6AA9F9462522439F00EB0644 /* VideoSink.swift in Sources */,
 				B418163024B79C0600FA62BF /* DataMessage.swift in Sources */,
 				0068454926125063002AB143 /* SDKEvent.swift in Sources */,
+				8278478927188CA00071E7BE /* AudioMode.swift in Sources */,
 				002C1FB72642099F00C9B919 /* DefaultBackoffRetry.swift in Sources */,
 				003B588923E22C4F002493AB /* MeetingSessionStatus.swift in Sources */,
 				0064165926290BDB00626EB8 /* EventDao.swift in Sources */,
@@ -1622,6 +1639,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7CE107642421CC7B00E209D1 /* ActiveSpeakerDetectorTests.swift in Sources */,
+				827847C3271D15B20071E7BE /* AudioVideoConfigurationTests.swift in Sources */,
 				C6DA0B2224F6C63F00028F2B /* DefaultVideoTileTests.swift in Sources */,
 				7CE107652421CC7B00E209D1 /* ActiveSpeakerPolicyTests.swift in Sources */,
 				C49A1C54253F43A50089FEEF /* VideoFrameTests.swift in Sources */,
@@ -1638,10 +1656,12 @@
 				C4A30003259D4261007CFABE /* DefaultContentShareControllerTests.swift in Sources */,
 				C67EA02A26F7F0EB0084C9B4 /* TranscriptItemTypeTests.swift in Sources */,
 				002F8FEF25BFED6800006F46 /* DefaultMeetingStatsCollectorTests.swift in Sources */,
+				827847BF271D13A90071E7BE /* AudioModeTests.swift in Sources */,
 				5AE1322F23EA2FB700BF5997 /* ConsoleLoggerTests.swift in Sources */,
 				5A16C0052405E83000ADAE26 /* DictionaryExtensionTests.swift in Sources */,
 				00684538260D1F1E002AB143 /* SQLiteClientFileTests.swift in Sources */,
 				C49A1C52253F41690089FEEF /* VideoRotationTests.swift in Sources */,
+				827847C7271D16E20071E7BE /* DefaultAudioVideoFacadeTests.swift in Sources */,
 				B491F3C824BFC761005CF109 /* DataMessageTests.swift in Sources */,
 				C67EA03026F7F17B0084C9B4 /* TranscriptionStatusTypeTests.swift in Sources */,
 				5AE76F2F24204387009C41FD /* LogLevelTests.swift in Sources */,

--- a/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
+++ b/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
@@ -100,6 +100,7 @@
 		00F20F0F2620C55D00C470E9 /* HttpUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F20F0E2620C55D00C470E9 /* HttpUtilsTests.swift */; };
 		00F20F1B2620E73E00C470E9 /* URLSessionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F20F1A2620E73E00C470E9 /* URLSessionProtocol.swift */; };
 		00F6E60825FBEA7F006DA17D /* SQLiteClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F6E60725FBEA7F006DA17D /* SQLiteClient.swift */; };
+		32F235B3714DA0906335CC12 /* AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7CEAE89DD08E6E863FC8BE /* AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift */; };
 		5A0E7317242EA072006636AB /* MediaDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A0E7316242EA072006636AB /* MediaDeviceTests.swift */; };
 		5A0E7319242EA283006636AB /* MeetingSessionStatusCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A0E7318242EA283006636AB /* MeetingSessionStatusCodeTests.swift */; };
 		5A0E731B242EA39E006636AB /* VideoTileStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A0E731A242EA39E006636AB /* VideoTileStateTests.swift */; };
@@ -178,12 +179,12 @@
 		7CE107642421CC7B00E209D1 /* ActiveSpeakerDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CE107602421CC7B00E209D1 /* ActiveSpeakerDetectorTests.swift */; };
 		7CE107652421CC7B00E209D1 /* ActiveSpeakerPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CE107612421CC7B00E209D1 /* ActiveSpeakerPolicyTests.swift */; };
 		7CE107662421CC7B00E209D1 /* SchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CE107632421CC7B00E209D1 /* SchedulerTests.swift */; };
-		AC865DC0271F9B4600D6A0D8 /* MockedAudioSessionPortDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC865DBF271F9B4600D6A0D8 /* MockedAudioSessionPortDescription.swift */; };
 		8278478927188CA00071E7BE /* AudioMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8278478827188CA00071E7BE /* AudioMode.swift */; };
 		8278478D27188D110071E7BE /* AudioVideoConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8278478C27188D110071E7BE /* AudioVideoConfiguration.swift */; };
 		827847BF271D13A90071E7BE /* AudioModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827847BE271D13A90071E7BE /* AudioModeTests.swift */; };
 		827847C3271D15B20071E7BE /* AudioVideoConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827847C2271D15B20071E7BE /* AudioVideoConfigurationTests.swift */; };
 		827847C7271D16E20071E7BE /* DefaultAudioVideoFacadeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827847C6271D16E20071E7BE /* DefaultAudioVideoFacadeTests.swift */; };
+		AC865DC0271F9B4600D6A0D8 /* MockedAudioSessionPortDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC865DBF271F9B4600D6A0D8 /* MockedAudioSessionPortDescription.swift */; };
 		B418163024B79C0600FA62BF /* DataMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = B418162F24B79C0600FA62BF /* DataMessage.swift */; };
 		B418163224B79CF100FA62BF /* DataMessageObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B418163124B79CF100FA62BF /* DataMessageObserver.swift */; };
 		B418164724B7EDA800FA62BF /* SendDataMessageError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B418164624B7EDA800FA62BF /* SendDataMessageError.swift */; };
@@ -256,7 +257,6 @@
 		F82D50D723FC752600D8F18C /* SignalStrength.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82D50C223FC732300D8F18C /* SignalStrength.swift */; };
 		F82D50D823FC752600D8F18C /* VolumeLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82D50C323FC732300D8F18C /* VolumeLevel.swift */; };
 		F83F53702452757700614913 /* ObserverUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F83F536F2452757700614913 /* ObserverUtils.swift */; };
-		F84CFCE0751438D8B8CFF7BB /* AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7CEAE89DD08E6E863FC8BE /* AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift */; };
 		F86CB7412411B9A6004FD82F /* exported_symbols in Resources */ = {isa = PBXBuildFile; fileRef = F86CB7402411B9A6004FD82F /* exported_symbols */; };
 		F8C0145E23F1D50E0083D478 /* VideoClientController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C0145D23F1D50E0083D478 /* VideoClientController.swift */; };
 		F8E42DEE247F9464004C8400 /* ConcurrentDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E42DED247F9464004C8400 /* ConcurrentDictionary.swift */; };
@@ -448,12 +448,12 @@
 		7CE107602421CC7B00E209D1 /* ActiveSpeakerDetectorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActiveSpeakerDetectorTests.swift; sourceTree = "<group>"; };
 		7CE107612421CC7B00E209D1 /* ActiveSpeakerPolicyTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActiveSpeakerPolicyTests.swift; sourceTree = "<group>"; };
 		7CE107632421CC7B00E209D1 /* SchedulerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SchedulerTests.swift; sourceTree = "<group>"; };
-		AC865DBF271F9B4600D6A0D8 /* MockedAudioSessionPortDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockedAudioSessionPortDescription.swift; sourceTree = "<group>"; };
 		8278478827188CA00071E7BE /* AudioMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioMode.swift; sourceTree = "<group>"; };
 		8278478C27188D110071E7BE /* AudioVideoConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioVideoConfiguration.swift; sourceTree = "<group>"; };
 		827847BE271D13A90071E7BE /* AudioModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioModeTests.swift; sourceTree = "<group>"; };
 		827847C2271D15B20071E7BE /* AudioVideoConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioVideoConfigurationTests.swift; sourceTree = "<group>"; };
 		827847C6271D16E20071E7BE /* DefaultAudioVideoFacadeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAudioVideoFacadeTests.swift; sourceTree = "<group>"; };
+		AC865DBF271F9B4600D6A0D8 /* MockedAudioSessionPortDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockedAudioSessionPortDescription.swift; sourceTree = "<group>"; };
 		B418162F24B79C0600FA62BF /* DataMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMessage.swift; sourceTree = "<group>"; };
 		B418163124B79CF100FA62BF /* DataMessageObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMessageObserver.swift; sourceTree = "<group>"; };
 		B418164624B7EDA800FA62BF /* SendDataMessageError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SendDataMessageError.swift; sourceTree = "<group>"; };
@@ -1412,7 +1412,7 @@
 			files = (
 			);
 			inputPaths = (
-				"/tmp/Mockingbird-6063D3E3-706D-4F7F-A3CF-55BD575CFB66",
+				"/tmp/Mockingbird-308DA08D-EE8C-48F1-9894-E440336D8EA4",
 			);
 			name = "Generate Mockingbird Mocks";
 			outputPaths = (
@@ -1420,7 +1420,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n\nmockingbird generate \\\n  --targets 'AmazonChimeSDK' \\\n  --outputs \"${SRCROOT}/MockingbirdMocks/AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift\" \\\n  --support \"${SRCROOT}/MockingbirdSupport\"\n\n# Ensure mocks are generated prior to running Compile Sources\nrm -f '/tmp/Mockingbird-6063D3E3-706D-4F7F-A3CF-55BD575CFB66'\n";
+			shellScript = "set -e\n\nmockingbird generate \\\n  --targets 'AmazonChimeSDK' \\\n  --outputs \"${SRCROOT}/MockingbirdMocks/AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift\" \\\n  --support \"${SRCROOT}/MockingbirdSupport\"\n\n# Ensure mocks are generated prior to running Compile Sources\nrm -f '/tmp/Mockingbird-308DA08D-EE8C-48F1-9894-E440336D8EA4'\n";
 		};
 		114854BF06996650440AB080 /* Clean Mockingbird Mocks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1431,11 +1431,11 @@
 			);
 			name = "Clean Mockingbird Mocks";
 			outputPaths = (
-				"/tmp/Mockingbird-6063D3E3-706D-4F7F-A3CF-55BD575CFB66",
+				"/tmp/Mockingbird-308DA08D-EE8C-48F1-9894-E440336D8EA4",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "echo $RANDOM > '/tmp/Mockingbird-6063D3E3-706D-4F7F-A3CF-55BD575CFB66'\n";
+			shellScript = "echo $RANDOM > '/tmp/Mockingbird-308DA08D-EE8C-48F1-9894-E440336D8EA4'\n";
 		};
 		5A3CFC6423C52B5D00BB63B7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1716,7 +1716,7 @@
 				5AE76F2024203A6E009C41FD /* VolumeUpdateTests.swift in Sources */,
 				00E19905259E575C00AD4DAA /* DefautCameraCaptureSourceTests.swift in Sources */,
 				00E19905259E575C00AD4DAA /* DefautCameraCaptureSourceTests.swift in Sources */,
-				F84CFCE0751438D8B8CFF7BB /* AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift in Sources */,
+				32F235B3714DA0906335CC12 /* AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
+++ b/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
@@ -100,7 +100,6 @@
 		00F20F0F2620C55D00C470E9 /* HttpUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F20F0E2620C55D00C470E9 /* HttpUtilsTests.swift */; };
 		00F20F1B2620E73E00C470E9 /* URLSessionProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F20F1A2620E73E00C470E9 /* URLSessionProtocol.swift */; };
 		00F6E60825FBEA7F006DA17D /* SQLiteClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F6E60725FBEA7F006DA17D /* SQLiteClient.swift */; };
-		32F235B3714DA0906335CC12 /* AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7CEAE89DD08E6E863FC8BE /* AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift */; };
 		5A0E7317242EA072006636AB /* MediaDeviceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A0E7316242EA072006636AB /* MediaDeviceTests.swift */; };
 		5A0E7319242EA283006636AB /* MeetingSessionStatusCodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A0E7318242EA283006636AB /* MeetingSessionStatusCodeTests.swift */; };
 		5A0E731B242EA39E006636AB /* VideoTileStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A0E731A242EA39E006636AB /* VideoTileStateTests.swift */; };
@@ -257,6 +256,7 @@
 		F82D50D723FC752600D8F18C /* SignalStrength.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82D50C223FC732300D8F18C /* SignalStrength.swift */; };
 		F82D50D823FC752600D8F18C /* VolumeLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82D50C323FC732300D8F18C /* VolumeLevel.swift */; };
 		F83F53702452757700614913 /* ObserverUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = F83F536F2452757700614913 /* ObserverUtils.swift */; };
+		F84CFCE0751438D8B8CFF7BB /* AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7CEAE89DD08E6E863FC8BE /* AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift */; };
 		F86CB7412411B9A6004FD82F /* exported_symbols in Resources */ = {isa = PBXBuildFile; fileRef = F86CB7402411B9A6004FD82F /* exported_symbols */; };
 		F8C0145E23F1D50E0083D478 /* VideoClientController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8C0145D23F1D50E0083D478 /* VideoClientController.swift */; };
 		F8E42DEE247F9464004C8400 /* ConcurrentDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E42DED247F9464004C8400 /* ConcurrentDictionary.swift */; };
@@ -1716,7 +1716,7 @@
 				5AE76F2024203A6E009C41FD /* VolumeUpdateTests.swift in Sources */,
 				00E19905259E575C00AD4DAA /* DefautCameraCaptureSourceTests.swift in Sources */,
 				00E19905259E575C00AD4DAA /* DefautCameraCaptureSourceTests.swift in Sources */,
-				32F235B3714DA0906335CC12 /* AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift in Sources */,
+				F84CFCE0751438D8B8CFF7BB /* AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoConfiguration.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoConfiguration.swift
@@ -13,7 +13,19 @@ import Foundation
     public let audioMode: AudioMode
     public let callKitEnabled: Bool
 
-    public init(audioMode: AudioMode = .mono, callKitEnabled: Bool = false) {
+    convenience override public init() {
+        self.init(audioMode: .mono, callKitEnabled: false)
+    }
+
+    convenience public init(audioMode: AudioMode) {
+        self.init(audioMode: audioMode, callKitEnabled: false)
+    }
+
+    convenience public init(callKitEnabled: Bool) {
+        self.init(audioMode: .mono, callKitEnabled: callKitEnabled)
+    }
+
+    public init(audioMode: AudioMode, callKitEnabled: Bool) {
         self.audioMode = audioMode
         self.callKitEnabled = callKitEnabled
     }

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoConfiguration.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoConfiguration.swift
@@ -1,0 +1,20 @@
+//
+//  AudioVideoConfiguration.swift
+//  AmazonChimeSDK
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// `AudioVideoConfiguration` represents the configuration to be used for audio and video during a meeting session.
+@objcMembers public class AudioVideoConfiguration: NSObject {
+    public let audioMode: AudioMode
+    public let callKitEnabled: Bool
+
+    public init(audioMode: AudioMode = .mono, callKitEnabled: Bool = false) {
+        self.audioMode = audioMode
+        self.callKitEnabled = callKitEnabled
+    }
+}

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoControllerFacade.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoControllerFacade.swift
@@ -12,6 +12,13 @@ import Foundation
 @objc public protocol AudioVideoControllerFacade {
     var configuration: MeetingSessionConfiguration { get }
     var logger: Logger { get }
+
+    /// Start AudioVideo Controller
+    ///
+    /// - Parameter audioVideoConfiguration: The configuration used for Audio & Video
+    /// - Throws: `PermissionError.audioPermissionError` if `RecordPermission` is not given
+    func start(audioVideoConfiguration: AudioVideoConfiguration) throws
+
     /// Start AudioVideo Controller
     ///
     /// - Parameter callKitEnabled: A Bool value to indicate whether the VoIP call to start has CallKit integration.

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoController.swift
@@ -38,16 +38,21 @@ import Foundation
     public func start() throws {
         // By default, start for calls without CallKit integration. Use start(callKitEnabled:)
         // to override the default behavior if the call is integrated with CallKit
-        try self.start(callKitEnabled: false)
+        try self.start(audioVideoConfiguration: AudioVideoConfiguration())
     }
 
     public func start(callKitEnabled: Bool) throws {
+        try self.start(audioVideoConfiguration: AudioVideoConfiguration(callKitEnabled: callKitEnabled))
+    }
+
+    public func start(audioVideoConfiguration: AudioVideoConfiguration) throws {
         try audioClientController.start(audioFallbackUrl: configuration.urls.audioFallbackUrl,
                                         audioHostUrl: configuration.urls.audioHostUrl,
                                         meetingId: configuration.meetingId,
                                         attendeeId: configuration.credentials.attendeeId,
                                         joinToken: configuration.credentials.joinToken,
-                                        callKitEnabled: callKitEnabled)
+                                        callKitEnabled: audioVideoConfiguration.callKitEnabled,
+                                        audioMode: audioVideoConfiguration.audioMode)
         videoClientController.subscribeToVideoTileControllerObservers(observer: videoTileController)
         videoClientController.start()
     }

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
@@ -41,14 +41,18 @@ import Foundation
         self.eventAnalyticsController = eventAnalyticsController
     }
 
-    public func start(callKitEnabled: Bool = false) throws {
-        try audioVideoController.start(callKitEnabled: callKitEnabled)
+    public func start(audioVideoConfiguration: AudioVideoConfiguration) throws {
+        try audioVideoController.start(audioVideoConfiguration: audioVideoConfiguration)
 
-        trace(name: "start(callKitEnabled: \(callKitEnabled))")
+        trace(name: "start(audioVideoConfiguration: \(audioVideoConfiguration))")
+    }
+
+    public func start(callKitEnabled: Bool = false) throws {
+        try audioVideoController.start(audioVideoConfiguration: AudioVideoConfiguration(callKitEnabled: callKitEnabled))
     }
 
     public func start() throws {
-        try self.start(callKitEnabled: false)
+        try self.start(audioVideoConfiguration: AudioVideoConfiguration())
     }
 
     public func stop() {

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
@@ -48,7 +48,7 @@ import Foundation
     }
 
     public func start(callKitEnabled: Bool = false) throws {
-        try audioVideoController.start(audioVideoConfiguration: AudioVideoConfiguration(callKitEnabled: callKitEnabled))
+        try self.start(audioVideoConfiguration: AudioVideoConfiguration(callKitEnabled: callKitEnabled))
     }
 
     public func start() throws {

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/audio/AudioMode.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/audio/AudioMode.swift
@@ -1,0 +1,27 @@
+//
+//  AudioMode.swift
+//  AmazonChimeSDK
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// `AudioMode` describes the audio mode in which the audio client should operate during a meeting session
+@objc public enum AudioMode: Int, CaseIterable, CustomStringConvertible {
+    /// There will be no audio through mic and speaker
+    case noAudio = 0
+
+    /// The default audio mode with single audio channel
+    case mono = 1
+
+    public var description: String {
+        switch self {
+        case .noAudio:
+            return "noAudio"
+        case .mono:
+            return "mono"
+        }
+    }
+}

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/AttendeeStatus.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/AttendeeStatus.swift
@@ -19,6 +19,9 @@ import Foundation
     /// The attendee dropped due to network issues
     case dropped = 3
 
+    /// The attendee joined without audio
+    case joinedNoAudio = 4
+
     public var description: String {
         switch self {
         case .joined:
@@ -27,6 +30,8 @@ import Foundation
             return "left"
         case .dropped:
             return "dropped"
+        case .joinedNoAudio:
+            return "joinedNoAudio"
         }
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
@@ -17,7 +17,7 @@ class DefaultAudioClientController: NSObject {
     private let audioClientObserver: AudioClientObserver
     private let audioSession: AudioSession
     private let audioPortOffset = 200
-    private let defaultMicAndSpeaker = false
+    private var muteMicAndSpeaker = false
     private let defaultPort = 0
     private let defaultPresenter = true
     private let eventAnalyticsController: EventAnalyticsController
@@ -67,7 +67,8 @@ extension DefaultAudioClientController: AudioClientController {
                       meetingId: String,
                       attendeeId: String,
                       joinToken: String,
-                      callKitEnabled: Bool) throws {
+                      callKitEnabled: Bool,
+                      audioMode: AudioMode) throws {
         audioLock.lock()
         defer {
             audioLock.unlock()
@@ -97,12 +98,13 @@ extension DefaultAudioClientController: AudioClientController {
         }
         eventAnalyticsController.publishEvent(name: .meetingStartRequested)
         let appInfo = DeviceUtils.getAppInfo()
+        muteMicAndSpeaker = audioMode == .noAudio
         let status = audioClient.startSession(host,
                                               basePort: port,
                                               callId: meetingId,
                                               profileId: attendeeId,
-                                              microphoneMute: defaultMicAndSpeaker,
-                                              speakerMute: defaultMicAndSpeaker,
+                                              microphoneMute: muteMicAndSpeaker,
+                                              speakerMute: muteMicAndSpeaker,
                                               isPresenter: defaultPresenter,
                                               sessionToken: joinToken,
                                               audioWsUrl: audioFallbackUrl,

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientObserver.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientObserver.swift
@@ -171,6 +171,7 @@ class DefaultAudioClientObserver: NSObject, AudioClientDelegate {
 
         if let attendeesWithJoinedStatus = newAttendeeMap[AttendeeStatus.joined] {
             let attendeesJoined = attendeesWithJoinedStatus.subtracting(currentAttendeeSet)
+            logger.info(msg: "attendeesJoined: \(attendeesJoined)")
             if !attendeesJoined.isEmpty {
                 ObserverUtils.forEach(observers: realtimeObservers) { (observer: RealtimeObserver) in
                     observer.attendeesDidJoin(attendeeInfo: [AttendeeInfo](attendeesJoined))
@@ -179,8 +180,20 @@ class DefaultAudioClientObserver: NSObject, AudioClientDelegate {
             }
         }
 
+        if let attendeesWithJoinedWithoutAudioStatus = newAttendeeMap[AttendeeStatus.joinedNoAudio] {
+            let attendeesJoinedWithoutAudio = attendeesWithJoinedWithoutAudioStatus.subtracting(currentAttendeeSet)
+            logger.info(msg: "attendeesJoinedWithoutAudio: \(attendeesJoinedWithoutAudio)")
+            if !attendeesJoinedWithoutAudio.isEmpty {
+                ObserverUtils.forEach(observers: realtimeObservers) { (observer: RealtimeObserver) in
+                    observer.attendeesDidJoinWithoutAudio?(attendeeInfo: [AttendeeInfo](attendeesJoinedWithoutAudio))
+                }
+                currentAttendeeSet = currentAttendeeSet.union(attendeesJoinedWithoutAudio)
+            }
+        }
+
         if let attendeesWithLeftStatus = newAttendeeMap[AttendeeStatus.left] {
             if !attendeesWithLeftStatus.isEmpty {
+                logger.info(msg: "attendeesLeft: \(attendeesWithLeftStatus)")
                 ObserverUtils.forEach(observers: realtimeObservers) { (observer: RealtimeObserver) in
                     observer.attendeesDidLeave(attendeeInfo: [AttendeeInfo](attendeesWithLeftStatus))
                 }
@@ -190,6 +203,7 @@ class DefaultAudioClientObserver: NSObject, AudioClientDelegate {
 
         if let attendeesWithDroppedStatus = newAttendeeMap[AttendeeStatus.dropped] {
             if !attendeesWithDroppedStatus.isEmpty {
+                logger.info(msg: "attendeesDropped: \(attendeesWithDroppedStatus)")
                 ObserverUtils.forEach(observers: realtimeObservers) { (observer: RealtimeObserver) in
                     observer.attendeesDidDrop(attendeeInfo: [AttendeeInfo](attendeesWithDroppedStatus))
                 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientController.swift
@@ -15,7 +15,8 @@ import Foundation
                meetingId: String,
                attendeeId: String,
                joinToken: String,
-               callKitEnabled: Bool) throws
+               callKitEnabled: Bool,
+               audioMode: AudioMode) throws
     func stop()
     func setVoiceFocusEnabled(enabled: Bool) -> Bool
     func isVoiceFocusEnabled() -> Bool

--- a/AmazonChimeSDK/AmazonChimeSDK/realtime/RealtimeObserver.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/realtime/RealtimeObserver.swift
@@ -32,6 +32,13 @@ import Foundation
     /// - Parameter attendeeInfo: an array of AttendeeInfo added
     func attendeesDidJoin(attendeeInfo: [AttendeeInfo])
 
+    /// List attendees that are newly added without audio to the meeting
+    ///
+    /// Note: this callback will be called on main thread.
+    ///
+    /// - Parameter attendeeInfo: an array of AttendeeInfo added without audio
+    @objc optional func attendeesDidJoinWithoutAudio(attendeeInfo: [AttendeeInfo])
+
     /// List attendees that left the meeting
     ///
     /// Note: this callback will be called on main thread.

--- a/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/AudioVideoConfigurationTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/AudioVideoConfigurationTests.swift
@@ -12,8 +12,15 @@ import XCTest
 class AudioVideoConfigurationTests: XCTestCase {
     func testDefaultConfigurations() {
         let audioVideoConfig = AudioVideoConfiguration()
-
         XCTAssertEqual(audioVideoConfig.audioMode, .mono)
         XCTAssertEqual(audioVideoConfig.callKitEnabled, false)
+
+        let audioVideoConfigAudioMode = AudioVideoConfiguration(audioMode: .noAudio)
+        XCTAssertEqual(audioVideoConfigAudioMode.audioMode, .noAudio)
+        XCTAssertEqual(audioVideoConfigAudioMode.callKitEnabled, false)
+
+        let audioVideoConfigCallkit = AudioVideoConfiguration(callKitEnabled: true)
+        XCTAssertEqual(audioVideoConfigCallkit.audioMode, .mono)
+        XCTAssertEqual(audioVideoConfigCallkit.callKitEnabled, true)
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/AudioVideoConfigurationTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/AudioVideoConfigurationTests.swift
@@ -1,0 +1,19 @@
+//
+//  AudioVideoConfigurationTests.swift
+//  AmazonChimeSDK
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import AmazonChimeSDK
+import XCTest
+
+class AudioVideoConfigurationTests: XCTestCase {
+    func testDefaultConfigurations() {
+        let audioVideoConfig = AudioVideoConfiguration()
+
+        XCTAssertEqual(audioVideoConfig.audioMode, .mono)
+        XCTAssertEqual(audioVideoConfig.callKitEnabled, false)
+    }
+}

--- a/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/DefaultAudioVideoControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/DefaultAudioVideoControllerTests.swift
@@ -47,7 +47,8 @@ class DefaultAudioVideoControllerTests: CommonTestCase {
             meetingId: self.meetingSessionConfigurationMock.meetingId,
             attendeeId: self.meetingSessionConfigurationMock.credentials.attendeeId,
             joinToken: self.meetingSessionConfigurationMock.credentials.joinToken,
-            callKitEnabled: false
+            callKitEnabled: false,
+            audioMode: .mono
         )).wasCalled()
         verify(videoClientControllerMock.start()).wasCalled()
     }
@@ -62,7 +63,38 @@ class DefaultAudioVideoControllerTests: CommonTestCase {
             meetingId: self.meetingSessionConfigurationMock.meetingId,
             attendeeId: self.meetingSessionConfigurationMock.credentials.attendeeId,
             joinToken: self.meetingSessionConfigurationMock.credentials.joinToken,
-            callKitEnabled: callKitEnabled
+            callKitEnabled: callKitEnabled,
+            audioMode: .mono
+        )).wasCalled()
+        verify(videoClientControllerMock.start()).wasCalled()
+    }
+
+    func testStart_noAudio_callKitDisabled() {
+        XCTAssertNoThrow(try defaultAudioVideoController.start(audioVideoConfiguration: AudioVideoConfiguration(audioMode: .noAudio, callKitEnabled: false)))
+
+        verify(audioClientControllerMock.start(
+            audioFallbackUrl: self.meetingSessionConfigurationMock.urls.audioFallbackUrl,
+            audioHostUrl: self.meetingSessionConfigurationMock.urls.audioHostUrl,
+            meetingId: self.meetingSessionConfigurationMock.meetingId,
+            attendeeId: self.meetingSessionConfigurationMock.credentials.attendeeId,
+            joinToken: self.meetingSessionConfigurationMock.credentials.joinToken,
+            callKitEnabled: false,
+            audioMode: .noAudio
+        )).wasCalled()
+        verify(videoClientControllerMock.start()).wasCalled()
+    }
+
+    func testStart_noAudio_callKitEnabled() {
+        XCTAssertNoThrow(try defaultAudioVideoController.start(audioVideoConfiguration: AudioVideoConfiguration(audioMode: .noAudio, callKitEnabled: true)))
+
+        verify(audioClientControllerMock.start(
+            audioFallbackUrl: self.meetingSessionConfigurationMock.urls.audioFallbackUrl,
+            audioHostUrl: self.meetingSessionConfigurationMock.urls.audioHostUrl,
+            meetingId: self.meetingSessionConfigurationMock.meetingId,
+            attendeeId: self.meetingSessionConfigurationMock.credentials.attendeeId,
+            joinToken: self.meetingSessionConfigurationMock.credentials.joinToken,
+            callKitEnabled: true,
+            audioMode: .noAudio
         )).wasCalled()
         verify(videoClientControllerMock.start()).wasCalled()
     }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/DefaultAudioVideoFacadeTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/DefaultAudioVideoFacadeTests.swift
@@ -1,0 +1,76 @@
+//
+//  DefaultAudioVideoFacadeTests.swift
+//  AmazonChimeSDK
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import AmazonChimeSDK
+import Mockingbird
+import XCTest
+
+class DefaultAudioVideoFacadeTests: CommonTestCase {
+    var audioVideoControllerMock: AudioVideoControllerFacadeMock!
+    var realtimeControllerMock: RealtimeControllerFacadeMock!
+    var deviceControllerMock: DeviceControllerMock!
+    var videoTileControllerMock: VideoTileControllerMock!
+    var activeSpeakerDetectorMock: ActiveSpeakerDetectorFacadeMock!
+    var contentShareControllerMock: ContentShareControllerMock!
+    var eventAnalyticsControllerMock: EventAnalyticsControllerMock!
+    var meetingStatsCollectorMock: MeetingStatsCollectorMock!
+
+    var defaultAudioVideoFacade: DefaultAudioVideoFacade!
+
+    override func setUp() {
+        super.setUp()
+
+        audioVideoControllerMock = mock(AudioVideoControllerFacade.self)
+        realtimeControllerMock = mock(RealtimeControllerFacade.self)
+        deviceControllerMock = mock(DeviceController.self)
+        videoTileControllerMock = mock(VideoTileController.self)
+        activeSpeakerDetectorMock = mock(ActiveSpeakerDetectorFacade.self)
+        contentShareControllerMock = mock(ContentShareController.self)
+        eventAnalyticsControllerMock = mock(EventAnalyticsController.self)
+        meetingStatsCollectorMock = mock(MeetingStatsCollector.self)
+
+        var valueProvider = ValueProvider()
+        valueProvider.register(loggerMock, for: Logger.self)
+        valueProvider.register(meetingSessionConfigurationMock, for: MeetingSessionConfiguration.self)
+        audioVideoControllerMock.useDefaultValues(from: valueProvider)
+
+        defaultAudioVideoFacade = DefaultAudioVideoFacade(audioVideoController: audioVideoControllerMock,
+                                                          realtimeController: realtimeControllerMock,
+                                                          deviceController: deviceControllerMock,
+                                                          videoTileController: videoTileControllerMock,
+                                                          activeSpeakerDetector: activeSpeakerDetectorMock,
+                                                          contentShareController: contentShareControllerMock,
+                                                          eventAnalyticsController: eventAnalyticsControllerMock,
+                                                          meetingStatsCollector: meetingStatsCollectorMock)
+    }
+
+    func testStart_WithConfigArgs() {
+        let audioVideoConfiguration = AudioVideoConfiguration(audioMode: .noAudio, callKitEnabled: true)
+        given(audioVideoControllerMock.start(audioVideoConfiguration: any())).willReturn()
+
+        XCTAssertNoThrow(try defaultAudioVideoFacade.start(audioVideoConfiguration: audioVideoConfiguration))
+
+        verify(audioVideoControllerMock.start(audioVideoConfiguration: audioVideoConfiguration)).wasCalled()
+    }
+
+    func testStart_WithCallKitArgs() {
+        given(audioVideoControllerMock.start(audioVideoConfiguration: any())).willReturn()
+
+        XCTAssertNoThrow(try defaultAudioVideoFacade.start(callKitEnabled: true))
+
+        verify(audioVideoControllerMock.start(audioVideoConfiguration: any(where: { $0.audioMode == .mono && $0.callKitEnabled == true }))).wasCalled()
+    }
+
+    func testStart_WithNoArgs() {
+        given(audioVideoControllerMock.start(audioVideoConfiguration: any())).willReturn()
+
+        XCTAssertNoThrow(try defaultAudioVideoFacade.start())
+
+        verify(audioVideoControllerMock.start(audioVideoConfiguration: any(where: { $0.audioMode == .mono && $0.callKitEnabled == false }))).wasCalled()
+    }
+}

--- a/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/audio/AudioModeTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/audio/AudioModeTests.swift
@@ -1,0 +1,17 @@
+//
+//  AudioModeTests.swift
+//  AmazonChimeSDK
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import AmazonChimeSDK
+import XCTest
+
+class AudioModeTests: XCTestCase {
+    func testDescriptionShouldMatch() {
+        XCTAssertEqual(AudioMode.mono.description, "mono")
+        XCTAssertEqual(AudioMode.noAudio.description, "noAudio")
+    }
+}

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/AttendeeStatusTest.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/AttendeeStatusTest.swift
@@ -12,6 +12,7 @@ import XCTest
 class AttendeeStatusTests: XCTestCase {
     func testDescriptionShouldMatch() {
         XCTAssertEqual(AttendeeStatus.joined.description, "joined")
+        XCTAssertEqual(AttendeeStatus.joinedNoAudio.description, "joinedNoAudio")
         XCTAssertEqual(AttendeeStatus.left.description, "left")
         XCTAssertEqual(AttendeeStatus.dropped.description, "dropped")
     }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientControllerTests.swift
@@ -69,7 +69,8 @@ class DefaultAudioClientControllerTests: CommonTestCase {
                                                                     meetingId: meetingId,
                                                                     attendeeId: attendeeId,
                                                                     joinToken: joinToken,
-                                                                    callKitEnabled: callKitEnabled))
+                                                                    callKitEnabled: callKitEnabled,
+                                                                    audioMode: .mono))
         verify(audioLockMock.lock()).wasCalled()
         verify(audioLockMock.unlock()).wasCalled()
     }
@@ -83,7 +84,8 @@ class DefaultAudioClientControllerTests: CommonTestCase {
                                                                     meetingId: meetingId,
                                                                     attendeeId: attendeeId,
                                                                     joinToken: joinToken,
-                                                                    callKitEnabled: callKitEnabled))
+                                                                    callKitEnabled: callKitEnabled,
+                                                                    audioMode: .mono))
         verify(audioLockMock.lock()).wasCalled()
         verify(audioLockMock.unlock()).wasCalled()
     }
@@ -124,7 +126,8 @@ class DefaultAudioClientControllerTests: CommonTestCase {
                                                                 meetingId: meetingId,
                                                                 attendeeId: attendeeId,
                                                                 joinToken: joinToken,
-                                                                callKitEnabled: callKitEnabled))
+                                                                callKitEnabled: callKitEnabled,
+                                                                audioMode: .mono))
         verify(audioLockMock.lock()).wasCalled()
         verify(audioClientObserverMock.notifyAudioClientObserver(observerFunction: any())).wasCalled()
         verify(audioClientMock.startSession(self.audioHostUrl,
@@ -133,6 +136,46 @@ class DefaultAudioClientControllerTests: CommonTestCase {
                                             profileId: self.attendeeId,
                                             microphoneMute: false,
                                             speakerMute: false,
+                                            isPresenter: true,
+                                            sessionToken: self.joinToken,
+                                            audioWsUrl: self.audioFallbackUrl,
+                                            callKitEnabled: false,
+                                            appInfo: any())).wasCalled()
+        verify(eventAnalyticsControllerMock.publishEvent(name: .meetingStartRequested)).wasCalled()
+        XCTAssertEqual(.started, DefaultAudioClientController.state)
+        verify(audioLockMock.unlock()).wasCalled()
+    }
+
+    func testStartWithNoAudio_startedOk() {
+        DefaultAudioClientController.state = .initialized
+        given(audioSessionMock.getRecordPermission()).willReturn(.granted)
+        given(audioClientMock.startSession(any(),
+                                           basePort: any(),
+                                           callId: any(),
+                                           profileId: any(),
+                                           microphoneMute: any(),
+                                           speakerMute: any(),
+                                           isPresenter: any(),
+                                           sessionToken: any(),
+                                           audioWsUrl: any(),
+                                           callKitEnabled: any(),
+                                           appInfo: any())).willReturn(AUDIO_CLIENT_OK)
+
+        XCTAssertNoThrow(try defaultAudioClientController.start(audioFallbackUrl: audioFallbackUrl,
+                                                                audioHostUrl: audioHostUrlWithPort,
+                                                                meetingId: meetingId,
+                                                                attendeeId: attendeeId,
+                                                                joinToken: joinToken,
+                                                                callKitEnabled: callKitEnabled,
+                                                                audioMode: .noAudio))
+        verify(audioLockMock.lock()).wasCalled()
+        verify(audioClientObserverMock.notifyAudioClientObserver(observerFunction: any())).wasCalled()
+        verify(audioClientMock.startSession(self.audioHostUrl,
+                                            basePort: 1820,
+                                            callId: self.meetingId,
+                                            profileId: self.attendeeId,
+                                            microphoneMute: true,
+                                            speakerMute: true,
                                             isPresenter: true,
                                             sessionToken: self.joinToken,
                                             audioWsUrl: self.audioFallbackUrl,
@@ -163,7 +206,8 @@ class DefaultAudioClientControllerTests: CommonTestCase {
                                                                     meetingId: meetingId,
                                                                     attendeeId: attendeeId,
                                                                     joinToken: joinToken,
-                                                                    callKitEnabled: callKitEnabled))
+                                                                    callKitEnabled: callKitEnabled,
+                                                                    audioMode: .mono))
         verify(audioLockMock.lock()).wasCalled()
         verify(audioClientObserverMock.notifyAudioClientObserver(observerFunction: any())).wasCalled()
         verify(audioClientMock.startSession(self.audioHostUrl,

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientObserverTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientObserverTests.swift
@@ -315,12 +315,65 @@ class DefaultAudioClientObserverTests: XCTestCase {
         wait(for: [expect], timeout: defaultTimeout)
     }
 
+    func testAttendeesPresenceChanged_attendeesDidJoinWithoutAudio() {
+        let attendees = [AttendeeUpdate(profileId: attendeeId, externalUserId: externalUserId, data: 4)]
+        defaultAudioClientObserver.attendeesPresenceChanged(attendees as [Any])
+        let expect = eventually {
+            verify(mockRealTimeObserver.attendeesDidJoinWithoutAudio(attendeeInfo: any())).wasCalled()
+        }
+
+        wait(for: [expect], timeout: defaultTimeout)
+    }
+
     func testAttendeesPresenceChanged_attendeesDidJoinDuplicate() {
         let attendees = [AttendeeUpdate(profileId: attendeeId, externalUserId: externalUserId, data: 1)]
         defaultAudioClientObserver.attendeesPresenceChanged(attendees as [Any])
         defaultAudioClientObserver.attendeesPresenceChanged(attendees as [Any])
         let expect = eventually {
             verify(mockRealTimeObserver.attendeesDidJoin(attendeeInfo: any())).wasCalled(1)
+        }
+
+        wait(for: [expect], timeout: defaultTimeout)
+    }
+
+    func testAttendeesPresenceChanged_attendeesDidJoinWithoutAudioDuplicate() {
+        let attendees = [AttendeeUpdate(profileId: attendeeId, externalUserId: externalUserId, data: 4)]
+        defaultAudioClientObserver.attendeesPresenceChanged(attendees as [Any])
+        defaultAudioClientObserver.attendeesPresenceChanged(attendees as [Any])
+        let expect = eventually {
+            verify(mockRealTimeObserver.attendeesDidJoinWithoutAudio(attendeeInfo: any())).wasCalled(1)
+        }
+
+        wait(for: [expect], timeout: defaultTimeout)
+    }
+
+    func testAttendeesPresenceChanged_attendeesWithAudioRejoinedWithoutAudio() {
+        let attendeesJoinedWithAudio = [AttendeeUpdate(profileId: attendeeId, externalUserId: externalUserId, data: 1)]
+        let attendeesLeft = [AttendeeUpdate(profileId: attendeeId, externalUserId: externalUserId, data: 2)]
+        let attendeesJoinedWithoutAudio = [AttendeeUpdate(profileId: attendeeId, externalUserId: externalUserId, data: 4)]
+        defaultAudioClientObserver.attendeesPresenceChanged(attendeesJoinedWithAudio as [Any])
+        defaultAudioClientObserver.attendeesPresenceChanged(attendeesLeft as [Any])
+        defaultAudioClientObserver.attendeesPresenceChanged(attendeesJoinedWithoutAudio as [Any])
+        let expect = eventually {
+            verify(mockRealTimeObserver.attendeesDidJoin(attendeeInfo: any())).wasCalled()
+            verify(mockRealTimeObserver.attendeesDidLeave(attendeeInfo: any())).wasCalled()
+            verify(mockRealTimeObserver.attendeesDidJoinWithoutAudio(attendeeInfo: any())).wasCalled()
+        }
+
+        wait(for: [expect], timeout: defaultTimeout)
+    }
+
+    func testAttendeesPresenceChanged_attendeesWithoutAudioRejoinedWithAudio() {
+        let attendeesJoinedWithoutAudio = [AttendeeUpdate(profileId: attendeeId, externalUserId: externalUserId, data: 4)]
+        let attendeesLeft = [AttendeeUpdate(profileId: attendeeId, externalUserId: externalUserId, data: 2)]
+        let attendeesJoinedWithAudio = [AttendeeUpdate(profileId: attendeeId, externalUserId: externalUserId, data: 1)]
+        defaultAudioClientObserver.attendeesPresenceChanged(attendeesJoinedWithoutAudio as [Any])
+        defaultAudioClientObserver.attendeesPresenceChanged(attendeesLeft as [Any])
+        defaultAudioClientObserver.attendeesPresenceChanged(attendeesJoinedWithAudio as [Any])
+        let expect = eventually {
+            verify(mockRealTimeObserver.attendeesDidJoinWithoutAudio(attendeeInfo: any())).wasCalled()
+            verify(mockRealTimeObserver.attendeesDidLeave(attendeeInfo: any())).wasCalled()
+            verify(mockRealTimeObserver.attendeesDidJoin(attendeeInfo: any())).wasCalled()
         }
 
         wait(for: [expect], timeout: defaultTimeout)

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
@@ -15,17 +15,17 @@
             <objects>
                 <viewController storyboardIdentifier="main" id="BYZ-38-t0r" customClass="JoiningViewController" customModule="AmazonChimeSDKDemo" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Join a meeting" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UUz-34-lb9">
-                                <rect key="frame" x="8" y="233" width="398" height="48"/>
+                                <rect key="frame" x="8" y="313" width="398" height="48"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="40"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Your Name" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="osX-FD-I0Z">
-                                <rect key="frame" x="109" y="351" width="196" height="34"/>
+                                <rect key="frame" x="109" y="431" width="196" height="34"/>
                                 <accessibility key="accessibilityConfiguration" identifier="Name Input">
                                     <bool key="isElement" value="YES"/>
                                 </accessibility>
@@ -36,7 +36,7 @@
                                 <textInputTraits key="textInputTraits" returnKeyType="done"/>
                             </textField>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Meeting ID" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="s6f-Ei-sAf">
-                                <rect key="frame" x="109" y="301" width="196" height="34"/>
+                                <rect key="frame" x="109" y="381" width="196" height="34"/>
                                 <accessibility key="accessibilityConfiguration" identifier="Meeting Id Input">
                                     <bool key="isElement" value="YES"/>
                                 </accessibility>
@@ -47,7 +47,7 @@
                                 <textInputTraits key="textInputTraits" returnKeyType="done"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="version" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9bX-Kc-eHT">
-                                <rect key="frame" x="16" y="705.66666666666663" width="382" height="14.333333333333371"/>
+                                <rect key="frame" x="16" y="831.66666666666663" width="382" height="14.333333333333371"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <color key="textColor" systemColor="secondaryLabelColor"/>
                                 <nil key="highlightedColor"/>
@@ -82,7 +82,7 @@
                                     </stackView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EBv-5d-gOg">
                                         <rect key="frame" x="130.66666666666666" y="121" width="89" height="30"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="Join Meeting"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="Join Without CallKit"/>
                                         <state key="normal" title="Join Meeting"/>
                                         <connections>
                                             <action selector="joinButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="WSb-T2-ggJ"/>
@@ -91,7 +91,7 @@
                                 </subviews>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="66Y-WJ-mRM">
-                                <rect key="frame" x="268" y="16" width="106" height="30"/>
+                                <rect key="frame" x="268" y="60" width="106" height="30"/>
                                 <accessibility key="accessibilityConfiguration" identifier="Debug Settings Button"/>
                                 <state key="normal" title="Debug Settings"/>
                                 <connections>
@@ -139,11 +139,11 @@
             <objects>
                 <viewController storyboardIdentifier="deviceSelection" id="Sfo-A7-USF" customClass="DeviceSelectionViewController" customModule="AmazonChimeSDKDemo" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="qB1-9y-yO7">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" directionalLockEnabled="YES" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="alh-Ag-Wwk">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="GdK-eP-aSg">
                                         <rect key="frame" x="10" y="0.0" width="394" height="570"/>
@@ -302,11 +302,11 @@
             <objects>
                 <viewController storyboardIdentifier="meeting" id="ur0-O1-pag" customClass="MeetingViewController" customModule="AmazonChimeSDKDemo" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="rf5-Vm-CUa">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BqF-z3-tHA">
-                                <rect key="frame" x="117" y="353" width="180" height="30"/>
+                                <rect key="frame" x="117" y="433" width="180" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="30" id="2eH-eX-B0v"/>
                                     <constraint firstAttribute="width" constant="180" id="eEc-sL-adM"/>
@@ -317,13 +317,13 @@
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dQc-r8-tDl" userLabel="Main View">
-                                <rect key="frame" x="0.0" y="101" width="414" height="526"/>
+                                <rect key="frame" x="0.0" y="145" width="414" height="608"/>
                                 <subviews>
                                     <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RGo-2N-w2S" userLabel="Chat View">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="526"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="608"/>
                                         <subviews>
                                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="SDw-oV-14H" userLabel="Chat Message Table">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="482"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="564"/>
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <prototypes>
                                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="chatMessageCell" rowHeight="150" id="IR1-ov-bzI" customClass="ChatMessageCell" customModule="AmazonChimeSDKDemo" customModuleProvider="target">
@@ -376,7 +376,7 @@
                                                 </prototypes>
                                             </tableView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EWw-5H-SAI" userLabel="InputBox">
-                                                <rect key="frame" x="0.0" y="482" width="414" height="44"/>
+                                                <rect key="frame" x="0.0" y="564" width="414" height="44"/>
                                                 <subviews>
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="WYB-Q9-vWU" userLabel="InputText">
                                                         <rect key="frame" x="8" y="0.0" width="326" height="44"/>
@@ -428,7 +428,7 @@
                                         </constraints>
                                     </view>
                                     <tableView clipsSubviews="YES" alpha="0.89999997615814209" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Y06-YL-yNg" userLabel="RosterTableView">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="526"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="608"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="rosterCell" rowHeight="87" id="oOQ-i3-TjW" customClass="RosterTableCell" customModule="AmazonChimeSDKDemo" customModuleProvider="target">
@@ -482,7 +482,7 @@
                                         </prototypes>
                                     </tableView>
                                     <collectionView hidden="YES" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="G6J-Ye-SbE">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="496"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="578"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="fpZ-c9-viK">
                                             <size key="itemSize" width="313" height="161"/>
@@ -598,7 +598,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </collectionView>
                                     <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="djd-pl-UBe" userLabel="VideoPaginationControlView">
-                                        <rect key="frame" x="0.0" y="496" width="414" height="30"/>
+                                        <rect key="frame" x="0.0" y="578" width="414" height="30"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="KsI-Gl-67W">
                                                 <rect key="frame" x="0.0" y="0.0" width="414" height="30"/>
@@ -632,16 +632,16 @@
                                         </constraints>
                                     </view>
                                     <view hidden="YES" multipleTouchEnabled="YES" contentMode="scaleAspectFit" preservesSuperviewLayoutMargins="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hHc-wX-fkV" userLabel="ScreenView">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="526"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="608"/>
                                         <subviews>
                                             <view hidden="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" translatesAutoresizingMaskIntoConstraints="NO" id="GTP-ih-O5E" userLabel="Screen Render View" customClass="DefaultVideoRenderView" customModule="AmazonChimeSDK">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="526"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="608"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="ScreenTile">
                                                     <bool key="isElement" value="YES"/>
                                                 </accessibility>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No screen share available" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RYz-O1-Yy3">
-                                                <rect key="frame" x="95.666666666666686" y="251" width="223" height="24"/>
+                                                <rect key="frame" x="95.666666666666686" y="292" width="223" height="24"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -658,7 +658,7 @@
                                         </constraints>
                                     </view>
                                     <tableView hidden="YES" clipsSubviews="YES" alpha="0.89999997615814209" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="7W8-Lm-wB8" userLabel="MetricsTableView">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="526"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="608"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="metricsCell" rowHeight="87" id="ScO-Sx-PnT" userLabel="metricsCell" customClass="MetricsTableCell" customModule="AmazonChimeSDKDemo" customModuleProvider="target">
@@ -704,7 +704,7 @@
                                         </prototypes>
                                     </tableView>
                                     <tableView hidden="YES" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="qMs-8n-X6I">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="526"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="608"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="captionCell" id="8aS-kd-Jde" customClass="CaptionCell" customModule="AmazonChimeSDKDemo" customModuleProvider="target">
@@ -785,7 +785,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Vyk-AZ-EWL" userLabel="Tab View">
-                                <rect key="frame" x="22" y="60" width="370" height="33"/>
+                                <rect key="frame" x="22" y="104" width="370" height="33"/>
                                 <subviews>
                                     <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" apportionsSegmentWidthsByContent="YES" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="ZED-i9-VcT" userLabel="Segmented Control">
                                         <rect key="frame" x="-10" y="0.0" width="390" height="34"/>
@@ -814,7 +814,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Xda-Kr-nXi" userLabel="Control View">
-                                <rect key="frame" x="4" y="635" width="406" height="44"/>
+                                <rect key="frame" x="4" y="761" width="406" height="44"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="l0A-Sg-Q3r">
                                         <rect key="frame" x="0.0" y="0.0" width="406" height="44"/>
@@ -893,7 +893,7 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="74m-cS-BUB" userLabel="Heading View">
-                                <rect key="frame" x="0.0" y="8" width="414" height="44"/>
+                                <rect key="frame" x="0.0" y="52" width="414" height="44"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Meeting#" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DdL-aA-lof">
                                         <rect key="frame" x="15.999999999999993" y="0.0" width="116.33333333333331" height="44"/>
@@ -977,10 +977,10 @@
             <objects>
                 <viewController storyboardIdentifier="liveTranscription" title="Live Transcriptions View Controller" useStoryboardIdentifierAsRestorationIdentifier="YES" id="oIM-X0-54O" customClass="LiveTranscriptionOptionsViewController" customModule="AmazonChimeSDKDemo" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ogQ-aQ-X61">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <subviews>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HAa-I4-bUz">
-                                <rect key="frame" x="30" y="164" width="354" height="34"/>
+                                <rect key="frame" x="30" y="208" width="354" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
@@ -990,7 +990,7 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xQi-rK-PWV">
-                                <rect key="frame" x="30" y="651" width="354" height="30"/>
+                                <rect key="frame" x="30" y="777" width="354" height="30"/>
                                 <accessibility key="accessibilityConfiguration" identifier="Start Transcription"/>
                                 <state key="normal" title="Start Transcription"/>
                                 <connections>
@@ -998,7 +998,7 @@
                                 </connections>
                             </button>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="center" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="UPV-0s-G4L">
-                                <rect key="frame" x="30" y="100" width="354" height="34"/>
+                                <rect key="frame" x="30" y="144" width="354" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
@@ -1036,18 +1036,18 @@
             <objects>
                 <viewController storyboardIdentifier="debugSettings" id="GpE-ar-Sxz" customClass="DebugSettingsViewController" customModule="AmazonChimeSDKDemo" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="F9N-fz-NNe">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Override Meeting Endpoint" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ugh-Cp-DHh">
-                                <rect key="frame" x="104.66666666666669" y="357.66666666666669" width="205" height="21"/>
+                                <rect key="frame" x="104.66666666666669" y="437.66666666666669" width="205" height="21"/>
                                 <accessibility key="accessibilityConfiguration" identifier="Override Meeting Endpoint Label"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Meeting Endpoint Url" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HWT-wf-Hd8">
-                                <rect key="frame" x="77" y="402.66666666666669" width="260" height="34"/>
+                                <rect key="frame" x="77" y="482.66666666666669" width="260" height="34.000000000000057"/>
                                 <accessibility key="accessibilityConfiguration" identifier="Meeting Endpoint Url Input"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="260" id="sRN-0P-oTP"/>
@@ -1056,14 +1056,14 @@
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Debug Settings" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dlf-w7-2eY">
-                                <rect key="frame" x="113.66666666666669" y="283.66666666666669" width="187" height="34"/>
+                                <rect key="frame" x="113.66666666666669" y="363.66666666666669" width="187" height="34"/>
                                 <accessibility key="accessibilityConfiguration" identifier="Debug Settings Title"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="28"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AHd-Vp-rMm">
-                                <rect key="frame" x="181.66666666666666" y="663" width="51" height="41"/>
+                                <rect key="frame" x="181.66666666666666" y="789" width="51" height="41"/>
                                 <accessibility key="accessibilityConfiguration" identifier="Debug Settings Save"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="24"/>
                                 <state key="normal" title="Save"/>

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina5_5" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -52,31 +52,40 @@
                                 <color key="textColor" systemColor="secondaryLabelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="U4C-4u-Vzl" userLabel="Button Stack View">
-                                <rect key="frame" x="87" y="397" width="240" height="110"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="U4C-4u-Vzl" userLabel="Join Config">
+                                <rect key="frame" x="32" y="477" width="350" height="151"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SCO-KH-TkU" userLabel="Join without CallKit Button">
-                                        <rect key="frame" x="0.0" y="0.0" width="240" height="30"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="Join Without CallKit"/>
-                                        <state key="normal" title="Join without CallKit"/>
+                                    <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="j1Y-t4-xgU">
+                                        <rect key="frame" x="0.0" y="0.0" width="350" height="70"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="CallKit Options">
+                                            <bool key="isElement" value="YES"/>
+                                        </accessibility>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="350" id="4Eg-u0-9f6"/>
+                                            <constraint firstAttribute="height" constant="70" id="RZy-gv-cbQ"/>
+                                        </constraints>
+                                    </pickerView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="57w-s6-L9Q" userLabel="Audio Config">
+                                        <rect key="frame" x="75.000000000000014" y="80" width="200.33333333333337" height="31"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Audio output/input" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8Hk-p1-iUS">
+                                                <rect key="frame" x="0.0" y="0.0" width="141.33333333333334" height="31"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="P7T-QG-xAv">
+                                                <rect key="frame" x="151.33333333333331" y="0.0" width="51" height="31"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="Audio Switch"/>
+                                            </switch>
+                                        </subviews>
+                                    </stackView>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="EBv-5d-gOg">
+                                        <rect key="frame" x="130.66666666666666" y="121" width="89" height="30"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="Join Meeting"/>
+                                        <state key="normal" title="Join Meeting"/>
                                         <connections>
-                                            <action selector="joinWithoutCallKitButtonClicked:" destination="BYZ-38-t0r" eventType="touchUpInside" id="zJh-Ks-Sbt"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5eE-Oj-duC" userLabel="Join with CallKit as Incoming Button">
-                                        <rect key="frame" x="0.0" y="40" width="240" height="30"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="Join CallKit Incoming"/>
-                                        <state key="normal" title="Join with CallKit as Incoming in 10s"/>
-                                        <connections>
-                                            <action selector="joinAsIncomingCallButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="HoE-bj-dWO"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Alk-Rp-DLi" userLabel="Join with CallKit as Outgoing Button">
-                                        <rect key="frame" x="0.0" y="80" width="240" height="30"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="Join CallKit Outgoing"/>
-                                        <state key="normal" title="Join with CallKit as Outgoing"/>
-                                        <connections>
-                                            <action selector="joinAsOutgoingCallButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="HJW-oH-3iN"/>
+                                            <action selector="joinButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="WSb-T2-ggJ"/>
                                         </connections>
                                     </button>
                                 </subviews>
@@ -112,10 +121,10 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="audioSwitch" destination="P7T-QG-xAv" id="vDM-Tm-cqb"/>
+                        <outlet property="callKitOptionsPicker" destination="j1Y-t4-xgU" id="aLn-e0-4WW"/>
                         <outlet property="debugSettingsButton" destination="66Y-WJ-mRM" id="eul-Gi-QFC"/>
-                        <outlet property="joinAsIncomingCallButton" destination="5eE-Oj-duC" id="GP7-uN-Zir"/>
-                        <outlet property="joinAsOutgoingCallButton" destination="Alk-Rp-DLi" id="Jax-Of-5sG"/>
-                        <outlet property="joinWithoutCallKitButton" destination="SCO-KH-TkU" id="YnN-ti-7uX"/>
+                        <outlet property="joinButton" destination="EBv-5d-gOg" id="FfN-4U-iAy"/>
                         <outlet property="meetingIdTextField" destination="s6f-Ei-sAf" id="vmx-Lh-C7I"/>
                         <outlet property="nameTextField" destination="osX-FD-I0Z" id="lFR-t4-JOi"/>
                         <outlet property="versionLabel" destination="9bX-Kc-eHT" id="M1d-QC-GNU"/>
@@ -276,6 +285,7 @@
                     <toolbarItems/>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
+                        <outlet property="audioDeviceLabel" destination="Jt4-1L-aqf" id="po2-eh-wum"/>
                         <outlet property="audioDevicePicker" destination="ibL-Lh-i5w" id="Ni4-3h-Ayi"/>
                         <outlet property="joinButton" destination="Qc7-Qf-8m1" id="leg-wf-FcV"/>
                         <outlet property="videoDevicePicker" destination="93n-jX-4CD" id="I7q-g4-uRR"/>
@@ -317,7 +327,7 @@
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <prototypes>
                                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="chatMessageCell" rowHeight="150" id="IR1-ov-bzI" customClass="ChatMessageCell" customModule="AmazonChimeSDKDemo" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="24.333333969116211" width="414" height="150"/>
+                                                        <rect key="frame" x="0.0" y="28" width="414" height="150"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="IR1-ov-bzI" id="jwj-GW-jrz">
                                                             <rect key="frame" x="0.0" y="0.0" width="414" height="150"/>
@@ -422,7 +432,7 @@
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="rosterCell" rowHeight="87" id="oOQ-i3-TjW" customClass="RosterTableCell" customModule="AmazonChimeSDKDemo" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="24.333333969116211" width="414" height="87"/>
+                                                <rect key="frame" x="0.0" y="28" width="414" height="87"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="oOQ-i3-TjW" id="yy8-Oi-9EV">
                                                     <rect key="frame" x="0.0" y="0.0" width="414" height="87"/>
@@ -652,7 +662,7 @@
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="metricsCell" rowHeight="87" id="ScO-Sx-PnT" userLabel="metricsCell" customClass="MetricsTableCell" customModule="AmazonChimeSDKDemo" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="24.333333969116211" width="414" height="87"/>
+                                                <rect key="frame" x="0.0" y="28" width="414" height="87"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ScO-Sx-PnT" id="XjQ-XE-b0u">
                                                     <rect key="frame" x="0.0" y="0.0" width="414" height="87"/>
@@ -698,7 +708,7 @@
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="captionCell" id="8aS-kd-Jde" customClass="CaptionCell" customModule="AmazonChimeSDKDemo" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="24.333333969116211" width="414" height="39.333332061767578"/>
+                                                <rect key="frame" x="0.0" y="28" width="414" height="39.333332061767578"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8aS-kd-Jde" id="4gI-K8-L7e">
                                                     <rect key="frame" x="0.0" y="0.0" width="414" height="39.333332061767578"/>
@@ -886,7 +896,7 @@
                                 <rect key="frame" x="0.0" y="8" width="414" height="44"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Meeting#" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DdL-aA-lof">
-                                        <rect key="frame" x="16.000000000000007" y="0.0" width="103.66666666666669" height="44"/>
+                                        <rect key="frame" x="15.999999999999993" y="0.0" width="116.33333333333331" height="44"/>
                                         <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <accessibility key="accessibilityConfiguration">
                                             <accessibilityTraits key="traits" staticText="YES" header="YES"/>

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DeviceSelectionModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DeviceSelectionModel.swift
@@ -13,6 +13,7 @@ class DeviceSelectionModel {
     let audioDevices: [MediaDevice]
     let videoDevices: [MediaDevice]
     let cameraCaptureSource: DefaultCameraCaptureSource
+    let audioVideoConfig: AudioVideoConfiguration
 
     lazy var supportedVideoFormat: [[VideoCaptureFormat]] = {
         self.videoDevices.map { videoDevice in
@@ -57,11 +58,12 @@ class DeviceSelectionModel {
         return selectedVideoDevice?.type == MediaDeviceType.videoFrontCamera
     }
 
-    init(deviceController: DeviceController, cameraCaptureSource: DefaultCameraCaptureSource) {
+    init(deviceController: DeviceController, cameraCaptureSource: DefaultCameraCaptureSource, audioVideoConfig: AudioVideoConfiguration) {
         audioDevices = deviceController.listAudioDevices()
         // Reverse these so the front camera is the initial choice
         videoDevices = MediaDevice.listVideoDevices().reversed()
         self.cameraCaptureSource = cameraCaptureSource
+        self.audioVideoConfig = audioVideoConfig
         cameraCaptureSource.device = selectedVideoDevice
         guard let selectedVideoFormat = selectedVideoFormat else { return }
         cameraCaptureSource.format = selectedVideoFormat

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DeviceSelectionViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DeviceSelectionViewController.swift
@@ -10,6 +10,7 @@ import AmazonChimeSDK
 import UIKit
 
 class DeviceSelectionViewController: UIViewController {
+    @IBOutlet var audioDeviceLabel: UILabel!
     @IBOutlet var audioDevicePicker: UIPickerView!
     @IBOutlet var videoDevicePicker: UIPickerView!
     @IBOutlet var videoFormatPicker: UIPickerView!
@@ -27,6 +28,10 @@ class DeviceSelectionViewController: UIViewController {
         videoDevicePicker.dataSource = self
         videoFormatPicker.delegate = self
         videoFormatPicker.dataSource = self
+
+        /// Update the visibility of Audio Device selection based on the audio mode
+        updateAudioState(audioEnabled: model?.audioVideoConfig.audioMode != .noAudio)
+
         videoPreviewImageView.mirror = model?.shouldMirrorPreview ?? false
         model?.cameraCaptureSource.addVideoSink(sink: videoPreviewImageView)
         model?.cameraCaptureSource.start()
@@ -39,6 +44,11 @@ class DeviceSelectionViewController: UIViewController {
         model.cameraCaptureSource.stop()
         model.cameraCaptureSource.removeVideoSink(sink: videoPreviewImageView)
         MeetingModule.shared().deviceSelected(model)
+    }
+
+    private func updateAudioState(audioEnabled: Bool) {
+        audioDeviceLabel.isHidden = !audioEnabled
+        audioDevicePicker.isHidden = !audioEnabled
     }
 }
 

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/JoiningViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/JoiningViewController.swift
@@ -40,7 +40,7 @@ class JoiningViewController: UIViewController, UITextFieldDelegate {
 
     override func viewWillAppear(_: Bool) {
         callKitOptionsPicker.selectRow(0, inComponent: 0, animated: false)
-        enableJoinButton(isEnabled: true)
+        joinButton.isEnabled = true
     }
 
     @IBAction func joinButton(_: UIButton) {
@@ -81,10 +81,6 @@ class JoiningViewController: UIViewController, UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         return true
-    }
-
-    private func enableJoinButton(isEnabled: Bool) {
-        joinButton.isEnabled = isEnabled
     }
 
     func joinMeeting(audioVideoConfig: AudioVideoConfiguration, callKitOption: CallKitOption) {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/JoiningViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/JoiningViewController.swift
@@ -15,10 +15,12 @@ class JoiningViewController: UIViewController, UITextFieldDelegate {
     @IBOutlet var meetingIdTextField: UITextField!
     @IBOutlet var nameTextField: UITextField!
     @IBOutlet var versionLabel: UILabel!
-    @IBOutlet var joinWithoutCallKitButton: UIButton!
-    @IBOutlet var joinAsIncomingCallButton: UIButton!
-    @IBOutlet var joinAsOutgoingCallButton: UIButton!
+    @IBOutlet var callKitOptionsPicker: UIPickerView!
+    @IBOutlet var audioSwitch: UISwitch!
+    @IBOutlet var joinButton: UIButton!
     @IBOutlet var debugSettingsButton: UIButton!
+
+    var callKitOptions = ["Don't use CallKit", "CallKit as Incoming in 10s", "CallKit as Outgoing"]
 
     private let toastDisplayDuration = 2.0
     private let mainStoryboard = UIStoryboard(name: "Main", bundle: nil)
@@ -29,26 +31,41 @@ class JoiningViewController: UIViewController, UITextFieldDelegate {
         meetingIdTextField.delegate = self
         nameTextField.delegate = self
 
+        callKitOptionsPicker.delegate = self
+        callKitOptionsPicker.dataSource = self
+
         setupHideKeyboardOnTap()
         versionLabel.text = "amazon-chime-sdk-ios@\(Versioning.sdkVersion())"
     }
 
     override func viewWillAppear(_: Bool) {
-        setJoinButtons(isEnabled: true)
+        callKitOptionsPicker.selectRow(0, inComponent: 0, animated: false)
+        enableJoinButton(isEnabled: true)
     }
 
-    @IBAction func joinWithoutCallKitButtonClicked(_: UIButton) {
-        joinMeeting(callKitOption: .disabled)
-    }
+    @IBAction func joinButton(_: UIButton) {
+        // CallKit Option
+        var callKitOption: CallKitOption = .disabled
+        switch callKitOptionsPicker.selectedRow(inComponent: 0) {
+        case 1:
+            callKitOption = .incoming
+            view.makeToast("You can background the app or lock screen while waiting",
+                           duration: incomingCallKitDelayInSeconds)
+        case 2:
+            callKitOption = .outgoing
+        default:
+            callKitOption = .disabled
+        }
 
-    @IBAction func joinAsIncomingCallButton(_: UIButton) {
-        view.makeToast("You can background the app or lock screen while waiting",
-                       duration: incomingCallKitDelayInSeconds)
-        joinMeeting(callKitOption: .incoming)
-    }
+        // Audio Mode
+        var audioMode: AudioMode = .mono
+        if !audioSwitch.isOn {
+            audioMode = .noAudio
+        }
 
-    @IBAction func joinAsOutgoingCallButton(_: UIButton) {
-        joinMeeting(callKitOption: .outgoing)
+        joinMeeting(audioVideoConfig: AudioVideoConfiguration(audioMode: audioMode, callKitEnabled: callKitOption != .disabled),
+                    callKitOption: callKitOption
+        )
     }
 
     @IBAction func debugSettingsButtonClicked (_: UIButton) {
@@ -66,13 +83,11 @@ class JoiningViewController: UIViewController, UITextFieldDelegate {
         return true
     }
 
-    private func setJoinButtons(isEnabled: Bool) {
-        joinWithoutCallKitButton.isEnabled = isEnabled
-        joinAsIncomingCallButton.isEnabled = isEnabled
-        joinAsOutgoingCallButton.isEnabled = isEnabled
+    private func enableJoinButton(isEnabled: Bool) {
+        joinButton.isEnabled = isEnabled
     }
 
-    func joinMeeting(callKitOption: CallKitOption) {
+    func joinMeeting(audioVideoConfig: AudioVideoConfiguration, callKitOption: CallKitOption) {
         view.endEditing(true)
         let meetingId = meetingIdTextField.text ?? ""
         let name = nameTextField.text ?? ""
@@ -87,6 +102,7 @@ class JoiningViewController: UIViewController, UITextFieldDelegate {
 
         MeetingModule.shared().prepareMeeting(meetingId: meetingId,
                                               selfName: name,
+                                              audioVideoConfig: audioVideoConfig,
                                               option: callKitOption,
                                               overriddenEndpoint: debugSettingsModel.endpointUrl) { success in
             DispatchQueue.main.async {
@@ -97,5 +113,24 @@ class JoiningViewController: UIViewController, UITextFieldDelegate {
                 }
             }
         }
+    }
+}
+
+extension JoiningViewController: UIPickerViewDelegate {
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent _: Int) -> String? {
+        if row >= callKitOptions.count {
+            return nil
+        }
+        return callKitOptions[row]
+    }
+}
+
+extension JoiningViewController: UIPickerViewDataSource {
+    func numberOfComponents(in _: UIPickerView) -> Int {
+        return 1
+    }
+
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent _: Int) -> Int {
+        return callKitOptions.count
     }
 }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -24,6 +24,7 @@ class MeetingModel: NSObject {
     // Dependencies
     let meetingId: String
     let selfName: String
+    var audioVideoConfig = AudioVideoConfiguration()
     let callKitOption: CallKitOption
     let meetingSessionConfig: MeetingSessionConfiguration
     lazy var currentMeetingSession = DefaultMeetingSession(configuration: meetingSessionConfig,
@@ -43,7 +44,8 @@ class MeetingModel: NSObject {
                                                  contentShareController: currentMeetingSession.audioVideo)
     let chatModel = ChatModel()
     lazy var deviceSelectionModel = DeviceSelectionModel(deviceController: currentMeetingSession.audioVideo,
-                                                         cameraCaptureSource: videoModel.customSource)
+                                                         cameraCaptureSource: videoModel.customSource,
+                                                         audioVideoConfig: audioVideoConfig)
     let captionsModel = CaptionsModel()
     let uuid = UUID()
     var call: Call?
@@ -121,9 +123,11 @@ class MeetingModel: NSObject {
     init(meetingSessionConfig: MeetingSessionConfiguration,
          meetingId: String,
          selfName: String,
+         audioVideoConfig: AudioVideoConfiguration,
          callKitOption: CallKitOption) {
         self.meetingId = meetingId
         self.selfName = selfName
+        self.audioVideoConfig = audioVideoConfig
         self.callKitOption = callKitOption
         self.meetingSessionConfig = meetingSessionConfig
         let url = AppConfiguration.url.hasSuffix("/") ? AppConfiguration.url : "\(AppConfiguration.url)/"
@@ -144,7 +148,7 @@ class MeetingModel: NSObject {
     func startMeeting() {
         if self.callKitOption == .disabled {
             self.configureAudioSession()
-            self.startAudioVideoConnection(isCallKitEnabled: false)
+            self.startAudioVideoConnection()
             self.currentMeetingSession.audioVideo.startRemoteVideo()
         }
         screenShareModel.broadcastCaptureModel.isBlocked = false
@@ -295,10 +299,10 @@ class MeetingModel: NSObject {
         MeetingModule.shared().configureAudioSession()
     }
 
-    private func startAudioVideoConnection(isCallKitEnabled: Bool) {
+    private func startAudioVideoConnection() {
         do {
             setupAudioVideoFacadeObservers()
-            try currentMeetingSession.audioVideo.start(callKitEnabled: isCallKitEnabled)
+            try currentMeetingSession.audioVideo.start(audioVideoConfiguration: audioVideoConfig)
         } catch {
             logger.error(msg: "Error starting the Meeting: \(error.localizedDescription)")
             endMeeting()
@@ -323,7 +327,7 @@ class MeetingModel: NSObject {
             self?.configureAudioSession()
         }
         call.isAudioSessionActiveHandler = { [weak self] in
-            self?.startAudioVideoConnection(isCallKitEnabled: true)
+            self?.startAudioVideoConnection()
             self?.currentMeetingSession.audioVideo.startRemoteVideo()
             if self?.isMuted ?? false {
                 _ = self?.currentMeetingSession.audioVideo.realtimeLocalMute()
@@ -442,9 +446,46 @@ extension MeetingModel: AudioVideoObserver {
 // MARK: RealtimeObserver
 
 extension MeetingModel: RealtimeObserver {
+    private func isSelfAttendee(attendeeId: String) -> Bool {
+        return DefaultModality(id: attendeeId).base == meetingSessionConfig.credentials.attendeeId
+    }
+
     private func removeAttendeesAndReload(attendeeInfo: [AttendeeInfo]) {
         let attendeeIds = attendeeInfo.map { $0.attendeeId }
         rosterModel.removeAttendees(attendeeIds)
+        if activeMode == .roster {
+            rosterModel.rosterUpdatedHandler?()
+        }
+    }
+
+    private func attendeesDidJoinWithStatus(attendeeInfo: [AttendeeInfo], status: AttendeeStatus) {
+        var newAttendees = [RosterAttendee]()
+        for currentAttendeeInfo in attendeeInfo {
+            let attendeeId = currentAttendeeInfo.attendeeId
+            if !rosterModel.contains(attendeeId: attendeeId) {
+                let attendeeName = RosterModel.convertAttendeeName(from: currentAttendeeInfo)
+                let newAttendee = RosterAttendee(attendeeId: attendeeId,
+                                                 attendeeName: attendeeName,
+                                                 volume: .notSpeaking,
+                                                 signal: .high,
+                                                 attendeeStatus: status)
+                newAttendees.append(newAttendee)
+                var action = "Joined"
+                if status == .joinedNoAudio {
+                    action = "JoinedNoAudio"
+                }
+                logger.info(msg: "attendeeId:\(currentAttendeeInfo.attendeeId) externalUserId:\(currentAttendeeInfo.externalUserId) \(action)")
+
+                // if other attendee starts sharing content, stop content sharing from current device
+                let modality = DefaultModality(id: attendeeId)
+                if modality.isOfType(type: .content),
+                   !isSelfAttendee(attendeeId: attendeeId) {
+                    screenShareModel.stopLocalSharing()
+                    notifyHandler?("\(rosterModel.getAttendeeName(for: modality.base) ?? "") took over the screen share")
+                }
+            }
+        }
+        rosterModel.addAttendees(newAttendees)
         if activeMode == .roster {
             rosterModel.rosterUpdatedHandler?()
         }
@@ -493,31 +534,11 @@ extension MeetingModel: RealtimeObserver {
     }
 
     func attendeesDidJoin(attendeeInfo: [AttendeeInfo]) {
-        var newAttendees = [RosterAttendee]()
-        for currentAttendeeInfo in attendeeInfo {
-            let attendeeId = currentAttendeeInfo.attendeeId
-            if !rosterModel.contains(attendeeId: attendeeId) {
-                let attendeeName = RosterModel.convertAttendeeName(from: currentAttendeeInfo)
-                let newAttendee = RosterAttendee(attendeeId: attendeeId,
-                                                 attendeeName: attendeeName,
-                                                 volume: .notSpeaking,
-                                                 signal: .high)
-                newAttendees.append(newAttendee)
+        attendeesDidJoinWithStatus(attendeeInfo: attendeeInfo, status: AttendeeStatus.joined)
+    }
 
-                // if other attendee starts sharing content, stop content sharing from current device
-                let modality = DefaultModality(id: attendeeId)
-                if modality.isOfType(type: .content),
-                   modality.base != meetingSessionConfig.credentials.attendeeId {
-
-                    screenShareModel.stopLocalSharing()
-                    notifyHandler?("\(rosterModel.getAttendeeName(for: modality.base) ?? "") took over the screen share")
-                }
-            }
-        }
-        rosterModel.addAttendees(newAttendees)
-        if activeMode == .roster {
-            rosterModel.rosterUpdatedHandler?()
-        }
+    func attendeesDidJoinWithoutAudio(attendeeInfo: [AttendeeInfo]) {
+        attendeesDidJoinWithStatus(attendeeInfo: attendeeInfo, status: AttendeeStatus.joinedNoAudio)
     }
 }
 

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModule.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModule.swift
@@ -31,6 +31,7 @@ class MeetingModule {
 
     func prepareMeeting(meetingId: String,
                         selfName: String,
+                        audioVideoConfig: AudioVideoConfiguration,
                         option: CallKitOption,
                         overriddenEndpoint: String,
                         completion: @escaping (Bool) -> Void) {
@@ -51,6 +52,7 @@ class MeetingModule {
                 let meetingModel = MeetingModel(meetingSessionConfig: meetingSessionConfig,
                                                 meetingId: meetingId,
                                                 selfName: selfName,
+                                                audioVideoConfig: audioVideoConfig,
                                                 callKitOption: option)
                 self.meetings[meetingModel.uuid] = meetingModel
 

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -204,6 +204,9 @@ class MeetingViewController: UIViewController {
         prevVideoPageButton.isEnabled = false
         nextVideoPageButton.isEnabled = false
 
+        // Update Audio state i.e Mic and Speaker based on the audio mode
+        updateLocalAttendeeAudioState(audioEnabled: meetingModel?.audioVideoConfig.audioMode != .noAudio)
+
         // Segmented Controler
         segmentedControl.selectedSegmentIndex = SegmentedControlIndex.attendees.rawValue
 
@@ -238,6 +241,11 @@ class MeetingViewController: UIViewController {
                 setupBroadcastPickerView()
             }
         #endif
+    }
+
+    private func updateLocalAttendeeAudioState(audioEnabled: Bool) {
+        muteButton.isHidden = !audioEnabled
+        deviceButton.isHidden = !audioEnabled
     }
 
     // RPSystemBroadcastPickerView

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/RosterTableCell.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/RosterTableCell.swift
@@ -39,7 +39,11 @@ class RosterTableCell: UITableViewCell {
         indicator.layer.cornerRadius = indicator.frame.size.width / 2.0
         speakLevel.tintColor = .systemGray
 
-        speakLevel.image = getSpeakLevelImage(signal: attendee.signal, volume: attendee.volume)
+        let audioEnabled = attendee.attendeeStatus == .joined
+        speakLevel.isHidden = !audioEnabled
+        if audioEnabled {
+            speakLevel.image = getSpeakLevelImage(signal: attendee.signal, volume: attendee.volume)
+        }
     }
 
     private func getSpeakLevelImage(signal: SignalStrength, volume: VolumeLevel) -> UIImage? {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/data/RosterAttendee.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/data/RosterAttendee.swift
@@ -14,11 +14,13 @@ public class RosterAttendee {
     let attendeeName: String?
     var volume: VolumeLevel
     var signal: SignalStrength
+    var attendeeStatus: AttendeeStatus
 
-    init(attendeeId: String, attendeeName: String, volume: VolumeLevel, signal: SignalStrength) {
+    init(attendeeId: String, attendeeName: String, volume: VolumeLevel, signal: SignalStrength, attendeeStatus: AttendeeStatus = AttendeeStatus.joined) {
         self.attendeeId = attendeeId
         self.attendeeName = attendeeName
         self.volume = volume
         self.signal = signal
+        self.attendeeStatus = attendeeStatus
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## [Unreleased]
 
 ### Added
+* Added APIs for Audio Video configuration i.e `AudioVideoConfiguration` to be used during a meeting session.
+* Added support for joining meetings without audio i.e `AudioMode.NoAudio`.
+* Added an optional method `onAttendeesJoinedWithoutAudio` in `RealtimeObserver` to communicate the status of attendees who joined without audio.
 * Supports integration with Amazon Transcribe and Amazon Transcribe Medical for live transcription. The Amazon Chime Service uses its active talker algorithm to select the top two active talkers, and sends their audio to Amazon Transcribe (or Amazon Transcribe Medical) in your AWS account. User-attributed transcriptions are then sent directly to every meeting attendee via data messages. Use transcriptions to overlay subtitles, build a transcript, or perform real-time content analysis. For more information, visit [the live transcription guide](https://docs.aws.amazon.com/chime/latest/dg/meeting-transcription.html).
+* [Demo] Added ways to join a meeting without audio.
 * [Demo] Added meeting captions functionality based on the live transcription APIs. You will need to have a serverless deployment to create new AWS Lambda endpoints for live transcription. Follow [the live transcription guide](https://docs.aws.amazon.com/chime/latest/dg/meeting-transcription.html) to create necessary service-linked role so that the demo app can call Amazon Transcribe and Amazon Transcribe Medical on your behalf.
 
 ## [0.16.6] - 2021-10-14

--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ let activeAudioDevice = meetingSession.audioVideo.getActiveAudioDevice()
 ### Audio
 
 > Note: So far, you've added observers to receive device and session lifecycle events. In the following use cases, you'll use the real-time API methods to send and receive volume indicators and control mute state.
+> Attendees can join a meeting with or without audio.
+> Attendees who join without audio aka Checked-In attendees will have no audio through their Mic and Speaker. They can still enable their video and view videos of other attendees. No volume and signal updates for Checked-In attendees will be delivered to other attendees in the meeting. Attendees may want to join a meeting without audio if they just want to be shown as present in the meeting and share or view videos but are using a different audio source. For example, multiple attendees joining a meeting from a conference room may want to use common audio source installed in the conference room.
 
 #### Use case 8. Mute and unmute an audio input.
 
@@ -287,6 +289,11 @@ class MyRealtimeObserver: RealtimeObserver {
     func attendeesDidJoin(attendeeInfo: [AttendeeInfo]) {
         for currentAttendeeInfo in attendeeInfo {
             logger.info(msg: "\(currentAttendeeInfo.attendeeId) joined the meeting")
+        }
+    }
+    func attendeesDidJoinWithoutAudio(attendeeInfo: [AttendeeInfo]) {
+        for currentAttendeeInfo in attendeeInfo {
+            logger.info(msg: "\(currentAttendeeInfo.attendeeId) joined the meeting without audio")
         }
     }
     func attendeesDidLeave(attendeeInfo: [AttendeeInfo]) {


### PR DESCRIPTION
### Issue #, if available:
N/A

### Description of changes:
**SDK**
* Add APIs for Audio Video Configuration. Currently the configuration only support Audio Modes - `AudioMode.noAudio` and `AudioMode.mono` (i.e Audio from a single channel, it's the default audio mode)
* Add an optional method `attendeesDidJoinWithoutAudio` to `RealtimeObserver` for notifying about the attendees who join without audio
* Update `DefaultAudioClientObserver` to process presence updates for attendees who join without audio, and notify through `attendeesDidJoinWithoutAudio`
* Updated README and CHANGELOG

**Demo App**
* Allow joining a meeting with/without audio for all CallKit options
* Hide audio device selection from preview when joining without audio
* Hide mic and speaker from meeting controls when joining without audio
* Hide volume/signal indicators from roster for all attendees (local or remote) who joined the meeting without audio

### Testing done:
* Tested by starting a meeting from JS Demo App ***(DesktopUser)***, and then joining with as well without audio from iOS Demo App ***(iOSUser)***.
* Verified that Home Screen shows Switch for Audio and Picker for CallKit options

**iOSUser user joins with Audio**
* Audio works both ways for the iOSUser as well as DesktopUser
* Mute/Unmute and Speaker selection works for iOSUser
* Roster shows volume/signal indicators for iOSUser as well as DesktopUser
* Video functionality works for iOSUser as well as DesktopUser
* Chat functionality works for iOSUser as well as DesktopUser
* iOSUser can view screen share from DesktopUser

**iOSUser user joins without Audio**
* Preview doesn't show Audio Device selection
* Audio doesn't works both ways for the iOSUser
* Mic and Speaker icons are not available for iOSUser
* Roster shows volume/signal indicators for DesktopUser only
* Video functionality works for iOSUser as well as DesktopUser
* Chat functionality works for iOSUser as well as DesktopUser
* iOSUser can view screen share from DesktopUser
* *DesktopUser doesn't see iOSUser in Roster because JS Demo hasn't implemented the JoinWithoutAudio yet, however Video and Chats from iOSUser can be seen with correct attendee name of iOSUser*

**Testing with CallKit options**
* Tested with Audio/NoAudio with all combinations of CallKit options and verified to be working as expected.

#### Manual test cases (add more as needed):

- [x] Join meeting without CallKit
- [x] Join meeting with CallKit as Incoming
- [x] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [x] Rejoin meeting
- [x] See metrics
- [x] See attendee presence
- [x] Send audio
- [x] Receive audio
- [x] Mute self
- [x] Unmute self
- [x] See local mute indicator when muted
- [x] See remote mute indicator when other is muted
- [x] Enable and disable local video
- [x] Enable and disable remote video from remote side
- [x] Send local video
- [x] Pause and resume remote video
- [x] Switch local camera
- [x] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

* ![iOSSDKDemoApp_HomeScreen](https://user-images.githubusercontent.com/84412426/137940958-7e364774-923d-4a57-bbdb-adaccef4be52.png)
* ![iOSSDKDemoApp_WithAudio](https://user-images.githubusercontent.com/84412426/137941009-7cac149b-8563-4e11-b7b0-9bdccb5bb20e.png)
* ![iOSSDKDemoApp_WithoutAudio](https://user-images.githubusercontent.com/84412426/137941040-c39e1d30-9a8c-4194-a147-da84e1d9d454.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
