### PR TITLE
Add ability to join primary meeting from replica, add demo features

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
+++ b/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
@@ -160,6 +160,7 @@
 		5AE76F3624204A03009C41FD /* MediaDeviceTypeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AE76F3524204A03009C41FD /* MediaDeviceTypeTests.swift */; };
 		5AF7E00E245B6E86006C7C86 /* VersioningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF7E00D245B6E86006C7C86 /* VersioningTests.swift */; };
 		6A01CAE523F8FCAF005C5193 /* ClientMetricsCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A01CAE423F8FCAF005C5193 /* ClientMetricsCollectorTests.swift */; };
+		6A26542127E1207D00C8885F /* PrimaryMeetingPromotionObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A26542027E1207D00C8885F /* PrimaryMeetingPromotionObserver.swift */; };
 		6A68E79F24196773004F5A56 /* VideoPauseState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A68E79E24196773004F5A56 /* VideoPauseState.swift */; };
 		6AA9F93F2522438F00EB0644 /* VideoSourceAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA9F93E2522438F00EB0644 /* VideoSourceAdapter.swift */; };
 		6AA9F9462522439F00EB0644 /* VideoSink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA9F9402522439F00EB0644 /* VideoSink.swift */; };
@@ -432,8 +433,9 @@
 		5AE76F33242049E0009C41FD /* MediaDeviceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDeviceType.swift; sourceTree = "<group>"; };
 		5AE76F3524204A03009C41FD /* MediaDeviceTypeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaDeviceTypeTests.swift; sourceTree = "<group>"; };
 		5AF7E00D245B6E86006C7C86 /* VersioningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersioningTests.swift; sourceTree = "<group>"; };
-		5E7CEAE89DD08E6E863FC8BE /* AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; lastKnownFileType = sourcecode.swift; name = "AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift"; path = "MockingbirdMocks/AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift"; sourceTree = "<group>"; };
+		5E7CEAE89DD08E6E863FC8BE /* AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; name = "AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift"; path = "MockingbirdMocks/AmazonChimeSDKTests-AmazonChimeSDKMocks.generated.swift"; sourceTree = "<group>"; };
 		6A01CAE423F8FCAF005C5193 /* ClientMetricsCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClientMetricsCollectorTests.swift; sourceTree = "<group>"; };
+		6A26542027E1207D00C8885F /* PrimaryMeetingPromotionObserver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrimaryMeetingPromotionObserver.swift; sourceTree = "<group>"; };
 		6A68E79E24196773004F5A56 /* VideoPauseState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPauseState.swift; sourceTree = "<group>"; };
 		6AA9F93E2522438F00EB0644 /* VideoSourceAdapter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoSourceAdapter.swift; sourceTree = "<group>"; };
 		6AA9F9402522439F00EB0644 /* VideoSink.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoSink.swift; sourceTree = "<group>"; };
@@ -851,6 +853,7 @@
 				F82D50C223FC732300D8F18C /* SignalStrength.swift */,
 				F82D50C323FC732300D8F18C /* VolumeLevel.swift */,
 				8278478C27188D110071E7BE /* AudioVideoConfiguration.swift */,
+				6A26542027E1207D00C8885F /* PrimaryMeetingPromotionObserver.swift */,
 			);
 			path = audiovideo;
 			sourceTree = "<group>";
@@ -1539,6 +1542,7 @@
 				00D12B8B265F02130059461B /* NoopEventReporterFactory.swift in Sources */,
 				C4643F0625784EEB0085D51E /* DefaultModality.swift in Sources */,
 				820288D42735997100B0B5D3 /* AudioMode.swift in Sources */,
+				6A26542127E1207D00C8885F /* PrimaryMeetingPromotionObserver.swift in Sources */,
 				5A6A209923CB1164000C9157 /* DefaultMeetingSession.swift in Sources */,
 				0083A11623D8CFFD0057027A /* DefaultRealtimeController.swift in Sources */,
 				00D9DBB2241AE23F00146467 /* DefaultVideoClient.swift in Sources */,

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoControllerFacade.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoControllerFacade.swift
@@ -112,4 +112,37 @@ import Foundation
     /// - Parameter addedOrUpdated: Dictionary of remote video sources to configurations to add or update
     /// - Parameter removed: Array of remote video sources to remove
     func updateVideoSourceSubscriptions(addedOrUpdated: Dictionary<RemoteVideoSource, VideoSubscriptionConfiguration>, removed: Array<RemoteVideoSource>)
