### PR TITLE
Use inbound turn for screen share

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/DefaultContentShareVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/DefaultContentShareVideoClientController.swift
@@ -25,6 +25,7 @@ import Foundation
         config.isDisablingSimulcastP2P = true
         config.isUsingPixelBufferRenderer = true
         config.isContentShare = true
+        config.isUsingInbandTurnCreds = true
         return config
     }()
 
@@ -70,7 +71,8 @@ import Foundation
                           token: configuration.credentials.joinToken,
                           sending: false,
                           config: videoConfig,
-                          appInfo: DeviceUtils.getDetailedInfo())
+                          appInfo: DeviceUtils.getDetailedInfo(),
+                          signalingUrl: configuration.urls.signalingUrl)
     }
 
     private func stopVideoClient() {

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/contentshare/DefaultContentShareVideoClientControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/contentshare/DefaultContentShareVideoClientControllerTests.swift
@@ -39,7 +39,8 @@ class DefaultContentShareVideoClientControllerTests: CommonTestCase {
                                      token: self.joinToken,
                                      sending: false,
                                      config: any(),
-                                     appInfo: any())).wasCalled()
+                                     appInfo: any(),
+                                     signalingUrl: any())).wasCalled()
         verify(videoClientMock.setExternalVideoSource(any())).wasCalled()
         verify(videoClientMock.setSending(true)).wasCalled()
     }
@@ -49,7 +50,8 @@ class DefaultContentShareVideoClientControllerTests: CommonTestCase {
                                     token: any(),
                                     sending: any(),
                                     config: any(),
-                                    appInfo: any())).will {_, _, _, _, _ in
+                                    appInfo: any(),
+                                    signalingUrl: any())).will {_, _, _, _, _ in
             self.defaultContentShareVideoClientController.videoClientDidConnect(nil, controlStatus: 1)
         }
         given(videoClientMock.stop()).will {
@@ -73,7 +75,8 @@ class DefaultContentShareVideoClientControllerTests: CommonTestCase {
                                     token: any(),
                                     sending: any(),
                                     config: any(),
-                                    appInfo: any())).will {_, _, _, _, _ in
+                                    appInfo: any(),
+                                    signalingUrl: any())).will {_, _, _, _, _ in
             self.defaultContentShareVideoClientController.videoClientDidConnect(nil, controlStatus: 1)
         }
 

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/contentshare/DefaultContentShareVideoClientControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/contentshare/DefaultContentShareVideoClientControllerTests.swift
@@ -51,7 +51,7 @@ class DefaultContentShareVideoClientControllerTests: CommonTestCase {
                                     sending: any(),
                                     config: any(),
                                     appInfo: any(),
-                                    signalingUrl: any())).will {_, _, _, _, _ in
+                                    signalingUrl: any())).will {_, _, _, _, _, _ in
             self.defaultContentShareVideoClientController.videoClientDidConnect(nil, controlStatus: 1)
         }
         given(videoClientMock.stop()).will {
@@ -65,7 +65,8 @@ class DefaultContentShareVideoClientControllerTests: CommonTestCase {
                                      token: self.joinToken,
                                      sending: false,
                                      config: any(),
-                                     appInfo: any())).wasCalled()
+                                     appInfo: any(),
+                                     signalingUrl: any())).wasCalled()
         verify(videoClientMock.setExternalVideoSource(any())).wasCalled(2)
         verify(videoClientMock.setSending(true)).wasCalled(2)
     }
@@ -76,7 +77,7 @@ class DefaultContentShareVideoClientControllerTests: CommonTestCase {
                                     sending: any(),
                                     config: any(),
                                     appInfo: any(),
-                                    signalingUrl: any())).will {_, _, _, _, _ in
+                                    signalingUrl: any())).will {_, _, _, _, _, _ in
             self.defaultContentShareVideoClientController.videoClientDidConnect(nil, controlStatus: 1)
         }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [0.17.0] - 2021-11-01
 
+### Changed
+* Changed ContentShareController to use inbound turn credentials
+
 ### Added
 * Supports integration with Amazon Transcribe and Amazon Transcribe Medical for live transcription. The Amazon Chime Service uses its active talker algorithm to select the top two active talkers, and sends their audio to Amazon Transcribe (or Amazon Transcribe Medical) in your AWS account. User-attributed transcriptions are then sent directly to every meeting attendee via data messages. Use transcriptions to overlay subtitles, build a transcript, or perform real-time content analysis. For more information, visit [the live transcription guide](https://docs.aws.amazon.com/chime/latest/dg/meeting-transcription.html).
 * [Demo] Added meeting captions functionality based on the live transcription APIs. You will need to have a serverless deployment to create new AWS Lambda endpoints for live transcription. Follow [the live transcription guide](https://docs.aws.amazon.com/chime/latest/dg/meeting-transcription.html) to create necessary service-linked role so that the demo app can call Amazon Transcribe and Amazon Transcribe Medical on your behalf.


### PR DESCRIPTION
### Issue #, if available:
WTBugs-26172
### Description of changes:
Use inbound turn credentials for screen share controller.

### Testing done:
Able to share screen with this.

#### Manual test cases (add more as needed):

- [ ] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [ ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
