### PR TITLE
Change SDK version to a placeholder in demo Podfile

### DIFF
--- a/AmazonChimeSDKDemo/Podfile
+++ b/AmazonChimeSDKDemo/Podfile
@@ -4,11 +4,11 @@ platform :ios, '10.0'
 target 'AmazonChimeSDKDemoPods' do
   use_frameworks!
   # Pods for AmazonChimeSDKDemoPods
-  pod 'AmazonChimeSDK-Bitcode', '0.19.3'
+  pod 'AmazonChimeSDK-Bitcode', 'AMAZON_CHIME_SDK_VERSION'
 end
 
 target 'AmazonChimeSDKDemoBroadcastPods' do
   use_frameworks!
   # Pods for AmazonChimeSDKDemoBroadcastPods
-  pod 'AmazonChimeSDK-Bitcode', '0.19.3'
+  pod 'AmazonChimeSDK-Bitcode', 'AMAZON_CHIME_SDK_VERSION'
 end

--- a/README.md
+++ b/README.md
@@ -128,10 +128,13 @@ To run the demo application, follow these steps.
 
 ### 2. Import Amazon Chime SDK
 #### From CocoaPods
-In `AmazonChimeSDKDemo/`, run the following command to install pods:
+For both targets in `/AmazonChimeSDKDemo/Podfile`, replace `AMAZON_CHIME_SDK_VERSION` with a specific SDK version, e.g. `0.19.3` or remove it if utilize the latest version of Amazon Chime SDK.
+
+Under `/AmazonChimeSDKDemo`, run the following command to install pods:
 ```
 $ pod install --repo-update
 ```
+
 #### Or From Downloaded Binary
 * Download `AmazonChimeSDKMedia` binary with bitcode support from the latest [release](https://github.com/aws/amazon-chime-sdk-ios/releases/latest).
 


### PR DESCRIPTION
### Description of changes:
Will not specify a version number in the demo Podfile in each release.
As a result, builders will need to specify a SDK version for the pod when building the `AmazonChimeSDKDemoPods` target.


### Testing done:

#### Manual test cases (add more as needed):

- [ ] Join meeting without CallKit
- [ ] Join meeting with CallKit as Incoming
- [ ] Join meeting with CallKit as Outgoing
- [ ] Leave meeting
- [ ] Rejoin meeting
- [ ] See metrics
- [ ] See attendee presence
- [ ] Send audio
- [ ] Receive audio
- [ ] Mute self
- [ ] Unmute self
- [ ] See local mute indicator when muted
- [ ] See remote mute indicator when other is muted
- [ ] Enable and disable local video
- [ ] Enable and disable remote video from remote side
- [ ] Send local video
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Receive remote screen share

#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

### Screenshots, if available:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
