### PR TITLE
Support M1 simulator on CocoaPods

### DIFF
--- a/AmazonChimeSDK-Bitcode.podspec
+++ b/AmazonChimeSDK-Bitcode.podspec
@@ -11,5 +11,4 @@ Pod::Spec.new do |s|
   s.vendored_frameworks = "AmazonChimeSDK.xcframework"
   s.swift_version    = '5.0'
   s.dependency 'AmazonChimeSDKMedia-Bitcode', '~> 0.15.3'
-  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end

--- a/AmazonChimeSDK-No-Bitcode.podspec
+++ b/AmazonChimeSDK-No-Bitcode.podspec
@@ -11,5 +11,4 @@ Pod::Spec.new do |s|
   s.vendored_frameworks = "AmazonChimeSDK.xcframework"
   s.swift_version    = '5.0'
   s.dependency 'AmazonChimeSDKMedia-No-Bitcode', '~> 0.15.3'
-  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end

--- a/AmazonChimeSDKMedia-Bitcode.podspec
+++ b/AmazonChimeSDKMedia-Bitcode.podspec
@@ -10,5 +10,4 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '10.0'
   s.vendored_frameworks = "AmazonChimeSDKMedia.xcframework"
   s.swift_version    = '5.0'
-  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end

--- a/AmazonChimeSDKMedia-No-Bitcode.podspec
+++ b/AmazonChimeSDKMedia-No-Bitcode.podspec
@@ -10,5 +10,4 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '10.0'
   s.vendored_frameworks = "AmazonChimeSDKMedia.xcframework"
   s.swift_version    = '5.0'
-  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end


### PR DESCRIPTION
### Issue #, if available:
N/A
### Description of changes:
To generate SDK for M1 simulator on CocoaPods.

### Testing done:
Built pods and tested on M1 simulator.

#### Manual test cases (add more as needed):

- [ ] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [ ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
