### PR TITLE
Add support to set maxBitRateKbps for local video and content share

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ AmazonChimeSDK/docs
 AmazonChimeSDK/MockingbirdSupport/
 **/IDEWorkspaceChecks.plist
 Pods
+Mockingbird*

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoControllerFacade.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoControllerFacade.swift
@@ -51,8 +51,9 @@ import Foundation
     /// Calling this after passing in a custom `VideoSource` will replace it with the internal capture source.
     ///
     /// This function will only have effect if `start` has already been called
+    /// If maxBitRateKbps is not set, it will be self adjusted depending on number of users and videos in the meeting
     ///
-    /// Parameter config: configurations of emitted video stream, e.g. simulcast
+    /// Parameter config: configurations of emitted video stream, e.g. simulcast, maxBitRateKbps
     /// - Throws: `PermissionError.videoPermissionError` if video permission of `AVCaptureDevice` is not granted
     func startLocalVideo(config: LocalVideoConfiguration) throws
 
@@ -78,9 +79,10 @@ import Foundation
     /// was previously called with no arguments.
     ///
     /// This function will only have effect if `start` has already been called
+    /// If maxBitRateKbps is not set, it will be self adjusted depending on number of users and videos in the meeting
     ///
     /// - Parameter source: The source of video frames to be sent to other clients
-    /// - Parameter config: Configurations of emitted video stream, e.g. simulcast
+    /// - Parameter config: Configurations of emitted video stream, e.g. simulcast, maxBitRateKbps
     func startLocalVideo(source: VideoSource, config: LocalVideoConfiguration)
 
     /// Stops sending video for local attendee. This will additionally stop the internal capture source if being used.

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/contentshare/ContentShareController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/contentshare/ContentShareController.swift
@@ -38,7 +38,7 @@ import Foundation
     /// Calling this function repeatedly will replace the previous `ContentShareSource` as the one being transmitted.
     ///
     /// - Parameter source: source of content to be shared
