### PR TITLE
Audio permission check is not required in nodevice audio mode

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
@@ -73,8 +73,11 @@ extension DefaultAudioClientController: AudioClientController {
         defer {
             audioLock.unlock()
         }
-        guard audioSession.recordPermission == .granted else {
-            throw PermissionError.audioPermissionError
+        
+        if audioMode != .nodevice {
+            guard audioSession.recordPermission == .granted else {
+                throw PermissionError.audioPermissionError
+            }
         }
 
         if Self.state == .started {


### PR DESCRIPTION
### Issue #, if available:
Chime-47643

### Description of changes:
Do not check audio permission when join a meeting with nodevice audio mode.

### Testing done:

#### Manual test cases (add more as needed):

- [x] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [x] Rejoin meeting
- [x] See metrics
- [x] See attendee presence
- [] Send audio
- [x] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [x] See remote mute indicator when other is muted
- [x] Enable and disable local video
- [x] Enable and disable remote video from remote side
- [x] Send local video
- [x] Pause and resume remote video
- [x] Switch local camera
- [x] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
