### PR TITLE
Dual camera

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo.xcodeproj/project.pbxproj
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo.xcodeproj/project.pbxproj
@@ -29,11 +29,11 @@
 		5A9E17D124A6A810002CACC5 /* AmazonChimeSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5AE38AD7242873FD00B234EC /* AmazonChimeSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5AE38AE02428747100B234EC /* AmazonChimeSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5AE38AD7242873FD00B234EC /* AmazonChimeSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		71922C3F276BDEEC00D4F1A9 /* DualCameraSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71922C3E276BDEEC00D4F1A9 /* DualCameraSource.swift */; };
-		71922C42276BED6500D4F1A9 /* AmazonChimeSDKMedia.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71922C41276BED6500D4F1A9 /* AmazonChimeSDKMedia.xcframework */; };
-		71922C43276BED6500D4F1A9 /* AmazonChimeSDKMedia.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 71922C41276BED6500D4F1A9 /* AmazonChimeSDKMedia.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		71922C44276BED8000D4F1A9 /* AmazonChimeSDKMedia.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71922C41276BED6500D4F1A9 /* AmazonChimeSDKMedia.xcframework */; };
-		71922C45276BED8000D4F1A9 /* AmazonChimeSDKMedia.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 71922C41276BED6500D4F1A9 /* AmazonChimeSDKMedia.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		71922C47276BEEE700D4F1A9 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71922C46276BEEE700D4F1A9 /* Constants.swift */; };
+		71922C4C276D708500D4F1A9 /* AmazonChimeSDKMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5ACB3E6F249AEE6800FC6E1B /* AmazonChimeSDKMedia.framework */; };
+		71922C4D276D708500D4F1A9 /* AmazonChimeSDKMedia.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5ACB3E6F249AEE6800FC6E1B /* AmazonChimeSDKMedia.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		71922C4E276D709700D4F1A9 /* AmazonChimeSDKMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5ACB3E6F249AEE6800FC6E1B /* AmazonChimeSDKMedia.framework */; };
+		71922C4F276D709700D4F1A9 /* AmazonChimeSDKMedia.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5ACB3E6F249AEE6800FC6E1B /* AmazonChimeSDKMedia.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		ADE3CFCA27050CD800DAC586 /* LiveTranscriptionOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE3CFC927050CD800DAC586 /* LiveTranscriptionOptionsViewController.swift */; };
 		B4FCD85224B9330A00064C9E /* ChatMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4FCD85124B9330A00064C9E /* ChatMessageCell.swift */; };
 		B4FCD85524B9364900064C9E /* ChatModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4FCD85424B9364900064C9E /* ChatModel.swift */; };
@@ -111,8 +111,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				71922C45276BED8000D4F1A9 /* AmazonChimeSDKMedia.xcframework in Embed Frameworks */,
 				5A9E17D124A6A810002CACC5 /* AmazonChimeSDK.framework in Embed Frameworks */,
+				71922C4D276D708500D4F1A9 /* AmazonChimeSDKMedia.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -123,8 +123,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				71922C43276BED6500D4F1A9 /* AmazonChimeSDKMedia.xcframework in Embed Frameworks */,
 				5AE38AE02428747100B234EC /* AmazonChimeSDK.framework in Embed Frameworks */,
+				71922C4F276D709700D4F1A9 /* AmazonChimeSDKMedia.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -219,8 +219,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				71922C42276BED6500D4F1A9 /* AmazonChimeSDKMedia.xcframework in Frameworks */,
 				00F0F6E12411B8E20013DA25 /* Toast in Frameworks */,
+				71922C4E276D709700D4F1A9 /* AmazonChimeSDKMedia.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -237,8 +237,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				71922C44276BED8000D4F1A9 /* AmazonChimeSDKMedia.xcframework in Frameworks */,
 				5A9E17D024A6A810002CACC5 /* AmazonChimeSDK.framework in Frameworks */,
+				71922C4C276D708500D4F1A9 /* AmazonChimeSDKMedia.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -817,7 +817,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0.17.0;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = 94KV3E626L;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../AmazonChimeSDK/";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -859,7 +859,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0.17.0;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = 94KV3E626L;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../AmazonChimeSDK/";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -898,7 +898,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0.17.0;
-				DEVELOPMENT_TEAM = 94KV3E626L;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = AmazonChimeSDKDemoBroadcast/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -949,7 +949,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0.17.0;
-				DEVELOPMENT_TEAM = 94KV3E626L;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../AmazonChimeSDK/";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -990,7 +990,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0.17.0;
-				DEVELOPMENT_TEAM = 94KV3E626L;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../AmazonChimeSDK/";
 				GCC_C_LANGUAGE_STANDARD = gnu99;

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo.xcodeproj/project.pbxproj
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo.xcodeproj/project.pbxproj
@@ -27,11 +27,13 @@
 		5A81417823F2300D00560201 /* RosterTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A81417723F2300D00560201 /* RosterTableCell.swift */; };
 		5A9E17D024A6A810002CACC5 /* AmazonChimeSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5AE38AD7242873FD00B234EC /* AmazonChimeSDK.framework */; };
 		5A9E17D124A6A810002CACC5 /* AmazonChimeSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5AE38AD7242873FD00B234EC /* AmazonChimeSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		5ACB3E71249AEE6800FC6E1B /* AmazonChimeSDKMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5ACB3E6F249AEE6800FC6E1B /* AmazonChimeSDKMedia.framework */; };
