### PR TITLE
Link AmazonChimeSDKMachineLearning for AmazonChimeSDKDemoPods

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo.xcodeproj/project.pbxproj
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo.xcodeproj/project.pbxproj
@@ -1341,6 +1341,8 @@
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-ObjC",
+					"-framework",
+					AmazonChimeSDKMachineLearning,
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazonaws.services.chime.SDKDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1384,6 +1386,8 @@
 				OTHER_LDFLAGS = (
 					"-lc++",
 					"-ObjC",
+					"-framework",
+					AmazonChimeSDKMachineLearning,
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.amazon.chime.sdk.enterprise;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
## ℹ️ Description
Same as #472 except into development.

Fix the linking of AmazonChimeSDKMachineLearning in the AmazonChimeSDKDemoPods target by manually adding the flag. Looks like Cocoapods isn't linking the dependency automatically, so we explicitly add it to the linker flags instead. Since the framework search paths are set properly to include the downloaded framework via Cocoapods after pod install, it is already available and needs no further changes.

### Issue #, if available
N/A

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guildes update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresonding legal documents)

## 🧪 How Has This Been Tested?
Ran the AmazonChimeSDKDemoPods target manually and verified that the background blur and replacement features worked.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