-    /// - Parameter config: configurations of emitted video stream, e.g simulcast
+    /// - Parameter config: configurations of emitted video stream, e.g maxBitRateKbps
     func startContentShare(source: ContentShareSource, config: LocalVideoConfiguration)
 
     /// Stop sharing the content of a `ContentShareSource` that previously started.

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/LocalVideoConfiguration.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/LocalVideoConfiguration.swift
@@ -12,6 +12,16 @@ import Foundation
 @objcMembers public class LocalVideoConfiguration: NSObject {
 
     /// The flag to disable/enable simulcast, default to true
-    /// only for localVideo, not work for content share
-    public var simulcastEnabled: Bool = true
+    /// For local video use only, will not work for content share
+    public var simulcastEnabled: Bool
+
+    /// The max bit rate for video encoding, should be greater than 0
+    /// Actual quality achieved may vary throughout the call depending on what system and network can provide
+    public var maxBitRateKbps: UInt32
+
+    public init(maxBitRateKbps: UInt32 = 0, simulcastEnabled: Bool = true) {
+        self.maxBitRateKbps = maxBitRateKbps
+        self.simulcastEnabled = simulcastEnabled
+        super.init()
+    }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/DefaultContentShareVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/DefaultContentShareVideoClientController.swift
@@ -48,7 +48,7 @@ import Foundation
     }
 
     public func startVideoShare(source: VideoSource, config: LocalVideoConfiguration) {
-        // ignore LocalVideoConfiguration because contentshare does not have simulcast
+        // ignore simulcast in config because contentshare does not have simulcast
         videoClientLock.lock()
         defer { videoClientLock.unlock() }
 
@@ -58,6 +58,11 @@ import Foundation
         videoSourceAdapter.source = source
         videoClient.setExternalVideoSource(videoSourceAdapter)
         videoClient.setSending(true)
+
+        if config.maxBitRateKbps > 0 {
+            logger.info(msg: "Setting max bit rate in kbps for content share")
+            videoClient.setMaxBitRateKbps(config.maxBitRateKbps)
+        }
     }
 
     public func stopVideoShare() {

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
@@ -398,10 +398,15 @@ extension DefaultVideoClientController: VideoClientController {
         videoSourceAdapter.source = source
         videoClient?.setExternalVideoSource(videoSourceAdapter)
         videoClient?.setSending(true)
-        
+
         let simulcastEnabled = config.simulcastEnabled
         logger.info(msg: "Setting simulcast")
         videoClient?.setSimulcast(simulcastEnabled)
+
+        if (config.maxBitRateKbps > 0) {
+            logger.info(msg: "Setting max bit rate in kbps for local video")
+            videoClient?.setMaxBitRateKbps(config.maxBitRateKbps)
+        }
     }
 
     public func stopLocalVideo() {

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientProtocol.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientProtocol.swift
@@ -52,6 +52,8 @@ import Foundation
     func demoteFromPrimaryMeeting()
 
     func setSimulcast(_ simulcast: Bool)
+    
+    func setMaxBitRateKbps(_ maxBitRate: UInt32)
 }
 
 extension VideoClient: VideoClientProtocol {}

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/contentshare/DefaultContentShareVideoClientControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/contentshare/DefaultContentShareVideoClientControllerTests.swift
@@ -46,11 +46,12 @@ class DefaultContentShareVideoClientControllerTests: CommonTestCase {
     }
 
     func testStartVideoShareWithConfig() {
-        let config = LocalVideoConfiguration()
+        let config = LocalVideoConfiguration(maxBitRateKbps: 300)
         defaultContentShareVideoClientController.startVideoShare(source: videoSourceMock, config: config)
 
         verify(videoClientMock.setExternalVideoSource(any())).wasCalled()
         verify(videoClientMock.setSending(true)).wasCalled()
+        verify(videoClientMock.setMaxBitRateKbps(300)).wasCalled()
     }
 
     func testStartVideoShareAfterStart() {

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/video/DefaultVideoClientControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/video/DefaultVideoClientControllerTests.swift
@@ -103,12 +103,13 @@ class DefaultVideoClientControllerTests: CommonTestCase {
 
     func testSendLocalVideoWithConfig() {
         defaultVideoClientController.start()
-        let config = LocalVideoConfiguration()
+        let config = LocalVideoConfiguration(maxBitRateKbps: 300)
         XCTAssertNoThrow(try defaultVideoClientController.startLocalVideo(config: config))
 
         verify(videoClientMock.setExternalVideoSource(any())).wasCalled()
         verify(videoClientMock.setSending(true)).wasCalled()
         verify(videoClientMock.setSimulcast(true)).wasCalled()
+        verify(videoClientMock.setMaxBitRateKbps(300)).wasCalled()
     }
 
     func testSendLocalVideoWithSource() {
@@ -121,11 +122,12 @@ class DefaultVideoClientControllerTests: CommonTestCase {
 
     func testSendLocalVideoWithSourceAndConfig() {
         defaultVideoClientController.start()
-        let config = LocalVideoConfiguration()
+        let config = LocalVideoConfiguration(maxBitRateKbps: 300)
         defaultVideoClientController.startLocalVideo(source: videoSourceMock, config: config)
 
         verify(videoClientMock.setExternalVideoSource(any())).wasCalled()
         verify(videoClientMock.setSending(true)).wasCalled()
         verify(videoClientMock.setSimulcast(true)).wasCalled()
+        verify(videoClientMock.setMaxBitRateKbps(300)).wasCalled()
     }
 }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_7" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DeviceSelectionViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DeviceSelectionViewController.swift
@@ -32,6 +32,8 @@ class DeviceSelectionViewController: UIViewController {
         videoPreviewImageView.mirror = model?.shouldMirrorPreview ?? false
         model?.cameraCaptureSource.addVideoSink(sink: videoPreviewImageView)
         model?.cameraCaptureSource.start()
+
+        setupHideKeyboardOnTap()
     }
 
     @IBAction func joinButtonTapped(_: UIButton) {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DeviceSelectionViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DeviceSelectionViewController.swift
@@ -32,8 +32,6 @@ class DeviceSelectionViewController: UIViewController {
         videoPreviewImageView.mirror = model?.shouldMirrorPreview ?? false
         model?.cameraCaptureSource.addVideoSink(sink: videoPreviewImageView)
         model?.cameraCaptureSource.start()
-
-        setupHideKeyboardOnTap()
     }
 
     @IBAction func joinButtonTapped(_: UIButton) {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
@@ -59,6 +59,8 @@ class VideoModel: NSObject {
         super.init()
     }
 
+    var localVideoMaxBitRateKbps: UInt32 = 0
+
     var videoTileCount: Int {
         return remoteVideoCountInCurrentPage + 1
     }
@@ -218,7 +220,7 @@ class VideoModel: NSObject {
                         customVideoSource = self.backgroundReplacementProcessor
                     }
                     // customers could set simulcast here
-                    let config = LocalVideoConfiguration()
+                    let config = LocalVideoConfiguration(maxBitRateKbps: self.localVideoMaxBitRateKbps)
                     self.audioVideoFacade.startLocalVideo(source: customVideoSource,
                                                           config: config)
                 } else {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## unreleased
+
+### Added
+* Added support to set max bit rate for local video and content share
+* [Demo] Add video configuration options to set max bit rate for local video in meeting
+
+
 ## [0.22.1] - 2022-07-28
 
 ### Fixed
@@ -5,6 +12,7 @@
 
 ### Changed
 * Changed `updateDeviceCaptureFormat` to match fps after resolution
+
 ## [0.22.0] - 2022-07-14
 
 ### Fixed
@@ -14,8 +22,6 @@
 
 ### Added
 * Added support to expose simulcast configuration
-
-### Fixed
 
 ## [0.21.2] - 2022-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@
 
 ### Changed
 * Changed `updateDeviceCaptureFormat` to match fps after resolution
-
 ## [0.22.0] - 2022-07-14
 
 ### Fixed
@@ -22,6 +21,8 @@
 
 ### Added
 * Added support to expose simulcast configuration
+
+### Fixed
 
 ## [0.21.2] - 2022-06-17
 

--- a/README.md
+++ b/README.md
@@ -502,9 +502,10 @@ class MyVideoTileObserver: VideoTileObserver {
 // Use internal camera capture for the local video
 meetingSession.audioVideo.startLocalVideo()
 
-// Use internal camera capture and set configuration for the video, e.g. simulcastEnabled
-// This can be called multiple times to enable/disable simulcast on the fly
-let localVideoConfig = LocalVideoConfiguration(simulcastEnabled: true)
+// Use internal camera capture and set configuration for the video, e.g. simulcastEnabled, maxBitRateKbps
+// If maxBitRateKbps is not set, it will be self adjusted depending on number of users and videos in the meeting
+// This can be called multiple times to enable/disable simulcast and adjust video max bit rate on the fly
+let localVideoConfig = LocalVideoConfiguration(simulcastEnabled: true， maxBitRateKbps: 600)
 meetingSession.audioVideo.startLocalVideo(config: localVideoConfig)
 
 // You can switch camera to change the video input device
@@ -569,6 +570,11 @@ class MyContentShareObserver: ContentShareObserver {
 }
 ```
 
+You can set configuration for content share, e.g. maxBitRateKbps. Actual quality achieved may vary throughout the call depending on what system and network can provide.
+```swift
+let contentShareConfig = LocalVideoConfiguration(maxBitRateKbps: 200)
+meetingSession.audioVideo.startContentShare(source: contentShareSource, config: contentShareConfig)
+```
 See [Content Share](https://github.com/aws/amazon-chime-sdk-ios/blob/master/guides/content_share.md) for more details.
 
 #### Use case 19. Stop sharing your screen or content.
@@ -691,9 +697,9 @@ Amazon Voice Focus reduces the background noise in the meeting for better meetin
 #### Use case 25. Enable/Disable Amazon Voice Focus.
 
 ```swift
-val enabled = audioVideo.realtimeSetVoiceFocusEnabled(true) // enabling Amazon Voice Focus successful
+let enabled = audioVideo.realtimeSetVoiceFocusEnabled(enabled: true) // enabling Amazon Voice Focus successful
 
-val disabled = audioVideo.realtimeSetVoiceFocusEnabled(false) // disabling Amazon Voice Focus successful
+let disabled = audioVideo.realtimeSetVoiceFocusEnabled(enabled: false) // disabling Amazon Voice Focus successful
 ```
 
 ### Custom Video Source

--- a/guides/content_share.md
+++ b/guides/content_share.md
@@ -49,6 +49,12 @@ func captureDidStart() {
 }
 ```
 
+Additionally, you can set configuration for content share, e.g. maxBitRateKbps. Actual quality achieved may vary throughout the call depending on what system and network can provide.
+```swift
+let contentShareConfig = LocalVideoConfiguration(maxBitRateKbps: 200)
+meetingSession.audioVideo.startContentShare(source: contentShareSource, config: contentShareConfig)
+```
+
 ### Stop Screen Share
 
 `stop()` on `InAppScreenCaptureSource` only stops `RPScreenRecorder` from capturing the screen, it is still necessary to call `stopContentShare()` on [`ContentShareController`](https://aws.github.io/amazon-chime-sdk-ios/Protocols/ContentShareController.html) to stop the peer connection for sending the screen capture data.


### PR DESCRIPTION
## ℹ️ Description
Provide a way to configure video send encoding parameters when start local video and content share.

### Issue #, if available
Chime-48548

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
    - [x] README update
    - [x] CHANGELOG update
    - [x] guildes update
- [ ] This change requires a dependency update
    - [x] Amazon Chime SDK Media
    - [ ] Other (update corresonding legal documents)

## 🧪 How Has This Been Tested?
Start local video with different maxBitRateKbps values, verified the metrics `videoSendBitrate` is closed to the maxBitRateKbps value.

### Additional Manual Test
- [x] Pause and resume remote video
- [x] Switch local camera
- [x] Rotate screen back and forth

## 📱 Screenshots, if available

![Image from iOS (1)](https://user-images.githubusercontent.com/60948810/182668536-4dcf84a3-3e79-4390-b751-6a576c86a456.png)
![Image from iOS (3)](https://user-images.githubusercontent.com/60948810/182668513-08c1531f-46a3-488e-80ef-dd2378312873.png)
![Image from iOS (2)](https://user-images.githubusercontent.com/60948810/182668528-50a28543-cf2a-46d6-ac95-d0a27457ca86.png)




## ✅ Checklist
#### Integration validation (required before release)

- [x] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [x] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [x] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