-		5ACB3E72249AEE6800FC6E1B /* AmazonChimeSDKMedia.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5ACB3E6F249AEE6800FC6E1B /* AmazonChimeSDKMedia.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		5ACB3E74249AEE7300FC6E1B /* AmazonChimeSDKMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5ACB3E6F249AEE6800FC6E1B /* AmazonChimeSDKMedia.framework */; };
-		5ACB3E75249AEE7300FC6E1B /* AmazonChimeSDKMedia.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5ACB3E6F249AEE6800FC6E1B /* AmazonChimeSDKMedia.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5AE38AE02428747100B234EC /* AmazonChimeSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5AE38AD7242873FD00B234EC /* AmazonChimeSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		71922C3F276BDEEC00D4F1A9 /* DualCameraSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71922C3E276BDEEC00D4F1A9 /* DualCameraSource.swift */; };
+		71922C42276BED6500D4F1A9 /* AmazonChimeSDKMedia.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71922C41276BED6500D4F1A9 /* AmazonChimeSDKMedia.xcframework */; };
+		71922C43276BED6500D4F1A9 /* AmazonChimeSDKMedia.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 71922C41276BED6500D4F1A9 /* AmazonChimeSDKMedia.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		71922C44276BED8000D4F1A9 /* AmazonChimeSDKMedia.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 71922C41276BED6500D4F1A9 /* AmazonChimeSDKMedia.xcframework */; };
+		71922C45276BED8000D4F1A9 /* AmazonChimeSDKMedia.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 71922C41276BED6500D4F1A9 /* AmazonChimeSDKMedia.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		71922C47276BEEE700D4F1A9 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71922C46276BEEE700D4F1A9 /* Constants.swift */; };
 		ADE3CFCA27050CD800DAC586 /* LiveTranscriptionOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADE3CFC927050CD800DAC586 /* LiveTranscriptionOptionsViewController.swift */; };
 		B4FCD85224B9330A00064C9E /* ChatMessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4FCD85124B9330A00064C9E /* ChatMessageCell.swift */; };
 		B4FCD85524B9364900064C9E /* ChatModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4FCD85424B9364900064C9E /* ChatModel.swift */; };
@@ -109,8 +111,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				71922C45276BED8000D4F1A9 /* AmazonChimeSDKMedia.xcframework in Embed Frameworks */,
 				5A9E17D124A6A810002CACC5 /* AmazonChimeSDK.framework in Embed Frameworks */,
-				5ACB3E72249AEE6800FC6E1B /* AmazonChimeSDKMedia.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -121,8 +123,8 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				71922C43276BED6500D4F1A9 /* AmazonChimeSDKMedia.xcframework in Embed Frameworks */,
 				5AE38AE02428747100B234EC /* AmazonChimeSDK.framework in Embed Frameworks */,
-				5ACB3E75249AEE7300FC6E1B /* AmazonChimeSDKMedia.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -162,6 +164,9 @@
 		5A81417723F2300D00560201 /* RosterTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RosterTableCell.swift; sourceTree = "<group>"; };
 		5ACB3E6F249AEE6800FC6E1B /* AmazonChimeSDKMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AmazonChimeSDKMedia.framework; path = ../AmazonChimeSDK/AmazonChimeSDKMedia.framework; sourceTree = "<group>"; };
 		5AE38AD1242873FD00B234EC /* AmazonChimeSDK.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = AmazonChimeSDK.xcodeproj; path = ../AmazonChimeSDK/AmazonChimeSDK.xcodeproj; sourceTree = "<group>"; };
+		71922C3E276BDEEC00D4F1A9 /* DualCameraSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DualCameraSource.swift; sourceTree = "<group>"; };
+		71922C41276BED6500D4F1A9 /* AmazonChimeSDKMedia.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = AmazonChimeSDKMedia.xcframework; path = ../AmazonChimeSDK/AmazonChimeSDKMedia.xcframework; sourceTree = "<group>"; };
+		71922C46276BEEE700D4F1A9 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		ADE3CFC927050CD800DAC586 /* LiveTranscriptionOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveTranscriptionOptionsViewController.swift; sourceTree = "<group>"; };
 		B4FCD85124B9330A00064C9E /* ChatMessageCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessageCell.swift; sourceTree = "<group>"; usesTabs = 0; };
 		B4FCD85424B9364900064C9E /* ChatModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModel.swift; sourceTree = "<group>"; };
@@ -214,8 +219,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				71922C42276BED6500D4F1A9 /* AmazonChimeSDKMedia.xcframework in Frameworks */,
 				00F0F6E12411B8E20013DA25 /* Toast in Frameworks */,