+
+    /// Allows an attendee in a Replica meeting to immediately transition to a Primary meeting attendee
+    /// without need for reconnection.
+    ///
+    ///  `PrimaryMeetingPromotionObserver.didPromoteToPrimaryMeeting` will be called exactly once on `observer` for each call. If
+    ///  the promotion is successful,  `PrimaryMeetingPromotionObserver.didDemoteFromPrimaryMeeting` will be called exactly once
+    ///  if/when the attendee is demoted. See the observer documentation for possible status codes.
+    ///
+    /// Application code may also receive a callback on `AudioVideoObserver.videoSessionDidStartWithStatus` without
+    /// `MeetingSessionStatusCode.VideoAtCapacityViewOnly` to indicate they can begin to share video.
+    ///
+    /// `chime::DeleteAttendee` on the Primary meeting attendee will result in `PrimaryMeetingPromotionObserver.didDemoteFromPrimaryMeeting`
+    /// to indicate the attendee is no longer able to share.
+    ///
+    /// Any disconnection will trigger an automatic demotion to avoid unexpected or unwanted promotion state on reconnection.
+    /// This will also call `PrimaryMeetingPromotionObserver.didDemoteFromPrimaryMeeting`;  if the attendee still needs to be
+    /// an interactive participant in the Primary meeting, `promoteToPrimaryMeeting` should be called again with the same credentials.
+    ///
+    /// Note that given the asynchronous nature of this function, this should not be called a second time before
+    /// `PrimaryMeetingPromotionObserver.didPromoteToPrimaryMeeting` is called for the first time. Doing so may result in unexpected
+    /// behavior.
+    ///
+    /// - Parameter credentials: The credentials for the primary meeting.  This needs to be obtained out of band.
+    /// - Returns: Promise which resolves to a session status for the request. See possible options above.
+    func promoteToPrimaryMeeting(credentials: MeetingSessionCredentials, observer: PrimaryMeetingPromotionObserver)
+
+    /// Remove the promoted attendee from the Primary meeting. This client will stop sharing audio, video, and data messages.
+    /// This will revert the end-user to precisely the state they were before a call to `promoteToPrimaryMeeting`]`
+    ///
+    /// This will have no effect if there was no previous successful call to `promoteToPrimaryMeeting`]`. This
+    /// may result in `PrimaryMeetingPromotionObserver.didPromoteToPrimaryMeeting`]` but there is no need to wait for that callback
+    /// to revert UX, etc.
+    func demoteFromPrimaryMeeting()
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoController.swift
@@ -18,6 +18,7 @@ import Foundation
     private let clientMetricsCollector: ClientMetricsCollector
     private var videoClientController: VideoClientController
     private let videoTileController: VideoTileController
