### PR TITLE
add meetingStartDurationMs event

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/analytics/EventAttributeName.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/analytics/EventAttributeName.swift
@@ -42,6 +42,8 @@ import Foundation
 
     /// Maximum number video tile shared during the meeting, including self video tile
     case maxVideoTileCount
+    /// Duration of the meeting start process
+    case meetingStartDurationMs
     /// Duration of the meeting
     case meetingDurationMs
     /// Error message of the meeting
@@ -89,6 +91,8 @@ import Foundation
             return "meetingHistory"
         case .maxVideoTileCount:
             return "maxVideoTileCount"
+        case .meetingStartDurationMs:
+            return "meetingStartDurationMs"
         case .meetingDurationMs:
             return "meetingDurationMs"
         case .meetingErrorMessage:

--- a/AmazonChimeSDK/AmazonChimeSDK/ingestion/IngestionEventConverter.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/ingestion/IngestionEventConverter.swift
@@ -38,6 +38,7 @@ import Foundation
         return IngestionMeetingEvent(name: String(describing: event.name),
                                      eventAttributes: IngestionEventAttributes(timestampMs: eventAttributes[EventAttributeName.timestampMs] as? Int64,
                                                                                maxVideoTileCount: eventAttributes[EventAttributeName.maxVideoTileCount] as? Int,
+                                                                               meetingStartDurationMs: eventAttributes[EventAttributeName.meetingStartDurationMs] as? Int64,
                                                                                meetingDurationMs: eventAttributes[EventAttributeName.meetingDurationMs] as? Int64,
                                                                                meetingErrorMessage:
                                                                                eventAttributes[EventAttributeName.meetingErrorMessage] as? String,
@@ -49,7 +50,7 @@ import Foundation
                                                                                attendeeId: meetingConfig?.attendeeId))
     }
 
-    func toIngestionRecord(dirtyMeetingEvents: [DirtyMeetingEventItem]) -> IngestionRecord {
+    func toIngestionRecord(dirtyMeetingEvents: [DirtyMeetingEventItem], ingestionConfiguration: IngestionConfiguration) -> IngestionRecord {
         if dirtyMeetingEvents.isEmpty {
             return IngestionRecord(metadata: IngestionMetadata(), events: [])
         }
@@ -67,13 +68,13 @@ import Foundation
             return nil
         }
 
-        let rootMeta = toIngestionMetadata(attributes: EventAttributeUtils.getCommonAttributes())
+        let rootMeta = toIngestionMetadata(attributes: EventAttributeUtils.getCommonAttributes(ingestionConfiguration: ingestionConfiguration))
 
         return IngestionRecord(metadata: rootMeta,
                                events: ingestionEvents)
     }
 
