### PR TITLE
Fix LT canary gamma failure in saucelabs IOS

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/LiveTranscriptionOptionsViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/LiveTranscriptionOptionsViewController.swift
@@ -16,6 +16,7 @@ class LiveTranscriptionOptionsViewController: UIViewController, UITextFieldDeleg
     var engineSelected = ""
     var languageSelected = ""
     var regionSelected = ""
+    var meetingEndpointUrl = ""
     
     @IBOutlet var startTranscriptionButton: UIButton!
     @IBOutlet var engineTextField: UITextField!
@@ -130,10 +131,11 @@ class LiveTranscriptionOptionsViewController: UIViewController, UITextFieldDeleg
         self.languageTextField.delegate = self
         self.regionTextField.delegate = self
         
-        guard let meetingId = self.model?.meetingId else {
+        guard let meetingId = self.model?.meetingId, let meetingEndpointUrl = self.model?.meetingEndpointUrl else {
             return MeetingModule.shared().dismissTranscription(self)
         }
         self.meetingId = meetingId
+        self.meetingEndpointUrl = meetingEndpointUrl
         engineTextField.inputView = enginePickerView
         languageTextField.inputView = languagePickerView
         regionTextField.inputView = regionPickerView
@@ -159,8 +161,7 @@ class LiveTranscriptionOptionsViewController: UIViewController, UITextFieldDeleg
     }
     
     @IBAction func startTranscriptionButton(_ sender: UIButton) {
-        var url = AppConfiguration.url
-        url = url.hasSuffix("/") ? url : "\(url)/"
+        let url = self.meetingEndpointUrl.hasSuffix("/") ? self.meetingEndpointUrl : "\(self.meetingEndpointUrl)/"
         let encodedURL = HttpUtils.encodeStrForURL(
             str: "\(url)start_transcription?title=\(meetingId)&language=\(languageSelected)&region=\(regionSelected)&engine=\(engineSelected)")
         HttpUtils.postRequest(url: encodedURL, jsonData: nil) {_, error in

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -23,6 +23,7 @@ class MeetingModel: NSObject {
 
     // Dependencies
     let meetingId: String
+    let meetingEndpointUrl: String
     let selfName: String
     var audioVideoConfig = AudioVideoConfiguration()
     let callKitOption: CallKitOption
@@ -124,8 +125,10 @@ class MeetingModel: NSObject {
          meetingId: String,
          selfName: String,
          audioVideoConfig: AudioVideoConfiguration,
-         callKitOption: CallKitOption) {
+         callKitOption: CallKitOption,
+         meetingEndpointUrl: String) {
         self.meetingId = meetingId
+        self.meetingEndpointUrl = meetingEndpointUrl.isEmpty ? AppConfiguration.url : meetingEndpointUrl
         self.selfName = selfName
         self.audioVideoConfig = audioVideoConfig
         self.callKitOption = callKitOption
@@ -199,8 +202,7 @@ class MeetingModel: NSObject {
     }
     
     func postStopTranscriptionRequest() {
-        var url = AppConfiguration.url
-        url = url.hasSuffix("/") ? url : "\(url)/"
+        let url = self.meetingEndpointUrl.hasSuffix("/") ? self.meetingEndpointUrl : "\(self.meetingEndpointUrl)/"
         let encodedURL = HttpUtils.encodeStrForURL(
                 str: "\(url)stop_transcription?title=\(meetingId)")
         HttpUtils.postRequest(url: encodedURL, jsonData: nil) { _, error in

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModule.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModule.swift
@@ -53,7 +53,8 @@ class MeetingModule {
                                                 meetingId: meetingId,
                                                 selfName: selfName,
                                                 audioVideoConfig: audioVideoConfig,
-                                                callKitOption: option)
+                                                callKitOption: option,
+                                                meetingEndpointUrl: overriddenEndpoint)
                 self.meetings[meetingModel.uuid] = meetingModel
 
                 switch option {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 ### Added
-* [Demo] Fix for Mobile SDK Gamma Canary failures in saucelabs. Added support for overridden meeting endpoint url in demo app.
+* [Demo] Added overridden endpoint url capability to live transcription API.
 
 ## [0.19.0] - 2022-02-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Added
+* [Demo] Fix for Mobile SDK Gamma Canary failures in saucelabs. Added support for overridden meeting endpoint url in demo app.
+
 ## [0.19.0] - 2022-02-24
 
 ### Added


### PR DESCRIPTION
### Issue #, if available:

### Description of changes:
Mobile SDK Gamma Canary were failing with 100% failure rate in saucelabs. The issue was in the demo app not handling the scenario when meeting endpoint url is overridden. This change adds the logic to consider the url's based on whether it is overridden or not in the demo app.
### Testing done:
Yes. The demo app was tested in local using physical device.

#### Manual test cases (add more as needed):
Test Case 1: With overridden endpoint
Join a meeting by overriding meeting endpoint url.
Enable Live Transcription.
Captions are showing transcriptions message.
Stop Live Transcription.
Live Transcription is stopped successfully.

Test Case 2: Without overriding endpoint URL.
Add test_url in strings.xml file
Join meeting
Start Live Transcriptions
Captions are showing transcripted statements
Stop Live Transcription.
- [ ] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [ ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
