### PR TITLE
Added initial priority downlink policy logic

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
+++ b/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
@@ -248,6 +248,10 @@
 		C6DA0B5B24F80BAC00028F2B /* AudioClientProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DA0B5A24F80BAC00028F2B /* AudioClientProtocol.swift */; };
 		C6DA0B5D24F8107000028F2B /* AudioLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DA0B5C24F8107000028F2B /* AudioLock.swift */; };
 		C6DA0B6224F961AA00028F2B /* DefaultAudioVideoControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DA0B6124F961AA00028F2B /* DefaultAudioVideoControllerTests.swift */; };
+		F81104AC276190AA003D17AD /* VideoPriority.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81104A8276190A9003D17AD /* VideoPriority.swift */; };
+		F81104AD276190AA003D17AD /* RemoteVideoSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81104A9276190A9003D17AD /* RemoteVideoSource.swift */; };
+		F81104AE276190AA003D17AD /* VideoResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81104AA276190A9003D17AD /* VideoResolution.swift */; };
+		F81104AF276190AA003D17AD /* VideoSubscriptionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81104AB276190A9003D17AD /* VideoSubscriptionConfiguration.swift */; };
 		F8204ADC23F499410099E3D1 /* MeetingSessionTURNCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8204ADB23F499410099E3D1 /* MeetingSessionTURNCredentials.swift */; };
 		F82D50D723FC752600D8F18C /* SignalStrength.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82D50C223FC732300D8F18C /* SignalStrength.swift */; };
 		F82D50D823FC752600D8F18C /* VolumeLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82D50C323FC732300D8F18C /* VolumeLevel.swift */; };