-				5ACB3E74249AEE7300FC6E1B /* AmazonChimeSDKMedia.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -232,8 +237,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				71922C44276BED8000D4F1A9 /* AmazonChimeSDKMedia.xcframework in Frameworks */,
 				5A9E17D024A6A810002CACC5 /* AmazonChimeSDK.framework in Frameworks */,
-				5ACB3E71249AEE6800FC6E1B /* AmazonChimeSDKMedia.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -311,6 +316,8 @@
 				5A1582C723C40C9D0099F8FA /* Info.plist */,
 				C61D436F27050FBF00150F03 /* CaptionsModel.swift */,
 				C61D4379270512A100150F03 /* CaptionCell.swift */,
+				71922C3E276BDEEC00D4F1A9 /* DualCameraSource.swift */,
+				71922C46276BEEE700D4F1A9 /* Constants.swift */,
 			);
 			path = AmazonChimeSDKDemo;
 			sourceTree = "<group>";
@@ -327,6 +334,7 @@
 		5FC5287C24209FE4009EC37F /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				71922C41276BED6500D4F1A9 /* AmazonChimeSDKMedia.xcframework */,
 				5ACB3E6F249AEE6800FC6E1B /* AmazonChimeSDKMedia.framework */,
 				C4A690A0255DFF4600F28BC2 /* ReplayKit.framework */,
 			);
@@ -572,6 +580,7 @@
 				00D82F1E25B2732D000496A2 /* PostLogger.swift in Sources */,
 				5A1582BA23C40C9B0099F8FA /* AppDelegate.swift in Sources */,
 				003B58B123E25032002493AB /* HttpUtils.swift in Sources */,
+				71922C47276BEEE700D4F1A9 /* Constants.swift in Sources */,
 				C61D4377270510D200150F03 /* Caption.swift in Sources */,
 				00D82F2425B27BD5000496A2 /* LogEntry.swift in Sources */,
 				003B58AF23E23E9D002493AB /* JoinMeetingResponse.swift in Sources */,
@@ -591,6 +600,7 @@
 				B4FCD85224B9330A00064C9E /* ChatMessageCell.swift in Sources */,
 				B4FCD85524B9364900064C9E /* ChatModel.swift in Sources */,
 				5A16BE7A24006A2A00ADAE26 /* VideoTileCell.swift in Sources */,
+				71922C3F276BDEEC00D4F1A9 /* DualCameraSource.swift in Sources */,
 				C61D437A270512A100150F03 /* CaptionCell.swift in Sources */,
 				C4632EBE24A57BF8009F8AF5 /* RosterModel.swift in Sources */,
 				C42A8A0D253E2E22008419A6 /* DeviceSelectionModel.swift in Sources */,
@@ -807,7 +817,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0.17.0;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 94KV3E626L;
 				ENABLE_BITCODE = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../AmazonChimeSDK/";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -849,7 +859,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0.17.0;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 94KV3E626L;
 				ENABLE_BITCODE = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../AmazonChimeSDK/";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -888,7 +898,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0.17.0;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 94KV3E626L;
 				INFOPLIST_FILE = AmazonChimeSDKDemoBroadcast/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -913,7 +923,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0.17.0;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 94KV3E626L;
 				INFOPLIST_FILE = AmazonChimeSDKDemoBroadcast/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -939,7 +949,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0.17.0;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 94KV3E626L;
 				ENABLE_BITCODE = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../AmazonChimeSDK/";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -980,7 +990,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 0.17.0;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 94KV3E626L;
 				ENABLE_BITCODE = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/../AmazonChimeSDK/";
 				GCC_C_LANGUAGE_STANDARD = gnu99;

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/AppConfiguration.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/AppConfiguration.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 struct AppConfiguration {
-    static let url = "https://hh4sazg8a5.execute-api.us-east-1.amazonaws.com/Prod/"
-    static let region = "us-west-1"
-    static let broadcastBundleId = "com.amazonaws.services.chime.SDKDemo.AmazonChimeSDKDemoBroadcast"
-    static let appGroupId = "group.com.amazonaws.services.chime.SDKDemo"
+    static let url = "YOUR_SERVER_URL"
+    static let region = "YOUR_SERVER_REGION"
+    static let broadcastBundleId = "YOUR_BROADCAST_BUNDLE_ID"
+    static let appGroupId = "YOUR_APP_GROUP_ID"
 }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/AppConfiguration.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/AppConfiguration.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 struct AppConfiguration {
-    static let url = "YOUR_SERVER_URL"
-    static let region = "YOUR_SERVER_REGION"
-    static let broadcastBundleId = "YOUR_BROADCAST_BUNDLE_ID"
-    static let appGroupId = "YOUR_APP_GROUP_ID"
+    static let url = "https://hh4sazg8a5.execute-api.us-east-1.amazonaws.com/Prod/"
+    static let region = "us-west-1"
+    static let broadcastBundleId = "com.amazonaws.services.chime.SDKDemo.AmazonChimeSDKDemoBroadcast"
+    static let appGroupId = "group.com.amazonaws.services.chime.SDKDemo"
 }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Constants.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Constants.swift
