### PR TITLE
Added NoDevice audio mode

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/audio/AudioMode.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/audio/AudioMode.swift
@@ -19,6 +19,8 @@ import Foundation
     /// The stereo audio mode with two audio channels for speaker, and single audio channel for microphone, both with 48KHz sampling rate.
     case stereo48K = 3
 
+    case nodevice = 4
+
     public var description: String {
         switch self {
         case .mono16K:
@@ -27,6 +29,8 @@ import Foundation
             return "mono48K"
         case .stereo48K:
             return "stereo48K"
+        case .nodevice:
+            return "nodevice"
         }
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
@@ -104,6 +104,8 @@ extension DefaultAudioClientController: AudioClientController {
             audioModeInternal = .Mono48K
         } else if (audioMode == .mono16K) {
             audioModeInternal = .Mono16K
+        } else if (audioMode == .nodevice) {
+            audioModeInternal = .NoDevice
         }
         let status = audioClient.startSession(host,
                                               basePort: port,

--- a/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/AudioVideoConfigurationTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/AudioVideoConfigurationTests.swift
@@ -30,5 +30,9 @@ class AudioVideoConfigurationTests: XCTestCase {
         let audioVideoConfigCallkit = AudioVideoConfiguration(callKitEnabled: true)
         XCTAssertEqual(audioVideoConfigCallkit.audioMode, .stereo48K)
         XCTAssertEqual(audioVideoConfigCallkit.callKitEnabled, true)
+
+        let audioVideoConfigAudioModeNoDevice = AudioVideoConfiguration(audioMode: .nodevice)
+        XCTAssertEqual(audioVideoConfigAudioModeNoDevice.audioMode, .nodevice)
+        XCTAssertEqual(audioVideoConfigAudioModeNoDevice.callKitEnabled, false)
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/DefaultAudioVideoControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/DefaultAudioVideoControllerTests.swift
@@ -99,6 +99,36 @@ class DefaultAudioVideoControllerTests: CommonTestCase {
         verify(videoClientControllerMock.start()).wasCalled()
     }
 
+    func testStart_nodevice_callKitDisabled() {
+        XCTAssertNoThrow(try defaultAudioVideoController.start(audioVideoConfiguration: AudioVideoConfiguration(audioMode: .nodevice, callKitEnabled: false)))
+
+        verify(audioClientControllerMock.start(
+            audioFallbackUrl: self.meetingSessionConfigurationMock.urls.audioFallbackUrl,
+            audioHostUrl: self.meetingSessionConfigurationMock.urls.audioHostUrl,
+            meetingId: self.meetingSessionConfigurationMock.meetingId,
+            attendeeId: self.meetingSessionConfigurationMock.credentials.attendeeId,
+            joinToken: self.meetingSessionConfigurationMock.credentials.joinToken,
+            callKitEnabled: false,
+            audioMode: .nodevice
+        )).wasCalled()
+        verify(videoClientControllerMock.start()).wasCalled()
+    }
+
+    func testStart_nodevice_callKitEnabled() {
+        XCTAssertNoThrow(try defaultAudioVideoController.start(audioVideoConfiguration: AudioVideoConfiguration(audioMode: .nodevice, callKitEnabled: true)))
+
+        verify(audioClientControllerMock.start(
+            audioFallbackUrl: self.meetingSessionConfigurationMock.urls.audioFallbackUrl,
+            audioHostUrl: self.meetingSessionConfigurationMock.urls.audioHostUrl,
+            meetingId: self.meetingSessionConfigurationMock.meetingId,
+            attendeeId: self.meetingSessionConfigurationMock.credentials.attendeeId,
+            joinToken: self.meetingSessionConfigurationMock.credentials.joinToken,
+            callKitEnabled: true,
+            audioMode: .nodevice
+        )).wasCalled()
+        verify(videoClientControllerMock.start()).wasCalled()
+    }
+
     func testStart_mono16K_callKitDisabled() {
         XCTAssertNoThrow(try defaultAudioVideoController.start(audioVideoConfiguration: AudioVideoConfiguration(audioMode: .mono16K, callKitEnabled: false)))
 

--- a/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/audio/AudioModeTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/audio/AudioModeTests.swift
@@ -13,5 +13,6 @@ class AudioModeTests: XCTestCase {
         XCTAssertEqual(AudioMode.mono16K.description, "mono16K")
         XCTAssertEqual(AudioMode.mono48K.description, "mono48K")
         XCTAssertEqual(AudioMode.stereo48K.description, "stereo48K")
+        XCTAssertEqual(AudioMode.nodevice.description, "nodevice")
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientControllerTests.swift
@@ -207,6 +207,35 @@ class DefaultAudioClientControllerTests: CommonTestCase {
         verify(audioLockMock.unlock()).wasCalled()
     }
 
+    func testStartWithNoDevice_startedOk() {
+        DefaultAudioClientController.state = .initialized
+
+        XCTAssertNoThrow(try defaultAudioClientController.start(audioFallbackUrl: audioFallbackUrl,
+                                                                audioHostUrl: audioHostUrlWithPort,
+                                                                meetingId: meetingId,
+                                                                attendeeId: attendeeId,
+                                                                joinToken: joinToken,
+                                                                callKitEnabled: callKitEnabled,
+                                                                audioMode: .nodevice))
+        verify(audioLockMock.lock()).wasCalled()
+        verify(audioClientObserverMock.notifyAudioClientObserver(observerFunction: any())).wasCalled()
+        verify(audioClientMock.startSession(self.audioHostUrl,
+                                            basePort: 1820,
+                                            callId: self.meetingId,
+                                            profileId: self.attendeeId,
+                                            microphoneMute: false,
+                                            speakerMute: false,
+                                            isPresenter: true,
+                                            sessionToken: self.joinToken,
+                                            audioWsUrl: self.audioFallbackUrl,
+                                            callKitEnabled: false,
+                                            appInfo: any(),
+                                            audioMode: .nodevice)).wasCalled()
+        verify(eventAnalyticsControllerMock.publishEvent(name: .meetingStartRequested)).wasCalled()
+        XCTAssertEqual(.started, DefaultAudioClientController.state)
+        verify(audioLockMock.unlock()).wasCalled()
+    }
+
     func testStart_failedToStart() {
         DefaultAudioClientController.state = .initialized
         given(audioClientMock.startSession(any(),

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientControllerTests.swift
@@ -230,7 +230,7 @@ class DefaultAudioClientControllerTests: CommonTestCase {
                                             audioWsUrl: self.audioFallbackUrl,
                                             callKitEnabled: false,
                                             appInfo: any(),
-                                            audioMode: .nodevice)).wasCalled()
+                                            audioMode: .NoDevice)).wasCalled()
         verify(eventAnalyticsControllerMock.publishEvent(name: .meetingStartRequested)).wasCalled()
         XCTAssertEqual(.started, DefaultAudioClientController.state)
         verify(audioLockMock.unlock()).wasCalled()


### PR DESCRIPTION
### Issue #, if available:
https://sim.amazon.com/issues/Chime-47005

### Description of changes:
Added NoDevice mode, in which audio devices will not be initialized in a meeting without audio.

### Testing done:
Tested with Xcode on iPad. When set to nodevice mode in debugging build, the behaviors were expected -

1. No audio were heard both way.
2. iOS remote presence was available.
3. Mic and speaker on iPad were not initialized.

#### Manual test cases (add more as needed):

- [x] Join meeting without CallKit
- [x] Join meeting with CallKit as Incoming
- [x] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [x] Rejoin meeting
- [x] See metrics
- [x] See attendee presence
- [x] Send audio
- [x] Receive audio
- [x] Mute self
- [x] Unmute self
- [x] See local mute indicator when muted
- [x] See remote mute indicator when other is muted
- [x] Enable and disable local video
- [x] Enable and disable remote video from remote side
- [x] Send local video
- [x] Pause and resume remote video
- [x] Switch local camera
- [x] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