@@ -513,6 +517,10 @@
 		C6DA0B5A24F80BAC00028F2B /* AudioClientProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioClientProtocol.swift; sourceTree = "<group>"; };
 		C6DA0B5C24F8107000028F2B /* AudioLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioLock.swift; sourceTree = "<group>"; };
 		C6DA0B6124F961AA00028F2B /* DefaultAudioVideoControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAudioVideoControllerTests.swift; sourceTree = "<group>"; };
+		F81104A8276190A9003D17AD /* VideoPriority.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoPriority.swift; sourceTree = "<group>"; };
+		F81104A9276190A9003D17AD /* RemoteVideoSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteVideoSource.swift; sourceTree = "<group>"; };
+		F81104AA276190A9003D17AD /* VideoResolution.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoResolution.swift; sourceTree = "<group>"; };
+		F81104AB276190A9003D17AD /* VideoSubscriptionConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoSubscriptionConfiguration.swift; sourceTree = "<group>"; };
 		F8204ADB23F499410099E3D1 /* MeetingSessionTURNCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingSessionTURNCredentials.swift; sourceTree = "<group>"; };
 		F82D50C223FC732300D8F18C /* SignalStrength.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignalStrength.swift; sourceTree = "<group>"; };
 		F82D50C323FC732300D8F18C /* VolumeLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeLevel.swift; sourceTree = "<group>"; };
@@ -845,6 +853,10 @@
 		5A631A4024297BB200C8DAF3 /* video */ = {
 			isa = PBXGroup;
 			children = (
+				F81104A9276190A9003D17AD /* RemoteVideoSource.swift */,
+				F81104A8276190A9003D17AD /* VideoPriority.swift */,
+				F81104AA276190A9003D17AD /* VideoResolution.swift */,
+				F81104AB276190A9003D17AD /* VideoSubscriptionConfiguration.swift */,
 				C4590E2B253E03530035F4E0 /* capture */,
 				6AA9F9422522439F00EB0644 /* VideoFrame.swift */,
 				6AA9F9452522439F00EB0644 /* VideoFrameBuffer.swift */,
@@ -1540,6 +1552,7 @@
 				C4A6F9C4252E686700455418 /* VideoContentHint.swift in Sources */,
 				5A6F8182246244C30031AE97 /* MediaError.swift in Sources */,
 				C67E9B8526F531B40084C9B4 /* TranscriptionStatusType.swift in Sources */,
+				F81104AC276190AA003D17AD /* VideoPriority.swift in Sources */,
 				0007BDBF26335E6A00A15BB6 /* IngestionRecord.swift in Sources */,
 				5A6A209523CB1164000C9157 /* MeetingSession.swift in Sources */,
 				5A6A209623CB1164000C9157 /* MeetingSessionConfiguration.swift in Sources */,
@@ -1553,6 +1566,7 @@
 				003B588B23E22C6E002493AB /* MeetingSessionStatusCode.swift in Sources */,
 				F8204ADC23F499410099E3D1 /* MeetingSessionTURNCredentials.swift in Sources */,
 				C4A6907E255B0EF600F28BC2 /* DefaultContentShareController.swift in Sources */,
+				F81104AD276190AA003D17AD /* RemoteVideoSource.swift in Sources */,
 				C61475E526EFF71500CDEC09 /* TranscriptEventObserver.swift in Sources */,
 				C4A69072255B0E8F00F28BC2 /* ContentShareStatus.swift in Sources */,
 				5A6A209823CB1164000C9157 /* MeetingSessionURLs.swift in Sources */,
@@ -1584,6 +1598,7 @@
 				002C1FA826412A5400C9B919 /* IngestionEventConverter.swift in Sources */,
 				5A9196FE245A4AE000E17CDE /* Versioning.swift in Sources */,
 				0064166226290C8800626EB8 /* EventSQLiteDao.swift in Sources */,
+				F81104AE276190AA003D17AD /* VideoResolution.swift in Sources */,
 				002C1FB0264208E100C9B919 /* BackoffRetry.swift in Sources */,
 				C67E9B7626F4FBC20084C9B4 /* TranscriptItem.swift in Sources */,
 				002F8FE625BF986800006F46 /* DefaultMeetingStatsCollector.swift in Sources */,
@@ -1610,6 +1625,7 @@
 				C4A6906A255B0E2100F28BC2 /* ContentShareController.swift in Sources */,
 				C4A69096255CB00700F28BC2 /* ContentShareStatusCode.swift in Sources */,
 				00C2A91723F76250008CD687 /* VideoTileState.swift in Sources */,
+				F81104AF276190AA003D17AD /* VideoSubscriptionConfiguration.swift in Sources */,
 				C61475DB26EFC18400CDEC09 /* TranscriptEvent.swift in Sources */,
 				0007BDA126334BA800A15BB6 /* DefaultEventReporter.swift in Sources */,
 				F82D50D823FC752600D8F18C /* VolumeLevel.swift in Sources */,

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoControllerFacade.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoControllerFacade.swift
@@ -80,4 +80,26 @@ import Foundation
     ///
     /// - Parameter observer: The observer to unsubscribe from events with
     func removeMetricsObserver(observer: MetricsObserver)
+    
+    /// Add, update, or remove subscriptions to remote video sources provided via `remoteVideoSourcesDidBecomeAvailable`.
+    ///
+    /// Including a `RemoteVideoSource` in `addedOrUpdated` which was not previously provided will result in the negotiation of media flow for that source. After negotiation has
+    /// completed,`videoTileDidAdd` on the tile controller will be called with the `TileState` of the source, and applications
+    /// can render the video via 'bindVideoTile'. Reincluding a `RemoteVideoSource` can be done to update the provided `VideoSubscriptionConfiguration`,
+    /// but it is not necessary to continue receiving frames.
+    ///
+    /// Including a `RemoteVideoSource` in `removed` will stop the flow video from that source, and lead to a `videoTileDidRemove` call on the
+    /// tile controller to indicate to the application that the tile should be unbound. To restart the flow of media, the source should be re-added by
+    /// including in `addedOrUpdated`. Note that videos no longer available in a meeting (i.e. listed in
+    /// `remoteVideoSourcesDidBecomeUnavailable` do not need to be removed, as they will be automatically unsubscribed from.
+    ///
+    /// Note that before this function is called for the first time, the client will automatically subscribe to all video sources.
+    /// However this behavior will cease upon first call (e.g. if there are 10 videos in the meeting, the controller will subscribe to all 10, however if
+    /// `updateVideoSourceSubscriptions` is called with a single video in `addedOrUpdated`, the client will unsubscribe from the other 9.
+    /// This automatic subscription behavior may be removed in future major version updates, builders should avoid relying on the logic
+    /// and instead explicitly call `updateVideoSourceSubscriptions` with the sources they want to receive.
+    ///
+    /// - Parameter addedOrUpdated: Dictionary of remote video sources to configurations to add or update
+    /// - Parameter removed: Array of remote video sources to remove
+    func updateVideoSourceSubscriptions(addedOrUpdated: Dictionary<RemoteVideoSource, VideoSubscriptionConfiguration>, removed: Array<RemoteVideoSource>)
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoObserver.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoObserver.swift
@@ -67,11 +67,27 @@ import Foundation
     /// - Parameter sessionStatus: The status of meeting session
     func videoSessionDidStartWithStatus(sessionStatus: MeetingSessionStatus)
 
-    /// Called when the video session has stopped from a started state with the reason
-    /// provided in the status.
+    /// Called when the video session has stopped from a started state with the reason provided in the status.
     ///
     /// Note: this callback will be called on main thread.
     ///
     /// - Parameter sessionStatus: The reason why the session has stopped.
     func videoSessionDidStopWithStatus(sessionStatus: MeetingSessionStatus)
+    
+    /// Called on the main thread when video sources become available.
+    ///
+    /// Video sources can be explicitly subscribed to through `updateVideoSourceSubscriptions`, which has more information.
+    /// See note in `updateVideoSourceSubscriptions` documentation for information on subscription behavior if
+    /// `updateVideoSourceSubscriptions` is never called.
+    ///
+    /// - Parameter sources: Array of remote video sources that are available
+    func remoteVideoSourcesDidBecomeAvailable(sources: [RemoteVideoSource])
+    
+    /// Called on the main thread when video sources become unavailable.
+    ///
+    /// Note that these sources do not need to be removed via `updateVideoSourceSubscriptions`,
+    /// as they will be automatically unsubscribed from.
+    ///
+    /// - Parameter sources: Array of video sources that are unavailable
+    func remoteVideoSourcesDidBecomeUnavailable(sources: [RemoteVideoSource])
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoController.swift
@@ -94,4 +94,8 @@ import Foundation
     public func stopRemoteVideo() {
         videoClientController.stopRemoteVideo()
     }
+    
+    public func updateVideoSourceSubscriptions(addedOrUpdated: Dictionary<RemoteVideoSource, VideoSubscriptionConfiguration>, removed: Array<RemoteVideoSource>) {
+        videoClientController.updateVideoSourceSubscriptions(addedOrUpdated: addedOrUpdated, removed: removed)
+    }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
@@ -142,6 +142,10 @@ import Foundation
     public func removeRealtimeTranscriptEventObserver(observer: TranscriptEventObserver) {
         realtimeController.removeRealtimeTranscriptEventObserver?(observer: observer)
     }
+    
+    public func updateVideoSourceSubscriptions(addedOrUpdated: Dictionary<RemoteVideoSource, VideoSubscriptionConfiguration>, removed: Array<RemoteVideoSource>) {
+        audioVideoController.updateVideoSourceSubscriptions(addedOrUpdated: addedOrUpdated, removed: removed)
+    }
 
     // MARK: DeviceController
 

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/RemoteVideoSource.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/RemoteVideoSource.swift
@@ -1,0 +1,13 @@
+//
+//  RemoteVideoSource.swift
+//  AmazonChimeSDK
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+@objcMembers public class RemoteVideoSource: NSObject {
+    public var attendeeId: String = ""
+}

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/VideoPriority.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/VideoPriority.swift
@@ -1,0 +1,19 @@
+//
+//  VideoPriority.swift
+//  AmazonChimeSDK
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// Enum defining video priority for remote video sources. The 'higher' the number the 'higher' the priority for the source when adjusting video quality
+/// to adapt to variable network conditions, i.e. `highest` will be chosen before `high`, `medium`, etc.
+@objc public enum VideoPriority: Int {
+    case lowest = 0
+    case low = 10
+    case medium = 20
+    case high = 30
+    case highest = 40
+}

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/VideoResolution.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/VideoResolution.swift
@@ -1,0 +1,35 @@
+//
+//  VideoResolution.swift
+//  AmazonChimeSDK
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// Customizable video resolution parameters for a remote video source.
+@objc public class VideoResolution: NSObject {
+    public var width: Int = 0
+    public var height: Int = 0
+    
+    /// Preset video resolutions.
+    static let high: VideoResolution = {
+        let res = VideoResolution()
+        res.width = 960
+        res.height = 720
+        return res
+    }()
+    static let medium: VideoResolution = {
+        let res = VideoResolution()
+        res.width = 640
+        res.height = 480
+        return res
+    }()
+    static let low: VideoResolution = {
+        let res = VideoResolution()
+        res.width = 320
+        res.height = 240
+        return res
+    }()
+}

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/VideoSubscriptionConfiguration.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/VideoSubscriptionConfiguration.swift
@@ -1,0 +1,15 @@
+//
+//  VideoSubscriptionConfiguration.swift
+//  AmazonChimeSDK
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// Remote video source initialized with attendeeId and hashed by object address.
+@objcMembers public class VideoSubscriptionConfiguration: NSObject {
+    public var priority: VideoPriority = VideoPriority.highest
+    public var resolution: VideoResolution = VideoResolution.high
+}

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientController.swift
@@ -28,4 +28,5 @@ import Foundation
     func subscribeToReceiveDataMessage(topic: String, observer: DataMessageObserver)
     func unsubscribeFromReceiveDataMessageFromTopic(topic: String)
     func sendDataMessage(topic: String, data: Any, lifetimeMs: Int32) throws
+    func updateVideoSourceSubscriptions(addedOrUpdated: Dictionary<RemoteVideoSource, VideoSubscriptionConfiguration>, removed: Array<RemoteVideoSource>)
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientProtocol.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientProtocol.swift
@@ -43,6 +43,9 @@ import Foundation
     func videoLogCallBack(_ logLevel: video_client_loglevel_t, msg: String!)
 
     func sendDataMessage(_ topic: String!, data: UnsafePointer<Int8>!, lifetimeMs: Int32)
+    
+    func updateVideoSourceSubscriptions(_ addedOrUpdated: Dictionary<AnyHashable, Any>!,
+                                        withRemoved: Array<Any>!)
 }
 
 extension VideoClient: VideoClientProtocol {}

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -317,7 +317,7 @@
                                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <prototypes>
                                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="chatMessageCell" rowHeight="150" id="IR1-ov-bzI" customClass="ChatMessageCell" customModule="AmazonChimeSDKDemo" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="24.333333969116211" width="414" height="150"/>
+                                                        <rect key="frame" x="0.0" y="28" width="414" height="150"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="IR1-ov-bzI" id="jwj-GW-jrz">
                                                             <rect key="frame" x="0.0" y="0.0" width="414" height="150"/>
@@ -422,7 +422,7 @@
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="rosterCell" rowHeight="87" id="oOQ-i3-TjW" customClass="RosterTableCell" customModule="AmazonChimeSDKDemo" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="24.333333969116211" width="414" height="87"/>
+                                                <rect key="frame" x="0.0" y="28" width="414" height="87"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="oOQ-i3-TjW" id="yy8-Oi-9EV">
                                                     <rect key="frame" x="0.0" y="0.0" width="414" height="87"/>
@@ -519,14 +519,27 @@
                                                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                                     <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 </button>
+                                                                <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PJ7-s8-YZq" userLabel="On Update Video Subscriptions Label">
+                                                                    <rect key="frame" x="237" y="4.3333333333333428" width="24" height="24"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" constant="24" id="Vyu-kA-Xkx"/>
+                                                                        <constraint firstAttribute="height" constant="24" id="aYu-cK-wgJ"/>
+                                                                    </constraints>
+                                                                    <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                                    <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                    <state key="normal" backgroundImage="more"/>
+                                                                </button>
                                                             </subviews>
                                                             <color key="backgroundColor" systemColor="secondaryLabelColor"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="trailing" secondItem="sga-dz-S8z" secondAttribute="trailing" constant="32" id="4NG-QF-Crg"/>
+                                                                <constraint firstItem="A9r-yc-76P" firstAttribute="leading" secondItem="PJ7-s8-YZq" secondAttribute="trailing" constant="5" id="AM7-5u-Bsq"/>
                                                                 <constraint firstItem="sga-dz-S8z" firstAttribute="leading" secondItem="rIq-lk-w7t" secondAttribute="leading" constant="32" id="C5O-8O-myw"/>
+                                                                <constraint firstItem="PJ7-s8-YZq" firstAttribute="top" secondItem="rIq-lk-w7t" secondAttribute="top" constant="4.3300000000000001" id="KPH-aX-J8U"/>
                                                                 <constraint firstItem="A9r-yc-76P" firstAttribute="centerY" secondItem="rIq-lk-w7t" secondAttribute="centerY" id="MUr-uI-c4Y"/>
                                                                 <constraint firstItem="sga-dz-S8z" firstAttribute="centerY" secondItem="rIq-lk-w7t" secondAttribute="centerY" id="UDV-PR-bRa"/>
                                                                 <constraint firstAttribute="height" constant="32" id="WYO-G2-zlY"/>
+                                                                <constraint firstItem="A9r-yc-76P" firstAttribute="leading" secondItem="PJ7-s8-YZq" secondAttribute="trailing" constant="20" id="bEP-aF-7NS"/>
                                                                 <constraint firstAttribute="trailing" secondItem="A9r-yc-76P" secondAttribute="trailing" constant="8" id="oMi-i7-Ib3"/>
                                                             </constraints>
                                                         </view>
@@ -578,6 +591,7 @@
                                                     <outlet property="poorConnectionImage" destination="oN8-OP-rV7" id="ycQ-wP-iIT"/>
                                                     <outlet property="poorConnectionLabel" destination="FMD-Q2-cFR" id="OLN-aX-lWc"/>
                                                     <outlet property="shadedView" destination="rIq-lk-w7t" id="wum-T3-p3b"/>
+                                                    <outlet property="updateVideoSubscriptionsButton" destination="PJ7-s8-YZq" id="u7z-9U-qwF"/>
                                                     <outlet property="videoDisabledImage" destination="tMr-mN-AG5" id="ymH-sC-Zy2"/>
                                                     <outlet property="videoRenderView" destination="80b-KU-QcI" id="AjQ-rS-6J2"/>
                                                 </connections>
@@ -652,7 +666,7 @@
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="metricsCell" rowHeight="87" id="ScO-Sx-PnT" userLabel="metricsCell" customClass="MetricsTableCell" customModule="AmazonChimeSDKDemo" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="24.333333969116211" width="414" height="87"/>
+                                                <rect key="frame" x="0.0" y="28" width="414" height="87"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ScO-Sx-PnT" id="XjQ-XE-b0u">
                                                     <rect key="frame" x="0.0" y="0.0" width="414" height="87"/>
@@ -698,7 +712,7 @@
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <prototypes>
                                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" reuseIdentifier="captionCell" id="8aS-kd-Jde" customClass="CaptionCell" customModule="AmazonChimeSDKDemo" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="24.333333969116211" width="414" height="39.333332061767578"/>
+                                                <rect key="frame" x="0.0" y="28" width="414" height="39.333332061767578"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8aS-kd-Jde" id="4gI-K8-L7e">
                                                     <rect key="frame" x="0.0" y="0.0" width="414" height="39.333332061767578"/>
@@ -886,7 +900,7 @@
                                 <rect key="frame" x="0.0" y="8" width="414" height="44"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Meeting#" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DdL-aA-lof">
-                                        <rect key="frame" x="16.000000000000007" y="0.0" width="103.66666666666669" height="44"/>
+                                        <rect key="frame" x="15.999999999999993" y="0.0" width="116.33333333333331" height="44"/>
                                         <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <accessibility key="accessibilityConfiguration">
                                             <accessibilityTraits key="traits" staticText="YES" header="YES"/>

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -678,17 +678,20 @@ extension MeetingViewController: UICollectionViewDataSource {
         let isSelf = indexPath.item == 0
         let videoTileState = meetingModel.videoModel.getVideoTileState(for: indexPath)
         let displayName = meetingModel.getVideoTileDisplayName(for: indexPath)
+        let attendeeId = meetingModel.getVideoTileAttendeeId(for: indexPath)
 
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: videoTileCellReuseIdentifier,
                                                             for: indexPath) as? VideoTileCell else {
             return VideoTileCell()
         }
 
-        cell.updateCell(name: displayName,
+        cell.updateCell(id: attendeeId,
+                        name: displayName,
                         isSelf: isSelf,
                         videoTileState: videoTileState,
                         tag: indexPath.row)
         cell.delegate = meetingModel.videoModel
+        cell.viewController = self
 
         if let tileState = videoTileState {
             if tileState.isLocalTile, !tileState.isContent, meetingModel.videoModel.isFrontCameraActive {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
@@ -17,6 +17,7 @@ class VideoModel: NSObject {
     private var selfVideoTileState: VideoTileState?
     private var remoteVideoTileStates: [(Int, VideoTileState)] = []
     private var userPausedVideoTileIds: Set<Int> = Set()
+    public var remoteVideoSourceConfigurations: Dictionary<String, VideoSubscriptionConfiguration> = Dictionary()
     private let audioVideoFacade: AudioVideoFacade
     let customSource: DefaultCameraCaptureSource
 
@@ -311,5 +312,17 @@ extension VideoModel: VideoTileCellDelegate {
                 }
             }
         }
+    }
+    
+    func onUpdateButtonClicked(attendeeId: String, priority: VideoPriority) {
+        if (remoteVideoSourceConfigurations[attendeeId] == nil) {
+            remoteVideoSourceConfigurations[attendeeId] = VideoSubscriptionConfiguration()
+        }
+        remoteVideoSourceConfigurations[attendeeId]?.priority = priority
+        
+        let newSource = RemoteVideoSource()
+        newSource.attendeeId = attendeeId
+        let added = [newSource: remoteVideoSourceConfigurations[attendeeId]!]
+        audioVideoFacade.updateVideoSourceSubscriptions(addedOrUpdated: added, removed: [])
     }
 }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoTileCell.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoTileCell.swift
@@ -13,12 +13,14 @@ let videoTileCellReuseIdentifier = "VideoTileCell"
 
 protocol VideoTileCellDelegate: class {
     func onTileButtonClicked(tag: Int, selected: Bool)
+    func onUpdateButtonClicked(attendeeId: String, priority: VideoPriority)
 }
 
 class VideoTileCell: UICollectionViewCell {
     @IBOutlet var attendeeName: UILabel!
     @IBOutlet var shadedView: UIView!
     @IBOutlet var onTileButton: UIButton!
+    @IBOutlet var updateVideoSubscriptionsButton: UIButton!
     @IBOutlet var videoDisabledImage: UIImageView!
     @IBOutlet var poorConnectionBackground: UIView!
     @IBOutlet var poorConnectionImage: UIImageView!
@@ -26,11 +28,14 @@ class VideoTileCell: UICollectionViewCell {
     @IBOutlet var videoRenderView: DefaultVideoRenderView!
 
     weak var delegate: VideoTileCellDelegate?
+    weak var viewController: UIViewController?
+    var attendeeId: String = ""
 
-    func updateCell(name: String, isSelf: Bool, videoTileState: VideoTileState?, tag: Int) {
+    func updateCell(id: String, name: String, isSelf: Bool, videoTileState: VideoTileState?, tag: Int) {
         let isVideoActive = videoTileState != nil
         let isVideoPausedByUser = isVideoActive && videoTileState?.pauseState == .pausedByUserRequest
 
+        attendeeId = id
         attendeeName.text = name
         backgroundColor = .systemGray
         isHidden = false
@@ -65,6 +70,33 @@ class VideoTileCell: UICollectionViewCell {
             let shouldShowPoorConnection = videoTileState?.pauseState == .pausedForPoorConnection
             renderPoorConnection(isHidden: !shouldShowPoorConnection)
         }
+        
+        if !isSelf {
+            updateVideoSubscriptionsButton.setImage(UIImage(named: "more")?.withRenderingMode(.alwaysTemplate), for: .normal)
+            updateVideoSubscriptionsButton.tintColor = .white
+            updateVideoSubscriptionsButton.isHidden = false
+            
+            updateVideoSubscriptionsButton.addTarget(self, action: #selector(showUpdateVideoSubscriptionsMenu), for: .touchUpInside)
+        } else {
+            updateVideoSubscriptionsButton.isHidden = true
+        }
+    }
+    
+    @objc func showUpdateVideoSubscriptionsMenu() {
+        let alertController = UIAlertController(title: "Set video priority", message: "Choose the display priority order for the selected video", preferredStyle: .alert)
+        let priorityList = [VideoPriority.lowest, VideoPriority.low, VideoPriority.medium, VideoPriority.high, VideoPriority.highest]
+        let titleList = ["Lowest", "Low", "Medium", "High", "Highest"]
+        
+        for i in 0...(priorityList.count-1) {
+            let action = UIAlertAction(title: titleList[i], style: UIAlertAction.Style.default) {
+                UIAlertAction in
+                self.delegate?.onUpdateButtonClicked(attendeeId: self.attendeeId, priority: priorityList[i])
+            }
+            alertController.addAction(action)
+        }
+
+        // Present the controller
+        viewController?.present(alertController, animated: true, completion: nil)
     }
 
     override func prepareForReuse() {
@@ -74,6 +106,7 @@ class VideoTileCell: UICollectionViewCell {
         isHidden = true
 
         onTileButton.imageView?.contentMode = UIView.ContentMode.scaleAspectFill
+        updateVideoSubscriptionsButton.imageView?.contentMode = UIView.ContentMode.scaleAspectFill
         shadedView.isHidden = false
         videoRenderView.backgroundColor = .systemGray
         videoRenderView.isHidden = true


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
Adding mobile sdk/demo parity for the priority downlink policy. Builders will be able to assign priority to specific remote video streams.

### Testing done:
Tested simultaneously with 2 JS SDK clients and 1 iOS client. Turned video on/off several times for the JS SDK clients to test the new iOS downlink policy.

#### Manual test cases (add more as needed):

- [x] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [x] Rejoin meeting
- [ ] See metrics
- [x] See attendee presence
- [x] Send audio
- [x] Receive audio
- [x] Mute self
- [x] Unmute self
- [x] See local mute indicator when muted
- [x] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [x] Enable and disable remote video from remote side
- [ ] Send local video
- [x] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:
![image](https://user-images.githubusercontent.com/92550665/146440561-aa207af1-9cb2-47c7-b906-0f6a2e8ca1be.png)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