+    private var primaryMeetingPromotionObserver: PrimaryMeetingPromotionObserver?
 
     public init(audioClientController: AudioClientController,
                 audioClientObserver: AudioClientObserver,
@@ -102,5 +103,94 @@ import Foundation
     
     public func updateVideoSourceSubscriptions(addedOrUpdated: Dictionary<RemoteVideoSource, VideoSubscriptionConfiguration>, removed: Array<RemoteVideoSource>) {
         videoClientController.updateVideoSourceSubscriptions(addedOrUpdated: addedOrUpdated, removed: removed)
+    }
+
+    public func promoteToPrimaryMeeting(
+        credentials: MeetingSessionCredentials,
+        observer: PrimaryMeetingPromotionObserver) {
+        let group = DispatchGroup()
+        var videoClientPromotionStatus: MeetingSessionStatus?
+        let videoClientPromotionCallback = { (status: MeetingSessionStatus) -> Void in
+            self.logger.info(
+                msg: "Video primary meeting promotion has completed with status \(status.statusCode.description)")
+            videoClientPromotionStatus = status
+            group.leave()
+        }
+        let videoClientDemotionCallback = { (status: MeetingSessionStatus) -> Void in
+            self.logger.info(
+                msg: "Video primary meeting demotion has completed with status \(status.statusCode.description)")
+            self.audioClientController.demoteFromPrimaryMeeting()
+            observer.didDemoteFromPrimaryMeeting(status: status)
+        }
+        group.enter()
+        var audioClientPromotionStatus: MeetingSessionStatus?
+        let audioClientPromotionCallback = { (status: MeetingSessionStatus) -> Void in
+            self.logger.info(
+                msg: "Video primary meeting join has completed with status \(status.statusCode.description)")
+            audioClientPromotionStatus = status
+            group.leave()
+        }
+        let audioClientDemotionCallback = { (status: MeetingSessionStatus) -> Void in
+            self.logger.info(
+                msg: "Audio primary meeting demotion has completed with status \(status.statusCode.description)")
+            self.videoClientController.demoteFromPrimaryMeeting()
+            observer.didDemoteFromPrimaryMeeting(status: status)
+        }
+        group.enter()
+
+        // In these observers we try demoting the other client. Note that the individual controllers
+        // do not follow the exact same pattern of calling back on observer (with `MeetingSessionStatusCode.OK` in
+        // the case of explicit demotion request so we don't need to worry about any infinite loops
+        class PrimaryMeetingPromotionObserverAdapter: PrimaryMeetingPromotionObserver {
+            var promotionCallback: (MeetingSessionStatus) -> Void
+            var demotionCallback: (MeetingSessionStatus) -> Void
+
+            init(promotionCallback: @escaping (MeetingSessionStatus) -> Void,
+                demotionCallback: @escaping (MeetingSessionStatus) -> Void) {
+                self.promotionCallback = promotionCallback
+                self.demotionCallback = demotionCallback
+            }
+
+            func didPromoteToPrimaryMeeting(status: MeetingSessionStatus) {
+                self.promotionCallback(status)
+            }
+
+            func didDemoteFromPrimaryMeeting(status: MeetingSessionStatus) {
+                self.demotionCallback(status)
+            }
+        }
+        let videoClientPromotionObserverAdapter = PrimaryMeetingPromotionObserverAdapter(
+            promotionCallback: videoClientPromotionCallback,
+            demotionCallback: videoClientDemotionCallback)
+        let audioClientPromotionObserverAdapter = PrimaryMeetingPromotionObserverAdapter(
+            promotionCallback: audioClientPromotionCallback,
+            demotionCallback: audioClientDemotionCallback)
+        primaryMeetingPromotionObserver = observer // Store for demotion
+        videoClientController.promoteToPrimaryMeeting(credentials: credentials,
+                                                      observer: videoClientPromotionObserverAdapter)
+        audioClientController.promoteToPrimaryMeeting(credentials: credentials,
+                                                        observer: audioClientPromotionObserverAdapter)
+            
+        group.notify(queue: DispatchQueue.main) {
+            if let videoClientStatus = videoClientPromotionStatus, let audioClientStatus = audioClientPromotionStatus {
+                // Mux the statuses together, single failure is total failure
+                if videoClientStatus.statusCode != MeetingSessionStatusCode.ok {
+                    self.audioClientController.demoteFromPrimaryMeeting() // Leave other controller
+                    observer.didPromoteToPrimaryMeeting(status: videoClientStatus)
+                } else if audioClientStatus.statusCode != MeetingSessionStatusCode.ok {
+                    self.videoClientController.demoteFromPrimaryMeeting()  // Leave other controller
+                    observer.didPromoteToPrimaryMeeting(status: audioClientStatus)
+                } else {
+                    observer.didPromoteToPrimaryMeeting(status: videoClientStatus) // Just use video client status
+                }
+            }
+        }
+    }
+
+    public func demoteFromPrimaryMeeting() {
+        videoClientController.demoteFromPrimaryMeeting()
+        audioClientController.demoteFromPrimaryMeeting()
+        primaryMeetingPromotionObserver?.didDemoteFromPrimaryMeeting(
+            status: MeetingSessionStatus(statusCode: MeetingSessionStatusCode.ok))
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
@@ -151,6 +151,16 @@ import Foundation
         audioVideoController.updateVideoSourceSubscriptions(addedOrUpdated: addedOrUpdated, removed: removed)
     }
 
+    public func promoteToPrimaryMeeting(credentials: MeetingSessionCredentials, observer: PrimaryMeetingPromotionObserver) {
+        audioVideoController.promoteToPrimaryMeeting(credentials: credentials, observer: observer)
+    }
+
+    public func demoteFromPrimaryMeeting() {
+        audioVideoController.demoteFromPrimaryMeeting()
+        // Stop content share as well
+        contentShareController.stopContentShare()
+    }
+
     // MARK: DeviceController
 
     public func listAudioDevices() -> [MediaDevice] {

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/PrimaryMeetingPromotionObserver.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/PrimaryMeetingPromotionObserver.swift
@@ -1,0 +1,55 @@
+//
+//  PrimaryMeetingPromotionObserver.swift
+//  AmazonChimeSDK
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// `PrimaryMeetingPromotionObserver` handles events related to Primary meeting promotion.
+/// See `AudioVideoControllerFacade.promoteToPrimaryMeeting` for more information.
+@objc public protocol PrimaryMeetingPromotionObserver {
+    /// Called when the `AudioVideoControllerFacade.promoteToPrimaryMeeting` completes.
+    ///
+    /// `MeetingSessionStatus`  that will contain a `MeetingSessionStatusCode` of the following:
+    ///
+    /// * `MeetingSessionStatusCode.ok`: The promotion was successful (i.e. session token was valid,
+    ///   there was room in the Primary meeting, etc.), audio will begin flowing
+    ///   and the attendee can begin to send data messages, and content/video if the call is not already at limit.
+    /// * `MeetingSessionStatusCode.audioAuthenticationRejected`: Credentials provided
+    ///   were invalid when connection attempted to Primary meeting. There may be an issue
+    ///   with your mechanism which allocates the Primary meeting attendee for the Replica
+    ///   meeting proxied promotion.  This also may indicate that this API was called in a
+    ///   non-Replica meeting.
+    /// * `MeetingSessionStatusCode.audioCallAtCapacity`: Credentials provided were correct
+    ///   but there was no room in the Primary meeting.  Promotions to Primary meeting attendee take up a slot, just like
+    ///   regular Primary meeting attendee connections and are limited by the same mechanisms.
+    /// * `MeetingSessionStatusCode.audioServiceUnavailable`: Media has not been connected yet so promotion is not yet possible.
+    /// * `MeetingSessionStatusCode.audioInternalServerError`: Other failure, possibly due to disconnect
+    ///   or timeout. These failures are likely retryable.
+    ///
+    /// Note: this callback will be called on main thread.
+    ///
+    /// - Parameter status: See notes above
+    func didPromoteToPrimaryMeeting(status: MeetingSessionStatus)
+
+    /// This observer callback will only be called for attendees in Replica meetings that have
+    /// been promoted to the Primary meeting via `AudioVideoFacade.promoteToPrimaryMeeting`.
+    ///
+    /// Indicates that the client is no longer authenticated to the Primary meeting
+    /// and can no longer share media. `status` will contain a `MeetingSessionStatusCode` of the following:
+    ///
+    /// * `MeetingSessionStatusCode.ok`: `AudioVideoFacade.demoteFromPrimaryMeeting` was used to remove the attendee.
+    /// * `MeetingSessionStatusCode.audioAuthenticationRejected`: `chime::DeleteAttendee` was called on the Primary
+    ///   meeting attendee used in `AudioVideoFacade.promoteToPrimaryMeeting`.
+    /// * `MeetingSessionStatusCode.audioInternalServerError`: Other failure, possibly due to disconnect
+    ///   or timeout. These failures are likely retryable. Any disconnection will trigger an automatic
+    ///   demotion to avoid unexpected or unwanted promotion state on reconnection.
+    ///
+    /// Note: this callback will be called on main thread.
+    ///
+    /// - Parameter status: See notes above
+    func didDemoteFromPrimaryMeeting(status: MeetingSessionStatus)
+}

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
@@ -171,6 +171,26 @@ extension DefaultAudioClientController: AudioClientController {
         }
     }
 
+    func promoteToPrimaryMeeting(credentials: MeetingSessionCredentials, observer: PrimaryMeetingPromotionObserver) {
+        guard Self.state == .started else {
+            logger.error(msg: "Cannot join primary meeting because state=\(Self.state)")
+            observer.didPromoteToPrimaryMeeting(status: MeetingSessionStatus(statusCode: MeetingSessionStatusCode.audioServiceUnavailable))
+            return
+        }
+        audioClientObserver.setPrimaryMeetingPromotionObserver(observer: observer)
+        audioClient.joinPrimaryMeeting(credentials.attendeeId,
+                                        externalUserId: credentials.externalUserId,
+                                        joinToken: credentials.joinToken)
+    }
+
+    func demoteFromPrimaryMeeting() {
+        guard Self.state == .started else {
+            logger.error(msg: "Cannot leave primary meeting because state=\(Self.state)")
+            return
+        }
+        audioClient.leavePrimaryMeeting()
+    }
+
     private func notifyStop() {
         eventAnalyticsController.publishEvent(name: .meetingEnded,
                                               attributes: [EventAttributeName.meetingStatus: MeetingSessionStatusCode.ok])

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientObserver.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientObserver.swift
@@ -24,6 +24,7 @@ class DefaultAudioClientObserver: NSObject, AudioClientDelegate {
     private let logger: Logger
     private let eventAnalyticsController: EventAnalyticsController
     private let meetingStatsCollector: MeetingStatsCollector
+    private var primaryMeetingPromotionObserver: PrimaryMeetingPromotionObserver?
 
     private let audioLock: AudioLock
 
@@ -269,6 +270,33 @@ class DefaultAudioClientObserver: NSObject, AudioClientDelegate {
         }
     }
 
+    public func primaryMeetingEventReceived(
+        _ type: PrimaryMeetingEventTypeInternal,
+        status: PrimaryMeetingEventStatusInternal) {
+        let code: MeetingSessionStatusCode
+        switch status {
+        case PrimaryMeetingEventStatusInternal.Ok:
+            code = MeetingSessionStatusCode.ok
+        case PrimaryMeetingEventStatusInternal.CallAtCapacity:
+            code = MeetingSessionStatusCode.audioCallAtCapacity
+        case PrimaryMeetingEventStatusInternal.AuthenticationFailed:
+            code = MeetingSessionStatusCode.audioAuthenticationRejected
+        default:
+            code = MeetingSessionStatusCode.unknown
+        }
+
+        switch type {
+        case PrimaryMeetingEventTypeInternal.joinAck:
+            self.primaryMeetingPromotionObserver?
+                .didPromoteToPrimaryMeeting(status: MeetingSessionStatus(statusCode: code))
+        case PrimaryMeetingEventTypeInternal.leave:
+            self.primaryMeetingPromotionObserver?
+                .didDemoteFromPrimaryMeeting(status: MeetingSessionStatus(statusCode: code))
+        default:
+            self.logger.error(msg: "Unexpected primary meeting event type \(type)")
+        }
+    }
+
     // Create AttendeeInfo based on AttendeeUpdate, fill up external ID for local attendee
     private func createAttendeeInfo(attendeeUpdate: AttendeeUpdate) -> AttendeeInfo {
         var externalUserId: String
@@ -422,5 +450,9 @@ extension DefaultAudioClientObserver: AudioClientObserver {
 
     func unsubscribeFromTranscriptEvent(observer: TranscriptEventObserver) {
         transcriptEventObservers.remove(observer)
+    }
+
+    func setPrimaryMeetingPromotionObserver(observer: PrimaryMeetingPromotionObserver) {
+        primaryMeetingPromotionObserver = observer
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientController.swift
@@ -20,4 +20,6 @@ import Foundation
     func stop()
     func setVoiceFocusEnabled(enabled: Bool) -> Bool
     func isVoiceFocusEnabled() -> Bool
+    func promoteToPrimaryMeeting(credentials: MeetingSessionCredentials, observer: PrimaryMeetingPromotionObserver)
+    func demoteFromPrimaryMeeting()
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientObserver.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientObserver.swift
@@ -16,4 +16,5 @@ import Foundation
     func unsubscribeFromRealTimeEvents(observer: RealtimeObserver)
     func subscribeToTranscriptEvent(observer: TranscriptEventObserver)
     func unsubscribeFromTranscriptEvent(observer: TranscriptEventObserver)
+    func setPrimaryMeetingPromotionObserver(observer: PrimaryMeetingPromotionObserver)
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientProtocol.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientProtocol.swift
@@ -72,6 +72,10 @@ import Foundation
 
     func endOnHold()
 
+    func joinPrimaryMeeting(_ attendeeId: String!, externalUserId: String!, joinToken: String!)
+
+    func leavePrimaryMeeting()
+
     var delegate: AudioClientDelegate! { get set }
 }
 

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
@@ -23,6 +23,7 @@ class DefaultVideoClientController: NSObject {
     // We have designed the SDK API to allow using `RemoteVideoSource` as a key in a map, e.g. for  `updateVideoSourceSubscription`.
     // Therefore we need to map to a consistent set of sources from the internal sources, by using attendeeId as a unique identifier.
     var cachedRemoteVideoSources = ConcurrentMutableSet()
+    var primaryMeetingPromotionObserver: PrimaryMeetingPromotionObserver?
 
     private let configuration: MeetingSessionConfiguration
     private let defaultVideoClient: VideoClientProtocol
@@ -285,6 +286,36 @@ extension DefaultVideoClientController: VideoClientDelegate {
     public func videoClientTurnURIsReceived(_ uris: [String]) -> [String] {
         return uris.map(self.configuration.urlRewriter)
     }
+
+    public func videoClientDidCompletePrimaryMeetingJoin(_ status: video_client_status_t) {
+        let code: MeetingSessionStatusCode
+        switch status {
+        case VIDEO_CLIENT_OK:
+            code = MeetingSessionStatusCode.ok
+        case VIDEO_CLIENT_ERR_PRIMARY_MEETING_JOIN_AT_CAPACITY:
+            code = MeetingSessionStatusCode.audioCallAtCapacity
+        case VIDEO_CLIENT_ERR_PRIMARY_MEETING_JOIN_AUTHENTICATION_FAILED:
+            code = MeetingSessionStatusCode.audioAuthenticationRejected
+        default:
+            code = MeetingSessionStatusCode.unknown
+        }
+        self.primaryMeetingPromotionObserver?
+            .didPromoteToPrimaryMeeting(status: MeetingSessionStatus.init(statusCode: code))
+    }
+
+    public func videoClientPrimaryMeetingDemoted(_ status: video_client_status_t) {
+        let code: MeetingSessionStatusCode
+        switch status {
+        case VIDEO_CLIENT_OK:
+            code = MeetingSessionStatusCode.ok
+        case VIDEO_CLIENT_ERR_PRIMARY_MEETING_JOIN_AUTHENTICATION_FAILED:
+            code = MeetingSessionStatusCode.audioAuthenticationRejected
+        default:
+            code = MeetingSessionStatusCode.unknown
+        }
+        self.primaryMeetingPromotionObserver?
+            .didDemoteFromPrimaryMeeting(status: MeetingSessionStatus.init(statusCode: code))
+    }
 }
 
 extension DefaultVideoClientController: VideoClientController {
@@ -493,5 +524,26 @@ extension DefaultVideoClientController: VideoClientController {
         } else {
             throw SendDataMessageError.invalidData
         }
+    }
+
+    func promoteToPrimaryMeeting(credentials: MeetingSessionCredentials,
+                                  observer: PrimaryMeetingPromotionObserver) {
+        guard videoClientState == .started else {
+            logger.error(msg: "Cannot join primary meeting because videoClientState=\(videoClientState)")
+            observer.didPromoteToPrimaryMeeting(status: MeetingSessionStatus(statusCode: MeetingSessionStatusCode.audioServiceUnavailable))
+            return
+        }
+        primaryMeetingPromotionObserver = observer
+        videoClient?.promotePrimaryMeeting(credentials.attendeeId,
+                                             externalUserId: credentials.externalUserId,
+                                             joinToken: credentials.joinToken)
+    }
+
+    func demoteFromPrimaryMeeting() {
+        guard videoClientState == .started else {
+            logger.error(msg: "Cannot leave primary meeting because videoClientState=\(videoClientState)")
+            return
+        }
+        videoClient?.demoteFromPrimaryMeeting()
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientController.swift
@@ -29,4 +29,7 @@ import Foundation
     func unsubscribeFromReceiveDataMessageFromTopic(topic: String)
     func sendDataMessage(topic: String, data: Any, lifetimeMs: Int32) throws
     func updateVideoSourceSubscriptions(addedOrUpdated: Dictionary<RemoteVideoSource, VideoSubscriptionConfiguration>, removed: Array<RemoteVideoSource>)
+    func promoteToPrimaryMeeting(credentials: MeetingSessionCredentials,
+                                 observer: PrimaryMeetingPromotionObserver)
+    func demoteFromPrimaryMeeting()
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientProtocol.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientProtocol.swift
@@ -44,8 +44,12 @@ import Foundation
 
     func sendDataMessage(_ topic: String!, data: UnsafePointer<Int8>!, lifetimeMs: Int32)
 
-    func updateVideoSourceSubscriptions(_ addedOrUpdated: Dictionary<AnyHashable, Any>!,
-                                        withRemoved: Array<Any>!)
+    func updateVideoSourceSubscriptions(_ addedOrUpdated: [AnyHashable: Any]!,
+                                        withRemoved: [Any]!)
+
+    func promotePrimaryMeeting(_ attendeeId: String!, externalUserId: String!, joinToken: String!)
+
+    func demoteFromPrimaryMeeting()
 }
 
 extension VideoClient: VideoClientProtocol {}

--- a/AmazonChimeSDK/AmazonChimeSDK/session/CreateMeetingResponse.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/session/CreateMeetingResponse.swift
@@ -21,15 +21,18 @@ import Foundation
     let mediaPlacement: MediaPlacement
     let mediaRegion: String
     let meetingId: String
+    let primaryMeetingId: String?
 
     public init(externalMeetingId: String?,
                 mediaPlacement: MediaPlacement,
                 mediaRegion: String,
-                meetingId: String) {
+                meetingId: String,
+                primaryMeetingId: String?) {
         self.externalMeetingId = externalMeetingId
         self.mediaPlacement = mediaPlacement
         self.mediaRegion = mediaRegion
         self.meetingId = meetingId
+        self.primaryMeetingId = primaryMeetingId
     }
 }
 

--- a/AmazonChimeSDK/AmazonChimeSDK/session/MeetingSessionConfiguration.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/session/MeetingSessionConfiguration.swift
@@ -27,6 +27,9 @@ import Foundation
 
     public let urlRewriter: URLRewriter
 
+    /// The id of the primary meeting that this session is joining a replica to
+    public let primaryMeetingId: String?
+
     public convenience init(createMeetingResponse: CreateMeetingResponse,
                             createAttendeeResponse: CreateAttendeeResponse) {
         self.init(createMeetingResponse: createMeetingResponse,
@@ -55,6 +58,7 @@ import Foundation
         self.credentials = credentials
         self.urls = urls
         self.urlRewriter = urlRewriter
+        self.primaryMeetingId = nil
     }
 
     public init(createMeetingResponse: CreateMeetingResponse,
@@ -62,6 +66,7 @@ import Foundation
                 urlRewriter: @escaping URLRewriter) {
         self.meetingId = createMeetingResponse.meeting.meetingId
         self.externalMeetingId = createMeetingResponse.meeting.externalMeetingId
+        self.primaryMeetingId = createMeetingResponse.meeting.primaryMeetingId
         self.credentials = MeetingSessionCredentials(attendeeId: createAttendeeResponse.attendee.attendeeId,
                                                      externalUserId: createAttendeeResponse.attendee.externalUserId,
                                                      joinToken: createAttendeeResponse.attendee.joinToken)

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
@@ -961,6 +961,7 @@
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="additionalOptionsButton" destination="Ief-dn-Lr8" id="3PU-5V-JQ7"/>
+                        <outlet property="broadcastButton" destination="45k-rb-bfn" id="qQI-Hs-yk2"/>
                         <outlet property="broadcastPickerContainerView" destination="45k-rb-bfn" id="DYh-zE-TBa"/>
                         <outlet property="cameraButton" destination="urn-hi-Y25" id="aXe-mE-gEa"/>
                         <outlet property="captionsTableView" destination="qMs-8n-X6I" id="2gX-qe-iRu"/>
@@ -1183,24 +1184,27 @@
                         <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Override Meeting Endpoint" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ugh-Cp-DHh">
-                                <rect key="frame" x="111.66666666666669" y="452.66666666666669" width="205" height="21"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Override Meeting Endpoint" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ugh-Cp-DHh">
+                                <rect key="frame" x="104" y="150" width="205" height="21"/>
                                 <accessibility key="accessibilityConfiguration" identifier="Override Meeting Endpoint Label"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Meeting Endpoint Url" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HWT-wf-Hd8">
-                                <rect key="frame" x="84" y="497.66666666666674" width="260" height="34"/>
+                                <rect key="frame" x="77" y="195" width="260" height="34"/>
                                 <accessibility key="accessibilityConfiguration" identifier="Meeting Endpoint Url Input"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" constant="260" id="sRN-0P-oTP"/>
-                                </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Debug Settings" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dlf-w7-2eY">
-                                <rect key="frame" x="120.66666666666669" y="378.66666666666669" width="187" height="34"/>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Meeting ID" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="gob-qw-3MV">
+                                <rect key="frame" x="77" y="302" width="260" height="34"/>
+                                <accessibility key="accessibilityConfiguration" identifier="Meeting Endpoint Url Input"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="Debug Settings" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Dlf-w7-2eY">
+                                <rect key="frame" x="113" y="76" width="187" height="34"/>
                                 <accessibility key="accessibilityConfiguration" identifier="Debug Settings Title"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="28"/>
                                 <nil key="textColor"/>
@@ -1215,20 +1219,36 @@
                                     <action selector="saveButtonClicked:" destination="GpE-ar-Sxz" eventType="touchUpInside" id="axH-hX-rqO"/>
                                 </connections>
                             </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Primary Meeting ID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JiN-Mk-dD7">
+                                <rect key="frame" x="134" y="259" width="146" height="21"/>
+                                <accessibility key="accessibilityConfiguration" identifier="Override Meeting Endpoint Label"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="HWT-wf-Hd8" firstAttribute="top" secondItem="ugh-Cp-DHh" secondAttribute="bottom" constant="24" id="RKy-ut-1qs"/>
-                            <constraint firstItem="Dlf-w7-2eY" firstAttribute="centerX" secondItem="F9N-fz-NNe" secondAttribute="centerX" id="UoD-tx-rJ7"/>
-                            <constraint firstItem="HWT-wf-Hd8" firstAttribute="centerX" secondItem="F9N-fz-NNe" secondAttribute="centerX" id="Wr9-dd-9ve"/>
-                            <constraint firstItem="YQw-GI-60q" firstAttribute="top" secondItem="AHd-Vp-rMm" secondAttribute="bottom" constant="32" id="Y4u-BA-9hi"/>
-                            <constraint firstItem="ugh-Cp-DHh" firstAttribute="top" secondItem="Dlf-w7-2eY" secondAttribute="bottom" constant="40" id="gFa-1i-Ome"/>
-                            <constraint firstItem="ugh-Cp-DHh" firstAttribute="centerY" secondItem="F9N-fz-NNe" secondAttribute="centerY" id="nLw-bc-E7u"/>
-                            <constraint firstItem="ugh-Cp-DHh" firstAttribute="centerX" secondItem="F9N-fz-NNe" secondAttribute="centerX" id="q5x-e7-Q27"/>
+                            <constraint firstItem="JiN-Mk-dD7" firstAttribute="top" secondItem="HWT-wf-Hd8" secondAttribute="bottom" constant="29.999999999999943" id="0Vk-2V-7Bo"/>
+                            <constraint firstItem="Dlf-w7-2eY" firstAttribute="top" secondItem="4TD-UJ-0Ke" secondAttribute="top" constant="32" id="Ajw-6r-gjw"/>
+                            <constraint firstItem="Dlf-w7-2eY" firstAttribute="centerX" secondItem="ugh-Cp-DHh" secondAttribute="centerX" id="Bk7-7N-5gQ"/>
+                            <constraint firstItem="HWT-wf-Hd8" firstAttribute="top" secondItem="ugh-Cp-DHh" secondAttribute="bottom" constant="24" id="DI9-KN-gys"/>
+                            <constraint firstItem="ugh-Cp-DHh" firstAttribute="centerX" secondItem="HWT-wf-Hd8" secondAttribute="centerX" id="E3j-Mj-yAi"/>
+                            <constraint firstItem="gob-qw-3MV" firstAttribute="centerX" secondItem="AHd-Vp-rMm" secondAttribute="centerX" id="EV2-Va-ZcJ"/>
+                            <constraint firstItem="JiN-Mk-dD7" firstAttribute="centerX" secondItem="gob-qw-3MV" secondAttribute="centerX" id="LuY-FE-elb"/>
+                            <constraint firstItem="gob-qw-3MV" firstAttribute="top" secondItem="JiN-Mk-dD7" secondAttribute="bottom" constant="22" id="MFd-LZ-0PO"/>
+                            <constraint firstItem="4TD-UJ-0Ke" firstAttribute="bottom" secondItem="AHd-Vp-rMm" secondAttribute="bottom" constant="32" id="Y4u-BA-9hi"/>
+                            <constraint firstItem="HWT-wf-Hd8" firstAttribute="trailing" secondItem="gob-qw-3MV" secondAttribute="trailing" id="h3t-vO-T8w"/>
+                            <constraint firstItem="ugh-Cp-DHh" firstAttribute="top" secondItem="Dlf-w7-2eY" secondAttribute="bottom" constant="40" id="oE6-em-IIS"/>
                             <constraint firstItem="AHd-Vp-rMm" firstAttribute="centerX" secondItem="F9N-fz-NNe" secondAttribute="centerX" id="qFv-Dz-fct"/>
+                            <constraint firstItem="HWT-wf-Hd8" firstAttribute="leading" secondItem="gob-qw-3MV" secondAttribute="leading" id="u6D-ns-sjB"/>
+                            <constraint firstItem="HWT-wf-Hd8" firstAttribute="leading" secondItem="4TD-UJ-0Ke" secondAttribute="leading" constant="77" id="vJg-4G-o4b"/>
+                            <constraint firstItem="Dlf-w7-2eY" firstAttribute="leading" secondItem="4TD-UJ-0Ke" secondAttribute="leading" constant="113" id="xPc-Y6-KbO"/>
+                            <constraint firstItem="ugh-Cp-DHh" firstAttribute="leading" secondItem="4TD-UJ-0Ke" secondAttribute="leading" constant="104" id="ym4-fC-If5"/>
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="primaryExternalMeetingIdTextField" destination="gob-qw-3MV" id="8Ta-yH-R6u"/>
                         <outlet property="saveButton" destination="AHd-Vp-rMm" id="wj4-7o-d2P"/>
                         <outlet property="serverEndpointUrlTextField" destination="HWT-wf-Hd8" id="lio-80-fpD"/>
                     </connections>

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/ChatModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/ChatModel.swift
@@ -11,7 +11,8 @@ import UIKit
 
 extension DataMessage {
     func chatMessage() -> ChatMessage? {
-        let senderName = self.senderExternalUserId.components(separatedBy: "#")[1]
+        let senderNameComponents = self.senderExternalUserId.components(separatedBy: "#")
+        let senderName = senderNameComponents.count > 1 ? senderNameComponents[1] : self.senderExternalUserId
         let message = self.text()
         let timestamp = TimeStampConversion.formatTimestamp(timestamp: self.timestampMs)
         if let messageNotNull = message {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DebugSettingsModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DebugSettingsModel.swift
@@ -10,4 +10,5 @@ import UIKit
 
 class DebugSettingsModel: NSObject {
     var endpointUrl: String = ""
+    var primaryExternalMeetingId: String = ""
 }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DebugSettingsViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DebugSettingsViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 
 class DebugSettingsViewController: UIViewController, UITextFieldDelegate {
     @IBOutlet var serverEndpointUrlTextField: UITextField!
+    @IBOutlet var primaryExternalMeetingIdTextField: UITextField!
     @IBOutlet var saveButton: UIButton!
 
     var model: DebugSettingsModel?
@@ -20,11 +21,16 @@ class DebugSettingsViewController: UIViewController, UITextFieldDelegate {
         setupHideKeyboardOnTap()
         serverEndpointUrlTextField.delegate = self
         serverEndpointUrlTextField.text = model?.endpointUrl
+        primaryExternalMeetingIdTextField.text = model?.primaryExternalMeetingId
     }
 
     @IBAction func saveButtonClicked(_: UIButton) {
         let endpointUrl = serverEndpointUrlTextField.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         model?.endpointUrl = endpointUrl
+
+        let primaryExternalMeetingId = primaryExternalMeetingIdTextField.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        model?.primaryExternalMeetingId = primaryExternalMeetingId
+
         self.dismiss(animated: true, completion: nil)
     }
 

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/JoiningViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/JoiningViewController.swift
@@ -117,7 +117,8 @@ class JoiningViewController: UIViewController, UITextFieldDelegate {
                                               selfName: name,
                                               audioVideoConfig: audioVideoConfig,
                                               option: callKitOption,
-                                              overriddenEndpoint: debugSettingsModel.endpointUrl) { success in
+                                              overriddenEndpoint: debugSettingsModel.endpointUrl,
+                                              primaryExternalMeetingId: debugSettingsModel.primaryExternalMeetingId) { success in
             DispatchQueue.main.async {
                 if !success {
                     self.view.hideToast()

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModule.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModule.swift
@@ -18,6 +18,10 @@ class MeetingModule {
     private let meetingPresenter = MeetingPresenter()
     private var meetings: [UUID: MeetingModel] = [:]
     private let logger = ConsoleLogger(name: "MeetingModule")
+    
+    // These need to be cached in case of primary meeting joins in the futre
+    var cachedOverriddenEndpoint = ""
+    var cachedPrimaryExternalMeetingId = ""
 
     static func shared() -> MeetingModule {
         if sharedInstance == nil {
@@ -34,23 +38,34 @@ class MeetingModule {
                         audioVideoConfig: AudioVideoConfiguration,
                         option: CallKitOption,
                         overriddenEndpoint: String,
+                        primaryExternalMeetingId: String,
                         completion: @escaping (Bool) -> Void) {
         requestRecordPermission { success in
             guard success else {
                 completion(false)
                 return
             }
+            self.cachedOverriddenEndpoint = overriddenEndpoint
+            self.cachedPrimaryExternalMeetingId = primaryExternalMeetingId
             JoinRequestService.postJoinRequest(meetingId: meetingId,
                                                name: selfName,
-                                               overriddenEndpoint: overriddenEndpoint) { meetingSessionConfig in
-                guard let meetingSessionConfig = meetingSessionConfig else {
+                                               overriddenEndpoint: overriddenEndpoint,
+                                               primaryExternalMeetingId: primaryExternalMeetingId) { joinMeetingResponse in
+                guard let joinMeetingResponse = joinMeetingResponse else {
                     DispatchQueue.main.async {
                         completion(false)
                     }
                     return
                 }
-                let meetingModel = MeetingModel(meetingSessionConfig: meetingSessionConfig,
+                let meetingResp = JoinRequestService.getCreateMeetingResponse(from: joinMeetingResponse)
+                let attendeeResp = JoinRequestService.getCreateAttendeeResponse(from: joinMeetingResponse)
+                let meetingSessionConfiguration = MeetingSessionConfiguration(createMeetingResponse: meetingResp,
+                                                   createAttendeeResponse: attendeeResp,
+                                                   urlRewriter: self.urlRewriter)
+                let meetingModel = MeetingModel(meetingSessionConfig: meetingSessionConfiguration,
                                                 meetingId: meetingId,
+                                                primaryMeetingId: meetingSessionConfiguration.primaryMeetingId ?? "",
+                                                primaryExternalMeetingId: joinMeetingResponse.joinInfo.primaryExternalMeetingId ?? "",
                                                 selfName: selfName,
                                                 audioVideoConfig: audioVideoConfig,
                                                 callKitOption: option,
@@ -82,6 +97,12 @@ class MeetingModule {
                 completion(true)
             }
         }
+    }
+    
+    func urlRewriter(url: String) -> String {
+        // changing url
+        // return url.replacingOccurrences(of: "example.com", with: "my.example.com")
+        return url
     }
 
     func selectDevice(_ meeting: MeetingModel, completion: @escaping (Bool) -> Void) {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/RosterModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/RosterModel.swift
@@ -21,12 +21,13 @@ class RosterModel: NSObject {
     var rosterUpdatedHandler: (() -> Void)?
 
     static func convertAttendeeName(from info: AttendeeInfo) -> String {
+        // The JS SDK Serverless demo will prepend a UUID to provided names followed by a hash to help uniqueness
         let externalUserIdArray = info.externalUserId.components(separatedBy: "#")
         if externalUserIdArray.isEmpty {
             return "<UNKNOWN>"
         }
-        let attendeeName: String = externalUserIdArray[1]
-        return info.attendeeId.hasSuffix(contentDelimiter) ? "\(attendeeName) \(contentSuffix)" : attendeeName
+        let rosterName: String = externalUserIdArray.count == 2 ? externalUserIdArray[1] : info.externalUserId
+        return info.attendeeId.hasSuffix(contentDelimiter) ? "\(rosterName) \(contentSuffix)" : rosterName
     }
 
     func addAttendees(_ newAttendees: [RosterAttendee]) {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
@@ -183,6 +183,14 @@ class VideoModel: NSObject {
         }
     }
 
+    func promoteToPrimaryMeeting(credentials: MeetingSessionCredentials, observer: PrimaryMeetingPromotionObserver) {
+        audioVideoFacade.promoteToPrimaryMeeting(credentials: credentials, observer: observer)
+    }
+
+    func demoteFromPrimaryMeeting() {
+        audioVideoFacade.demoteFromPrimaryMeeting()
+    }
+
     func isRemoteVideoDisplaying(tileId: Int) -> Bool {
         return remoteVideoStatesInCurrentPage.contains(where: { $0.0 == tileId })
     }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/data/JoinMeetingResponse.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/data/JoinMeetingResponse.swift
@@ -9,10 +9,10 @@
 import Foundation
 
 struct CreateMediaPlacementInfo: Codable {
-    var audioFallbackUrl: String
+    var audioFallbackUrl: String?
     var audioHostUrl: String
     var signalingUrl: String
-    var turnControlUrl: String
+    var turnControlUrl: String?
     var eventIngestionUrl: String?
 
     enum CodingKeys: String, CodingKey {
@@ -26,12 +26,14 @@ struct CreateMediaPlacementInfo: Codable {
 
 struct CreateMeetingInfo: Codable {
     var externalMeetingId: String?
+    var primaryMeetingId: String?
     var mediaPlacement: CreateMediaPlacementInfo
     var mediaRegion: String
     var meetingId: String
 
     enum CodingKeys: String, CodingKey {
         case externalMeetingId = "ExternalMeetingId"
+        case primaryMeetingId = "PrimaryMeetingId"
         case mediaPlacement = "MediaPlacement"
         case mediaRegion = "MediaRegion"
         case meetingId = "MeetingId"
@@ -69,10 +71,12 @@ struct CreateAttendee: Codable {
 struct CreateJoinInfo: Codable {
     var meeting: CreateMeeting
     var attendee: CreateAttendee
+    var primaryExternalMeetingId: String?
 
     enum CodingKeys: String, CodingKey {
         case meeting = "Meeting"
         case attendee = "Attendee"
+        case primaryExternalMeetingId = "PrimaryExternalMeetingId"
     }
 }
 


### PR DESCRIPTION
### Issue #, if available:
None

### Description of changes: 
Note this currently does not have guide, but it will be merged before release. For feature description, can rely on JS SDK guide for now: https://github.com/aws/amazon-chime-sdk-js/pull/2107/files#diff-fb6ab46020e038e9e0125b8ce0c85879ba9bc502a8e13c7d4ca32e2a77be55c3

### Testing done:
Extensive QA testing

- [x] Join meeting without CallKit
- [x] Join meeting with CallKit as Incoming
- [x] Join meeting with CallKit as Outgoing
- [x] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
