### PR TITLE
Fix promotion due to mismatched names

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
@@ -287,7 +287,7 @@ extension DefaultVideoClientController: VideoClientDelegate {
         return uris.map(self.configuration.urlRewriter)
     }
 
-    public func videoClientDidCompletePrimaryMeetingJoin(_ status: video_client_status_t) {
+    public func videoClientDidPromote(toPrimaryMeeting status: video_client_status_t) {
         let code: MeetingSessionStatusCode
         switch status {
         case VIDEO_CLIENT_OK:
@@ -303,7 +303,7 @@ extension DefaultVideoClientController: VideoClientDelegate {
             .didPromoteToPrimaryMeeting(status: MeetingSessionStatus.init(statusCode: code))
     }
 
-    public func videoClientPrimaryMeetingDemoted(_ status: video_client_status_t) {
+    public func videoClientDidDemote(fromPrimaryMeeting status: video_client_status_t) {
         let code: MeetingSessionStatusCode
         switch status {
         case VIDEO_CLIENT_OK:


### PR DESCRIPTION
### Issue #, if available: None

### Description of changes: Not sure how this got stale

### Testing done: Works locally

#### Manual test cases (add more as needed):

- [ ] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [ ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