@@ -1,0 +1,17 @@
+//
+//  Constants.swift
+//  AmazonChimeSDKDemo
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+import AmazonChimeSDKMedia
+import Foundation
+
+@objcMembers class Constants: NSObject {
+    static let maxSupportedVideoFrameRate = 15
+    static let maxSupportedVideoHeight = 720
+    static let maxSupportedVideoWidth = maxSupportedVideoHeight / 9 * 16
+}
+

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Constants.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Constants.swift
@@ -6,7 +6,6 @@
 //  SPDX-License-Identifier: Apache-2.0
 //
 
-import AmazonChimeSDKMedia
 import Foundation
 
 @objcMembers class Constants: NSObject {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DeviceSelectionModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DeviceSelectionModel.swift
@@ -12,7 +12,7 @@ import Foundation
 class DeviceSelectionModel {
     let audioDevices: [MediaDevice]
     let videoDevices: [MediaDevice]
-    let cameraCaptureSource: DefaultCameraCaptureSource
+    let cameraCaptureSource: DualCameraSource
 
     lazy var supportedVideoFormat: [[VideoCaptureFormat]] = {
         self.videoDevices.map { videoDevice in
@@ -57,7 +57,7 @@ class DeviceSelectionModel {
         return selectedVideoDevice?.type == MediaDeviceType.videoFrontCamera
     }
 
-    init(deviceController: DeviceController, cameraCaptureSource: DefaultCameraCaptureSource) {
+    init(deviceController: DeviceController, cameraCaptureSource: DualCameraSource) {
         audioDevices = deviceController.listAudioDevices()
         // Reverse these so the front camera is the initial choice
         videoDevices = MediaDevice.listVideoDevices().reversed()

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DeviceSelectionModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DeviceSelectionModel.swift
@@ -12,7 +12,7 @@ import Foundation
 class DeviceSelectionModel {
     let audioDevices: [MediaDevice]
     let videoDevices: [MediaDevice]
-    let cameraCaptureSource: DualCameraSource
+    let cameraCaptureSource: DualCameraCaptureSource
 
     lazy var supportedVideoFormat: [[VideoCaptureFormat]] = {
         self.videoDevices.map { videoDevice in
@@ -57,7 +57,7 @@ class DeviceSelectionModel {
         return selectedVideoDevice?.type == MediaDeviceType.videoFrontCamera
     }
 
-    init(deviceController: DeviceController, cameraCaptureSource: DualCameraSource) {
+    init(deviceController: DeviceController, cameraCaptureSource: DualCameraCaptureSource) {
         audioDevices = deviceController.listAudioDevices()
         // Reverse these so the front camera is the initial choice
         videoDevices = MediaDevice.listVideoDevices().reversed()

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DeviceSelectionViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DeviceSelectionViewController.swift
@@ -28,7 +28,9 @@ class DeviceSelectionViewController: UIViewController {
         videoFormatPicker.delegate = self
         videoFormatPicker.dataSource = self
         videoPreviewImageView.mirror = model?.shouldMirrorPreview ?? false
-        model?.cameraCaptureSource.addVideoSink(sink: videoPreviewImageView)
+        if let frontVideoSource: VideoSource = model?.cameraCaptureSource.frontFrameAdapter {
+            frontVideoSource.addVideoSink(sink: videoPreviewImageView)
+        }
         model?.cameraCaptureSource.start()
     }
 

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DualCameraSource.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DualCameraSource.swift
@@ -1,0 +1,408 @@
+//
+//  DualCameraSource.swift
+//  AmazonChimeSDKDemo
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+import AVFoundation
+import Foundation
+import UIKit
+import AmazonChimeSDK
+
+
+public class PassthroughVideoFrameAdapter: NSObject, VideoSource, AVCaptureVideoDataOutputSampleBufferDelegate {
+    public var videoContentHint: VideoContentHint = .motion
+    private let sinks = NSMutableSet()
+    private let dualCameraSource: DualCameraSource
+    private let isFront: Bool
+    
+    public init(dualCameraSource: DualCameraSource, isFront: Bool) {
+        self.dualCameraSource = dualCameraSource
+        self.isFront = isFront
+    }
+    
+    public func addVideoSink(sink: VideoSink) {
+        sinks.add(sink)
+    }
+
+    public func removeVideoSink(sink: VideoSink) {
+        sinks.remove(sink)
+    }
+    public func captureOutput(_ output: AVCaptureOutput,
+                              didOutput sampleBuffer: CMSampleBuffer,
+                              from _: AVCaptureConnection) {
+        guard let frame = VideoFrame(sampleBuffer: sampleBuffer) else {
+            print("DefaultCameraCaptureSource could not convert captured CMSampleBuffer to video frame")
+            return
+        }
+        
+        let videoDataOutput = output as? AVCaptureVideoDataOutput
+
+//        print("In captureoutput!!")
+        sinks.forEach { item in
+            guard let sink = item as? VideoSink else { return }
+//            print("In for loop sinks!!")
+            if videoDataOutput == dualCameraSource.frontCameraVideoDataOutput, isFront{
+                sink.onVideoFrameReceived(frame: frame)
+            }
+            if videoDataOutput == dualCameraSource.backCameraVideoDataOutput, !isFront{
+                sink.onVideoFrameReceived(frame: frame)
+            }
+        }
+    }
+}
+
+@objcMembers public class DualCameraSource: NSObject, VideoSource {
+    public var frontFrameAdapter: PassthroughVideoFrameAdapter?
+    public var backFrameAdapter: PassthroughVideoFrameAdapter?
+    public var videoContentHint: VideoContentHint = .motion
+    private let logger: Logger
+    private let cameraLock = NSLock()
+    private let deviceType = AVCaptureDevice.DeviceType.builtInWideAngleCamera
+    private let sinks = NSMutableSet()
+    private let captureSourceObservers = NSMutableSet()
+    private var backCameraDeviceInput: AVCaptureDeviceInput?
+    public let backCameraVideoDataOutput = AVCaptureVideoDataOutput()
+    private var frontCameraDeviceInput: AVCaptureDeviceInput?
+    public let frontCameraVideoDataOutput = AVCaptureVideoDataOutput()
+    private let dataOutputQueue = DispatchQueue(label: "data output queue")
+    private static let defaultCaptureFormat = VideoCaptureFormat(width: Constants.maxSupportedVideoWidth,
+                                                                 height: Constants.maxSupportedVideoHeight,
+                                                                 maxFrameRate: Constants.maxSupportedVideoFrameRate)
+
+    @available(iOS 13.0, *)
+    lazy var session: AVCaptureMultiCamSession! = {
+        let source = AVCaptureMultiCamSession()
+        return source
+    }()
+    private var orientation = UIInterfaceOrientation.portrait
+    private var captureDevice: AVCaptureDevice!
+    private var frontCamera: AVCaptureDevice!
+    private var backCamera: AVCaptureDevice!
+    private var eventAnalyticsController: EventAnalyticsController?
+
+    public init(logger: Logger) {
+        self.logger = logger
+        super.init()
+        frontFrameAdapter = PassthroughVideoFrameAdapter(dualCameraSource: self, isFront: true)
+        backFrameAdapter = PassthroughVideoFrameAdapter(dualCameraSource: self, isFront: false)
+        device = MediaDevice.listVideoDevices().first { mediaDevice in
+            mediaDevice.type == MediaDeviceType.videoFrontCamera
+        }
+        frontCamera = AVCaptureDevice.default(deviceType,
+                                               for: .video,
+                                               position: .front)
+        backCamera = AVCaptureDevice.default(deviceType,
+                                             for: .video,
+                                             position: .back)
+
+        let notificationCenter = NotificationCenter.default
+        notificationCenter.addObserver(self,
+                                       selector: #selector(deviceOrientationDidChange),
+                                       name: UIDevice.orientationDidChangeNotification,
+                                       object: nil)
+    }
+
+    deinit {
+        if torchEnabled {
+            torchEnabled = false
+        }
+        if #available(iOS 13.0, *) {
+            if session.isRunning {
+                session.stopRunning()
+            }
+        } else {
+            logger.error(msg: "Dual Camera is only available on iOS 13+")
+        }
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    public var getFrontAdapter: VideoSource {
+        return frontFrameAdapter!
+    }
+    public var getBackAdapter: VideoSource {
+        return backFrameAdapter!
+    }
+    
+    public var device: MediaDevice? = MediaDevice.listVideoDevices().first {
+        didSet {
+            guard let device = device else { return }
+            let isUsingFrontCamera = device.type == .videoFrontCamera
+            captureDevice = isUsingFrontCamera ? frontCamera : backCamera
+            if #available(iOS 13.0, *) {
+                if session.isRunning {
+                    start() // Restart
+                }
+            } else {
+                logger.error(msg: "Dual Camera is only available on iOS 13+")
+            }
+        }
+    }
+
+    public var format: VideoCaptureFormat = defaultCaptureFormat {
+        didSet {
+            if #available(iOS 13.0, *) {
+                if captureDevice != nil, session.isRunning {
+                    start() // Restart
+                }
+            } else {
+                logger.error(msg: "Dual Camera is only available on iOS 13+")
+            }
+        }
+    }
+
+    public var torchEnabled: Bool = false {
+        didSet {
+            if let captureDevice = captureDevice, torchAvailable {
+                do {
+                    try captureDevice.lockForConfiguration()
+                    if torchEnabled {
+                        captureDevice.torchMode = .on
+                    } else {
+                        captureDevice.torchMode = .off
+                    }
+                    captureDevice.unlockForConfiguration()
+                } catch {
+                    logger.error(msg: "Unable to set torch on current camera. Error: \(error.localizedDescription)")
+                }
+            } else {
+                torchEnabled = false
+                logger.info(msg: "Torch is not available on current camera.")
+            }
+        }
+    }
+
+    /// Expose current capture device's torch availability
+    public var torchAvailable: Bool {
+        guard let captureDevice = captureDevice else {
+            return false
+        }
+
+        return captureDevice.hasTorch && captureDevice.isTorchAvailable
+    }
+
+    public func addVideoSink(sink: VideoSink) {
+        sinks.add(sink)
+    }
+
+    public func removeVideoSink(sink: VideoSink) {
+        sinks.remove(sink)
+    }
+
+    private func configureBackCamera() {
+        if #available(iOS 13.0, *) {
+            session.beginConfiguration()
+            defer {
+                session.commitConfiguration()
+            }
+            
+            // Find the back camera
+            guard let backCamera = backCamera else {
+                print("Could not find the back camera")
+                return
+            }
+            
+            // Add the back camera input to the session
+            do {
+                backCameraDeviceInput = try AVCaptureDeviceInput(device: backCamera)
+                
+                guard let backCameraDeviceInput = backCameraDeviceInput,
+                    session.canAddInput(backCameraDeviceInput) else {
+                        print("Could not add back camera device input")
+                        return
+                }
+                session.addInputWithNoConnections(backCameraDeviceInput)
+            } catch {
+                print("Could not create back camera device input: \(error)")
+                return
+            }
+            
+            // Find the back camera device input's video port
+            guard let backCameraDeviceInput = backCameraDeviceInput,
+                let backCameraVideoPort = backCameraDeviceInput.ports(for: .video,
+                                                                  sourceDeviceType: backCamera.deviceType,
+                                                                  sourceDevicePosition: backCamera.position).first else {
+                                                                    print("Could not find the back camera device input's video port")
+                                                                    return
+            }
+            
+            // Add the back camera video data output
+            guard session.canAddOutput(backCameraVideoDataOutput) else {
+                print("Could not add the back camera video data output")
+                return
+            }
+            session.addOutputWithNoConnections(backCameraVideoDataOutput)
+            
+            backCameraVideoDataOutput.setSampleBufferDelegate(backFrameAdapter, queue: dataOutputQueue)
+            
+            // Connect the back camera device input to the back camera video data output
+            let backCameraVideoDataOutputConnection = AVCaptureConnection(inputPorts: [backCameraVideoPort], output: backCameraVideoDataOutput)
+            guard session.canAddConnection(backCameraVideoDataOutputConnection) else {
+                print("Could not add a connection to the back camera video data output")
+                return
+            }
+            session.addConnection(backCameraVideoDataOutputConnection)
+            backCameraVideoDataOutputConnection.videoOrientation = .portrait
+        } else {
+            logger.error(msg: "Dual Camera is only available on iOS 13+")
+        }
+        return
+    }
+    
+    private func configureFrontCamera(){
+        if #available(iOS 13.0, *) {
+            session.beginConfiguration()
+            defer {
+                session.commitConfiguration()
+            }
+            
+            // Find the front camera
+            guard let frontCamera = frontCamera else {
+                print("Could not find the front camera")
+                return
+            }
+            
+            // Add the front camera input to the session
+            do {
+                frontCameraDeviceInput = try AVCaptureDeviceInput(device: frontCamera)
+                
+                guard let frontCameraDeviceInput = frontCameraDeviceInput,
+                    session.canAddInput(frontCameraDeviceInput) else {
+                        print("Could not add front camera device input")
+                        return
+                }
+                session.addInputWithNoConnections(frontCameraDeviceInput)
+            } catch {
+                print("Could not create front camera device input: \(error)")
+                return
+            }
+            
+            // Find the front camera device input's video port
+            guard let frontCameraDeviceInput = frontCameraDeviceInput,
+                let frontCameraVideoPort = frontCameraDeviceInput.ports(for: .video,
+                                                                        sourceDeviceType: frontCamera.deviceType,
+                                                                        sourceDevicePosition: frontCamera.position).first else {
+                                                                            print("Could not find the front camera device input's video port")
+                                                                            return
+            }
+            
+            // Add the front camera video data output
+            guard session.canAddOutput(frontCameraVideoDataOutput) else {
+                print("Could not add the front camera video data output")
+                return
+            }
+            session.addOutputWithNoConnections(frontCameraVideoDataOutput)
+
+            frontCameraVideoDataOutput.setSampleBufferDelegate(frontFrameAdapter, queue: dataOutputQueue)
+            
+            // Connect the front camera device input to the front camera video data output
+            let frontCameraVideoDataOutputConnection = AVCaptureConnection(inputPorts: [frontCameraVideoPort], output: frontCameraVideoDataOutput)
+            guard session.canAddConnection(frontCameraVideoDataOutputConnection) else {
+                print("Could not add a connection to the front camera video data output")
+                return
+            }
+            session.addConnection(frontCameraVideoDataOutputConnection)
+            
+            frontCameraVideoDataOutputConnection.videoOrientation = .portrait
+            frontCameraVideoDataOutputConnection.automaticallyAdjustsVideoMirroring = false
+            frontCameraVideoDataOutputConnection.isVideoMirrored = true
+        } else {
+            logger.error(msg: "Dual Camera is only available on iOS 13+")
+        }
+        return
+    }
+    
+    public func start() {
+        cameraLock.lock()
+        defer { cameraLock.unlock() }
+        if #available(iOS 13.0, *) {
+            session.beginConfiguration()
+            
+            configureBackCamera()
+            configureFrontCamera()
+                
+            session.commitConfiguration()
+            session.startRunning()
+        } else {
+            logger.error(msg: "Dual Camera is only available on iOS 13+")
+        }
+
+        // If the torch was currently on, starting the sessions
+        // would turn it off. See if we can turn it back on.
+        let currentTorchEnabled = torchEnabled
+        self.torchEnabled = currentTorchEnabled
+    }
+
+    public func stop() {
+        cameraLock.lock()
+        defer { cameraLock.unlock() }
+
+        if #available(iOS 13.0, *) {
+            session.stopRunning()
+        } else {
+            logger.error(msg: "Dual Camera is only available on iOS 13+")
+        }
+
+        // If the torch was currently on, stopping the sessions
+        // would turn it off. See if we can turn it back on.
+        let currentTorchEnabled = torchEnabled
+        self.torchEnabled = currentTorchEnabled
+    }
+
+    public func addCaptureSourceObserver(observer: CaptureSourceObserver) {
+        captureSourceObservers.add(observer)
+    }
+
+    public func removeCaptureSourceObserver(observer: CaptureSourceObserver) {
+        captureSourceObservers.remove(observer)
+    }
+    
+    public func switchCamera() {
+        let isUsingFrontCamera = device?.type == .videoFrontCamera
+        device = MediaDevice.listVideoDevices().first { mediaDevice in
+            mediaDevice.type == (isUsingFrontCamera ? .videoBackCamera : .videoFrontCamera)
+        }
+
+        if device != nil {
+            eventAnalyticsController?.pushHistory(historyEventName: .videoInputSelected)
+        }
+    }
+
+    private func updateOrientation() {
+        guard let connection = backCameraVideoDataOutput.connection(with: AVMediaType.video) else {
+            return
+        }
+
+        DispatchQueue.main.async {
+            self.orientation = UIApplication.shared.statusBarOrientation
+
+            switch self.orientation {
+            case .portrait, .unknown:
+                connection.videoOrientation = .portrait
+            case .portraitUpsideDown:
+                connection.videoOrientation = .portraitUpsideDown
+            case .landscapeLeft:
+                connection.videoOrientation = .landscapeLeft
+            case .landscapeRight:
+                connection.videoOrientation = .landscapeRight
+            @unknown default:
+                break
+            }
+        }
+    }
+
+    @objc private func deviceOrientationDidChange(notification: NSNotification) {
+        dataOutputQueue.async {
+            self.updateOrientation()
+        }
+    }
+
+    public func setEventAnalyticsController(eventAnalyticsController: EventAnalyticsController?) {
+        self.eventAnalyticsController = eventAnalyticsController
+    }
+}
+
+
+

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -430,6 +430,15 @@ class MeetingViewController: UIViewController {
                                                     self.toggleMetalFilter(nextStatus: nextCpuFilterStatus)
                                                 })
             optionMenu.addAction(cpuFilterAction)
+            
+            let isDualCameraOn = meetingModel.videoModel.isUsingDualCameraSource
+            let nextDualCameraStatus = nextOnOrOff(current: isDualCameraOn)
+            let dualCameraAction = UIAlertAction(title: "Turn \(nextDualCameraStatus) Dual Camera",
+                                                style: .default,
+                                                handler: { _ in
+                                                    self.toggleDualCamera(nextStatus: nextDualCameraStatus)
+                                                })
+            optionMenu.addAction(dualCameraAction)
         }
 
         let nextSourceType = meetingModel.videoModel.isUsingExternalVideoSource ? "internal" : "external"
@@ -609,6 +618,18 @@ class MeetingViewController: UIViewController {
             return
         }
         meetingModel.videoModel.isUsingMetalVideoProcessor.toggle()
+    }
+    
+    @objc private func toggleDualCamera(nextStatus: String) {
+        logger.info(msg: "Turning \(nextStatus) dual camera")
+        guard let meetingModel = meetingModel else {
+            return
+        }
+        if #available(iOS 13.0, *) {
+            meetingModel.videoModel.isUsingDualCameraSource.toggle()
+        } else {
+            meetingModel.notifyHandler?("Dual Camera is only available on iOS 13+")
+        }
     }
 
     @objc private func toggleCustomCameraSource(nextSourceType: String) {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -431,7 +431,7 @@ class MeetingViewController: UIViewController {
                                                 })
             optionMenu.addAction(cpuFilterAction)
             
-            let isDualCameraOn = meetingModel.videoModel.isUsingDualCameraSource
+            let isDualCameraOn = meetingModel.videoModel.isUsingDualCameraCaptureSource
             let nextDualCameraStatus = nextOnOrOff(current: isDualCameraOn)
             let dualCameraAction = UIAlertAction(title: "Turn \(nextDualCameraStatus) Dual Camera",
                                                 style: .default,
@@ -626,7 +626,7 @@ class MeetingViewController: UIViewController {
             return
         }
         if #available(iOS 13.0, *) {
-            meetingModel.videoModel.isUsingDualCameraSource.toggle()
+            meetingModel.videoModel.isUsingDualCameraCaptureSource.toggle()
         } else {
             meetingModel.notifyHandler?("Dual Camera is only available on iOS 13+")
         }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
@@ -18,7 +18,7 @@ class VideoModel: NSObject {
     private var remoteVideoTileStates: [(Int, VideoTileState)] = []
     private var userPausedVideoTileIds: Set<Int> = Set()
     private let audioVideoFacade: AudioVideoFacade
-    let customSource: DualCameraSource
+    let customSource: DualCameraCaptureSource
 
     var videoUpdatedHandler: (() -> Void)?
     var localVideoUpdatedHandler: (() -> Void)?
@@ -26,7 +26,7 @@ class VideoModel: NSObject {
 
     init(audioVideoFacade: AudioVideoFacade, eventAnalyticsController: EventAnalyticsController) {
         self.audioVideoFacade = audioVideoFacade
-        self.customSource = DualCameraSource(logger: ConsoleLogger(name: "CustomCameraSource"))
+        self.customSource = DualCameraCaptureSource(logger: ConsoleLogger(name: "DualCameraCaptureSource"))
         self.customSource.setEventAnalyticsController(eventAnalyticsController: eventAnalyticsController)
         super.init()
     }
@@ -122,15 +122,15 @@ class VideoModel: NSObject {
         }
     }
     
-    var isUsingDualCameraSource = false {
-        willSet(isUsingDualCameraSource) {
-            if !isUsingDualCameraSource {
+    var isUsingDualCameraCaptureSource = false {
+        willSet(isUsingDualCameraCaptureSource) {
+            if !isUsingDualCameraCaptureSource {
                 customSource.stop()
                 stopLocalVideo()
             }
         }
         didSet {
-            if isUsingDualCameraSource {
+            if isUsingDualCameraCaptureSource {
                 customSource.start()
                 startLocalVideo()
             }
@@ -178,7 +178,7 @@ class VideoModel: NSObject {
                         self.logger.error(msg: "Error: Unable to get backVideoSource.")
                         return
                     }
-                    if self.isUsingDualCameraSource {
+                    if self.isUsingDualCameraCaptureSource {
                         self.audioVideoFacade.startLocalVideo(source: frontVideoSource)
 
                         let contentShareSource = ContentShareSource()
@@ -215,7 +215,7 @@ class VideoModel: NSObject {
         // See comments above isUsingExternalVideoSource
         if isUsingExternalVideoSource {
             customSource.stop()
-            if isUsingDualCameraSource {
+            if isUsingDualCameraCaptureSource {
                 self.audioVideoFacade.stopContentShare()
             }
 


### PR DESCRIPTION
### Issue #, if available:
Dual Camera: https://github.com/aws/amazon-chime-sdk-ios/issues/375

### Description of changes:
AVCaptureMultiCamSession (https://developer.apple.com/documentation/avfoundation/avcapturemulticamsession) is a capture session that supports simultaneous capture from multiple inputs of the same media type, and it is only available after IOS 13.0. 
AVCaptureMultiCamSession and AVCaptureSession cannot be called simultaneously.

**DualCameraSource.swift**
- Have a customized implementation for dual cameras of protocol `CameraCaptureSource`, builders are able to consume either(polymorphism) according to their use case.
- Implement class `PassthroughVideoFrameAdapter` to receive front and back data frame separately
- In `DualCameraSource`
    - Use `AVCaptureMultiCamSession` instead of `AVCaptureSession` to create captureSession
    - Initiate two `PassthroughVideoFrameAdapters`: `frontFrameAdapter` and `backFrameAdapter`
    - Configure front and back Cameras with `configureFrontCamera()` and `configureBackCamera()`

**MeetingViewController.swift** 
- Create `"Turn On Dual Camera"` button under `"Addtional Options"` which will trigger dual camera

**VideoModel.swift**
- Add logic for starting and stopping dual camera

**DeviceSelectionModel.swift  and DeviceSelectionViewController.swift** 
- Update local video preview to use `DualCameraSource` instead of `DefaultCameraCaptureSource`

### Testing done:
Dual Camera works well.