-    func toIngestionRecord(meetingEvents: [MeetingEventItem]) -> IngestionRecord {
+    func toIngestionRecord(meetingEvents: [MeetingEventItem], ingestionConfiguration: IngestionConfiguration) -> IngestionRecord {
         if meetingEvents.isEmpty {
             return IngestionRecord(metadata: IngestionMetadata(), events: [])
         }
@@ -108,7 +109,7 @@ import Foundation
             return nil
         }
 
-        let rootMeta = toIngestionMetadata(attributes: EventAttributeUtils.getCommonAttributes())
+        let rootMeta = toIngestionMetadata(attributes: EventAttributeUtils.getCommonAttributes(ingestionConfiguration: ingestionConfiguration))
 
         return IngestionRecord(metadata: rootMeta,
                                events: ingestionEvents)
@@ -121,6 +122,7 @@ import Foundation
                                 ts: attributes.timestampMs ?? 0,
                                 id: meetingEvent.id,
                                 maxVideoTileCount: attributes.maxVideoTileCount,
+                                meetingStartDurationMs: attributes.meetingStartDurationMs,
                                 meetingDurationMs: attributes.meetingDurationMs,
                                 meetingErrorMessage: attributes.meetingErrorMessage,
                                 meetingStatus: attributes.meetingStatus,
@@ -136,6 +138,7 @@ import Foundation
                                 ts: attributes.timestampMs ?? 0,
                                 id: dirtyMeetingEvent.id,
                                 maxVideoTileCount: attributes.maxVideoTileCount,
+                                meetingStartDurationMs: attributes.meetingStartDurationMs,
                                 meetingDurationMs: attributes.meetingDurationMs,
                                 meetingErrorMessage: attributes.meetingErrorMessage,
                                 meetingStatus: attributes.meetingStatus,

--- a/AmazonChimeSDK/AmazonChimeSDK/ingestion/IngestionPayload.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/ingestion/IngestionPayload.swift
@@ -13,6 +13,7 @@ import Foundation
     public let ts: Int64
     public let id: String?
     public let maxVideoTileCount: Int?
+    public let meetingStartDurationMs: Int64?
     public let meetingDurationMs: Int64?
     public let meetingErrorMessage: String?
     public let meetingStatus: String?
@@ -25,6 +26,7 @@ import Foundation
                 ts: Int64,
                 id: String? = nil,
                 maxVideoTileCount: Int? = nil,
+                meetingStartDurationMs: Int64? = nil,
                 meetingDurationMs: Int64? = nil,
                 meetingErrorMessage: String? = nil,
                 meetingStatus: String? = nil,
@@ -36,6 +38,7 @@ import Foundation
         self.ts = ts
         self.id = id
         self.maxVideoTileCount = maxVideoTileCount
+        self.meetingStartDurationMs = meetingStartDurationMs
         self.meetingDurationMs = meetingDurationMs
         self.meetingErrorMessage = meetingErrorMessage
         self.meetingStatus = meetingStatus

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/analytics/DefaultMeetingStatsCollector.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/analytics/DefaultMeetingStatsCollector.swift
@@ -30,7 +30,7 @@ import Foundation
         return [EventAttributeName.maxVideoTileCount: maxVideoTileCount,
                 EventAttributeName.retryCount: retryCount,
                 EventAttributeName.poorConnectionCount: poorConnectionCount,
-                EventAttributeName.meetingStartDurationMs: meetingStartConnectingTimeMs == 0 ?
+                EventAttributeName.meetingStartDurationMs: meetingStartTimeMs == 0 ?
                     0 : meetingStartTimeMs - meetingStartConnectingTimeMs,
                 EventAttributeName.meetingDurationMs: meetingStartTimeMs == 0 ?
                     0 : DateUtils.getCurrentTimeStampMs() - meetingStartTimeMs

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/analytics/DefaultMeetingStatsCollector.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/analytics/DefaultMeetingStatsCollector.swift
@@ -11,6 +11,7 @@ import Foundation
 @objcMembers public class DefaultMeetingStatsCollector: NSObject, MeetingStatsCollector {
     private let logger: Logger
     private var meetingStartTimeMs: Int64 = 0
+    private var meetingStartConnectingTimeMs: Int64 = 0
     private var retryCount: Int = 0
     private var poorConnectionCount: Int = 0
     private var maxVideoTileCount: Int = 0
@@ -29,6 +30,8 @@ import Foundation
         return [EventAttributeName.maxVideoTileCount: maxVideoTileCount,
                 EventAttributeName.retryCount: retryCount,
                 EventAttributeName.poorConnectionCount: poorConnectionCount,
+                EventAttributeName.meetingStartDurationMs: meetingStartConnectingTimeMs == 0 ?
+                    0 : meetingStartTimeMs - meetingStartConnectingTimeMs,
                 EventAttributeName.meetingDurationMs: meetingStartTimeMs == 0 ?
                     0 : DateUtils.getCurrentTimeStampMs() - meetingStartTimeMs
         ] as [EventAttributeName: Any]
@@ -51,6 +54,10 @@ import Foundation
         maxVideoTileCount = max(videoTileCount, maxVideoTileCount)
     }
 
+    public func updateMeetingStartConnectingTimeMs() {
+        meetingStartConnectingTimeMs = DateUtils.getCurrentTimeStampMs()
+    }
+    
     public func updateMeetingStartTimeMs() {
         meetingStartTimeMs = DateUtils.getCurrentTimeStampMs()
     }
@@ -60,5 +67,6 @@ import Foundation
         poorConnectionCount = 0
         maxVideoTileCount = 0
         meetingStartTimeMs = 0
+        meetingStartConnectingTimeMs = 0
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/analytics/MeetingStatsCollector.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/analytics/MeetingStatsCollector.swift
@@ -23,6 +23,9 @@ import Foundation
     /// - Parameter videoTileCount: current video tile count
     func updateMaxVideoTile(videoTileCount: Int)
 
+    /// Update meetingStartConnectingTimeMs.
+    func updateMeetingStartConnectingTimeMs()
+    
     /// Update meetingStartTimeMs.
     func updateMeetingStartTimeMs()
 

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
@@ -97,6 +97,7 @@ extension DefaultAudioClientController: AudioClientController {
             observer.audioSessionDidStartConnecting(reconnecting: false)
         }
         eventAnalyticsController.publishEvent(name: .meetingStartRequested)
+        meetingStatsCollector.updateMeetingStartConnectingTimeMs()
         let appInfo = DeviceUtils.getAppInfo()
         var audioModeInternal: AudioModeInternal = .Stereo48K
         if (audioMode == .mono48K) {

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/ingestion/database/IngestionEventAttributes.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/ingestion/database/IngestionEventAttributes.swift
@@ -12,6 +12,8 @@ class IngestionEventAttributes: Codable {
     /// Timestamp of event occurrence
     public let timestampMs: Int64?
     public let maxVideoTileCount: Int?
+    /// Duration of the meeting start process
+    public let meetingStartDurationMs: Int64?
     /// Duration of the meeting
     public let meetingDurationMs: Int64?
     /// Error message of the meeting
@@ -31,6 +33,7 @@ class IngestionEventAttributes: Codable {
 
     init(timestampMs: Int64? = nil,
          maxVideoTileCount: Int? = nil,
+         meetingStartDurationMs: Int64? = nil,
          meetingDurationMs: Int64? = nil,
          meetingErrorMessage: String? = nil,
          meetingStatus: String? = nil,
@@ -41,6 +44,7 @@ class IngestionEventAttributes: Codable {
          attendeeId: String? = nil) {
         self.timestampMs = timestampMs
         self.maxVideoTileCount = maxVideoTileCount
+        self.meetingStartDurationMs = meetingStartDurationMs
         self.meetingDurationMs = meetingDurationMs
         self.meetingErrorMessage = meetingErrorMessage
         self.meetingStatus = meetingStatus

--- a/AmazonChimeSDK/AmazonChimeSDKTests/analytics/EventAttributeNameTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/analytics/EventAttributeNameTests.swift
@@ -27,6 +27,7 @@ class EventAttributeNameTests: XCTestCase {
         XCTAssertEqual(EventAttributeName.meetingId.description, "meetingId")
         XCTAssertEqual(EventAttributeName.meetingHistory.description, "meetingHistory")
         XCTAssertEqual(EventAttributeName.maxVideoTileCount.description, "maxVideoTileCount")
+        XCTAssertEqual(EventAttributeName.meetingDurationMs.description, "meetingStartDurationMs")
         XCTAssertEqual(EventAttributeName.meetingDurationMs.description, "meetingDurationMs")
         XCTAssertEqual(EventAttributeName.meetingErrorMessage.description, "meetingErrorMessage")
         XCTAssertEqual(EventAttributeName.meetingStatus.description, "meetingStatus")

--- a/AmazonChimeSDK/AmazonChimeSDKTests/analytics/EventAttributeNameTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/analytics/EventAttributeNameTests.swift
@@ -27,7 +27,7 @@ class EventAttributeNameTests: XCTestCase {
         XCTAssertEqual(EventAttributeName.meetingId.description, "meetingId")
         XCTAssertEqual(EventAttributeName.meetingHistory.description, "meetingHistory")
         XCTAssertEqual(EventAttributeName.maxVideoTileCount.description, "maxVideoTileCount")
-        XCTAssertEqual(EventAttributeName.meetingDurationMs.description, "meetingStartDurationMs")
+        XCTAssertEqual(EventAttributeName.meetingStartDurationMs.description, "meetingStartDurationMs")
         XCTAssertEqual(EventAttributeName.meetingDurationMs.description, "meetingDurationMs")
         XCTAssertEqual(EventAttributeName.meetingErrorMessage.description, "meetingErrorMessage")
         XCTAssertEqual(EventAttributeName.meetingStatus.description, "meetingStatus")

--- a/AmazonChimeSDK/AmazonChimeSDKTests/ingestion/DefaultEventBufferTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/ingestion/DefaultEventBufferTests.swift
@@ -40,8 +40,8 @@ class DefaultEventBufferTests: XCTestCase {
         dirtyEventDao = mock(DirtyEventDao.self)
         eventSender = mock(EventSender.self)
         logger = mock(Logger.self)
-        given(converter.toIngestionRecord(meetingEvents: any())).willReturn(ingestionRecord)
-        given(converter.toIngestionRecord(dirtyMeetingEvents: any())).willReturn(ingestionRecord)
+        given(converter.toIngestionRecord(meetingEvents: any(), ingestionConfiguration: any())).willReturn(ingestionRecord)
+        given(converter.toIngestionRecord(dirtyMeetingEvents: any(), ingestionConfiguration: any())).willReturn(ingestionRecord)
         given(dirtyEventDao.queryDirtyMeetingEventItems(size: any())).willReturn([DirtyMeetingEventItem(id: "aa", data: ingestionEvent, ttl: 11123)])
 
         given(converter.toIngestionMeetingEvent(event: any(), ingestionConfiguration: any())).willReturn(IngestionMeetingEvent(name: "dsfdsf", eventAttributes: IngestionEventAttributes()))
@@ -69,6 +69,6 @@ class DefaultEventBufferTests: XCTestCase {
 
         verify(eventDao.queryMeetingEventItems(size: any())).wasCalled(1)
         verify(eventSender.sendEvents(ingestionRecord: any(), completionHandler: any())).wasCalled(2)
-        verify(converter.toIngestionRecord(meetingEvents: any())).wasCalled(1)
+        verify(converter.toIngestionRecord(meetingEvents: any(), ingestionConfiguration: any())).wasCalled(1)
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
-### Fixed
-* Fixed Mobile SDK metrics missing issue by adding meetingStartDurationMs event
+### Added
+* Added the meetingStartDurationMs event in ingestionEvents to record the time that elapsed between the start request and the beginning of the meeting.
 
 ## [0.18.0] - 2021-12-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Fixed
+* Fixed Mobile SDK metrics missing issue by adding meetingStartDurationMs event
+
 ## [0.18.0] - 2021-12-21
 
 ### Changed


### PR DESCRIPTION
### Issue #, if available:
https://issues.amazon.com/issues/Chime-41485
### Description of changes:
Just like JS SDK we need an event meetingStartDurationMs - the time that elapsed between the start request audioVideo.start and the beginning of the meeting AudioVideoObserver.audioVideoDidStart.
* Add an attribute `meetingStartDurationMs` in `IngestionPayload`.
* Replace `EventAttributeUtils.getCommonAttributes()` with `EventAttributeUtils.getCommonAttributes(ingestionConfiguration: ingestionConfiguration))` to include `meetingId` and `attendeeId` in metadata, which could enable the metrics.
* Send meetingEnded event immediately when it ends, which could avoid the failure of sending event after the end of meeting.

### Testing done:
Sanity Test done.
#### Manual test cases (add more as needed):

- [ ] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [ ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
