### PR TITLE
Expose Simulcast Configuration

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
+++ b/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
@@ -279,6 +279,7 @@
 		CFD14AAC281B4A8300C8D8CA /* selfie_segmentation_landscape.tflite in Resources */ = {isa = PBXBuildFile; fileRef = CFD14AAB281B4A8300C8D8CA /* selfie_segmentation_landscape.tflite */; };
 		CFD14AAD281B4A8300C8D8CA /* selfie_segmentation_landscape.tflite in Resources */ = {isa = PBXBuildFile; fileRef = CFD14AAB281B4A8300C8D8CA /* selfie_segmentation_landscape.tflite */; };
 		CFF1553C2819C123009E257B /* background-ml-test-image.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = CFF1553B2819C123009E257B /* background-ml-test-image.jpeg */; };
+		ED300F2A284877AC00497568 /* LocalVideoConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED300F29284877AC00497568 /* LocalVideoConfiguration.swift */; };
 		F81104AC276190AA003D17AD /* VideoPriority.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81104A8276190A9003D17AD /* VideoPriority.swift */; };
 		F81104AD276190AA003D17AD /* RemoteVideoSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81104A9276190A9003D17AD /* RemoteVideoSource.swift */; };
 		F81104AE276190AA003D17AD /* VideoResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81104AA276190A9003D17AD /* VideoResolution.swift */; };
@@ -577,6 +578,7 @@
 		CFA2A16F28087AE8008FDFF5 /* BackgroundFilterTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundFilterTest.swift; sourceTree = "<group>"; };
 		CFD14AAB281B4A8300C8D8CA /* selfie_segmentation_landscape.tflite */ = {isa = PBXFileReference; lastKnownFileType = file; path = selfie_segmentation_landscape.tflite; sourceTree = "<group>"; };
 		CFF1553B2819C123009E257B /* background-ml-test-image.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "background-ml-test-image.jpeg"; sourceTree = "<group>"; };
+		ED300F29284877AC00497568 /* LocalVideoConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalVideoConfiguration.swift; sourceTree = "<group>"; };
 		F81104A8276190A9003D17AD /* VideoPriority.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoPriority.swift; sourceTree = "<group>"; };
 		F81104A9276190A9003D17AD /* RemoteVideoSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteVideoSource.swift; sourceTree = "<group>"; };
 		F81104AA276190A9003D17AD /* VideoResolution.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoResolution.swift; sourceTree = "<group>"; };
@@ -943,6 +945,7 @@
 				00C9DC6423FA36BE00876B41 /* VideoTileControllerFacade.swift */,
 				00C9DC6623FA36E700876B41 /* VideoTileObserver.swift */,
 				00C2A91623F76250008CD687 /* VideoTileState.swift */,
+				ED300F29284877AC00497568 /* LocalVideoConfiguration.swift */,
 			);
 			path = video;
 			sourceTree = "<group>";
@@ -1609,6 +1612,7 @@
 				5A16B94923FCC00100ADAE26 /* AudioClientController.swift in Sources */,
 				5A16B99223FCD95100ADAE26 /* AudioClientObserver.swift in Sources */,
 				000C30A325807CD500863981 /* MeetingHistoryEventName.swift in Sources */,
+				ED300F2A284877AC00497568 /* LocalVideoConfiguration.swift in Sources */,
 				5A6F81842463665F0031AE97 /* AudioClientState.swift in Sources */,
 				C67E9B8026F5126F0084C9B4 /* TranscriptResult.swift in Sources */,
 				B418163224B79CF100FA62BF /* DataMessageObserver.swift in Sources */,

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoControllerFacade.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoControllerFacade.swift
@@ -45,6 +45,17 @@ import Foundation
     /// - Throws: `PermissionError.videoPermissionError` if video permission of `AVCaptureDevice` is not granted
     func startLocalVideo() throws
 
+    /// Start local video with configurations and begin transmitting frames from an internally held `DefaultCameraCaptureSource`.
+    /// `stopLocalVideo` will stop the internal capture source if being used.
+    ///
+    /// Calling this after passing in a custom `VideoSource` will replace it with the internal capture source.
+    ///
+    /// This function will only have effect if `start` has already been called
+    ///
+    /// Parameter config: configurations of emitted video stream, e.g. simulcast
+    /// - Throws: `PermissionError.videoPermissionError` if video permission of `AVCaptureDevice` is not granted
+    func startLocalVideo(config: LocalVideoConfiguration) throws
+
     /// Start local video with a provided custom `VideoSource` which can be used to provide custom
     /// `VideoFrame`s to be transmitted to remote clients. This will call `VideoSource.addVideoSink`
     /// on the provided source.
@@ -57,6 +68,20 @@ import Foundation
     ///
     /// - Parameter source: The source of video frames to be sent to other clients
     func startLocalVideo(source: VideoSource)
+
+    /// Start local video with configurations and a provided custom `VideoSource` which can be used to provide custom
+    /// `VideoFrame`s to be transmitted to remote clients. This will call `VideoSource.addVideoSink`
+    /// on the provided source.
+    ///
+    /// Calling this function repeatedly will replace the previous `VideoSource` as the one being
+    /// transmitted. It will also stop and replace the internal capture source if `startLocalVideo`
+    /// was previously called with no arguments.
+    ///
+    /// This function will only have effect if `start` has already been called
+    ///
+    /// - Parameter source: The source of video frames to be sent to other clients
+    /// - Parameter config: Configurations of emitted video stream, e.g. simulcast
+    func startLocalVideo(source: VideoSource, config: LocalVideoConfiguration)
 
     /// Stops sending video for local attendee. This will additionally stop the internal capture source if being used.
     /// If using a custom video source, this will call `VideoSource.removeVideoSink` on the previously provided source.

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoController.swift
@@ -85,8 +85,16 @@ import Foundation
         try videoClientController.startLocalVideo()
     }
 
+    public func startLocalVideo(config: LocalVideoConfiguration) throws {
+        try videoClientController.startLocalVideo(config: config)
+    }
+
     public func startLocalVideo(source: VideoSource) {
         videoClientController.startLocalVideo(source: source)
+    }
+
+    public func startLocalVideo(source: VideoSource, config: LocalVideoConfiguration) {
+        videoClientController.startLocalVideo(source: source, config: config)
     }
 
     public func stopLocalVideo() {
@@ -100,7 +108,7 @@ import Foundation
     public func stopRemoteVideo() {
         videoClientController.stopRemoteVideo()
     }
-    
+
     public func updateVideoSourceSubscriptions(addedOrUpdated: Dictionary<RemoteVideoSource, VideoSubscriptionConfiguration>, removed: Array<RemoteVideoSource>) {
         videoClientController.updateVideoSourceSubscriptions(addedOrUpdated: addedOrUpdated, removed: removed)
     }

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
@@ -64,8 +64,16 @@ import Foundation
         try audioVideoController.startLocalVideo()
     }
 
+    public func startLocalVideo(config: LocalVideoConfiguration) throws {
+        try audioVideoController.startLocalVideo(config: config)
+    }
+
     public func startLocalVideo(source: VideoSource) {
         audioVideoController.startLocalVideo(source: source)
+    }
+
+    public func startLocalVideo(source: VideoSource, config: LocalVideoConfiguration) {
+        audioVideoController.startLocalVideo(source: source, config: config)
     }
 
     public func stopLocalVideo() {
@@ -233,6 +241,10 @@ import Foundation
 
     public func startContentShare(source: ContentShareSource) {
         contentShareController.startContentShare(source: source)
+    }
+
+    public func startContentShare(source: ContentShareSource, config: LocalVideoConfiguration) {
+        contentShareController.startContentShare(source: source, config: config)
     }
 
     public func stopContentShare() {

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/contentshare/ContentShareController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/contentshare/ContentShareController.swift
@@ -26,6 +26,21 @@ import Foundation
     /// - Parameter source: source of content to be shared
     func startContentShare(source: ContentShareSource)
 
+    /// Start sharing the content of a given `ContentShareSource`, with configurations.
+    ///
+    /// Once sharing has started successfully, `ContentShareObserver.contentShareDidStart` will
+    /// be notified. If sharing fails or stops, `ContentShareObserver.contentShareDidStop`
+    /// will be invoked with `ContentShareStatus` as the cause.
+    ///
+    /// This will call `VideoSource.addVideoSink(sink:)` on the provided source
+    /// and `VideoSource.removeVideoSink(sink:)` on the previously provided source.
+    ///
+    /// Calling this function repeatedly will replace the previous `ContentShareSource` as the one being transmitted.
+    ///
+    /// - Parameter source: source of content to be shared
+    /// - Parameter config: configurations of emitted video stream, e.g simulcast
+    func startContentShare(source: ContentShareSource, config: LocalVideoConfiguration)
+
     /// Stop sharing the content of a `ContentShareSource` that previously started.
     ///
     /// Once the sharing stops successfully, `ContentShareObserver.contentShareDidStop`

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/contentshare/DefaultContentShareController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/contentshare/DefaultContentShareController.swift
@@ -23,6 +23,12 @@ import Foundation
         }
     }
 
+    public func startContentShare(source: ContentShareSource, config: LocalVideoConfiguration) {
+        if let videoSource = source.videoSource {
+            contentShareVideoClientController.startVideoShare(source: videoSource, config: config)
+        }
+    }
+
     public func stopContentShare() {
         contentShareVideoClientController.stopVideoShare()
     }

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/contentshare/DefaultContentShareController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/contentshare/DefaultContentShareController.swift
@@ -24,6 +24,8 @@ import Foundation
     }
 
     public func startContentShare(source: ContentShareSource, config: LocalVideoConfiguration) {
+        // ignore LocalVideoConfiguration because contentshare does not have simulcast
+        // we want to keep the API same as LocalVideo
         if let videoSource = source.videoSource {
             contentShareVideoClientController.startVideoShare(source: videoSource, config: config)
         }

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/LocalVideoConfiguration.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/LocalVideoConfiguration.swift
@@ -12,13 +12,6 @@ import Foundation
 @objcMembers public class LocalVideoConfiguration: NSObject {
 
     /// The flag to disable/enable simulcast, default to true
-    public var simulcastEnabled: Bool
-    
-    convenience override public init() {
-        self.init(simulcastEnabled: true)
-    }
-    
-    public init(simulcastEnabled: Bool) {
-        self.simulcastEnabled = simulcastEnabled
-    }
+    /// only for localVideo, not work for content share
+    public var simulcastEnabled: Bool = true
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/LocalVideoConfiguration.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/LocalVideoConfiguration.swift
@@ -1,0 +1,24 @@
+//
+//  LocalVideoConfiguration.swift
+//  AmazonChimeSDK
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+/// Configuration for a local video or content share to be sent
+@objcMembers public class LocalVideoConfiguration: NSObject {
+
+    /// The flag to disable/enable simulcast, default to true
+    public var simulcastEnabled: Bool
+    
+    convenience override public init() {
+        self.init(simulcastEnabled: true)
+    }
+    
+    public init(simulcastEnabled: Bool) {
+        self.simulcastEnabled = simulcastEnabled
+    }
+}

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/ContentShareVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/ContentShareVideoClientController.swift
@@ -10,6 +10,7 @@ import Foundation
 
 @objc public protocol ContentShareVideoClientController {
     func startVideoShare(source: VideoSource)
+    func startVideoShare(source: VideoSource, config: LocalVideoConfiguration)
     func stopVideoShare()
     func subscribeToVideoClientStateChange(observer: ContentShareObserver)
     func unsubscribeFromVideoClientStateChange(observer: ContentShareObserver)

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/DefaultContentShareVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/DefaultContentShareVideoClientController.swift
@@ -43,6 +43,12 @@ import Foundation
     }
 
     public func startVideoShare(source: VideoSource) {
+        logger.info(msg: "Starting video share with video source")
+        startVideoShare(source: source, config: LocalVideoConfiguration())
+    }
+
+    public func startVideoShare(source: VideoSource, config: LocalVideoConfiguration) {
+        // ignore LocalVideoConfiguration because contentshare does not have simulcast
         videoClientLock.lock()
         defer { videoClientLock.unlock() }
 

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
@@ -358,19 +358,28 @@ extension DefaultVideoClientController: VideoClientController {
     // MARK: - Video selection
 
     public func startLocalVideo() throws {
-        try checkVideoPermission()
-        setVideoSource(source: internalCaptureSource)
+        let config = LocalVideoConfiguration()
+        try startLocalVideo(config: config)
+    }
 
-        logger.info(msg: "Starting local video with internal source")
+    public func startLocalVideo(config: LocalVideoConfiguration) throws {
+        try checkVideoPermission()
+        logger.info(msg: "Starting local video with internal source and config")
+        setVideoSource(source: internalCaptureSource, config: config)
         internalCaptureSource.start()
         isInternalCaptureSourceRunning = true
     }
 
     public func startLocalVideo(source: VideoSource) {
-        stopInternalCaptureSourceIfRunning()
-        setVideoSource(source: source)
+        let config = LocalVideoConfiguration()
+        startLocalVideo(source: source, config: config)
+    }
 
-        logger.info(msg: "Starting local video with custom source")
+    public func startLocalVideo(source: VideoSource, config: LocalVideoConfiguration) {
+        stopInternalCaptureSourceIfRunning()
+        setVideoSource(source: source, config: config)
+
+        logger.info(msg: "Starting local video with custom source and custom config")
     }
 
     private func stopInternalCaptureSourceIfRunning() {
@@ -380,7 +389,7 @@ extension DefaultVideoClientController: VideoClientController {
         }
     }
 
-    private func setVideoSource(source: VideoSource) {
+    private func setVideoSource(source: VideoSource, config: LocalVideoConfiguration) {
         guard videoClientState != .uninitialized else {
             logger.fault(msg: "VideoClient is not initialized so returning without doing anything")
             return
@@ -389,6 +398,10 @@ extension DefaultVideoClientController: VideoClientController {
         videoSourceAdapter.source = source
         videoClient?.setExternalVideoSource(videoSourceAdapter)
         videoClient?.setSending(true)
+        
+        let simulcastEnabled = config.simulcastEnabled
+        logger.info(msg: "Setting simulcast")
+        videoClient?.setSimulcast(simulcastEnabled)
     }
 
     public func stopLocalVideo() {

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientController.swift
@@ -13,7 +13,9 @@ import Foundation
     func start()
     func stopAndDestroy()
     func startLocalVideo() throws
+    func startLocalVideo(config: LocalVideoConfiguration) throws
     func startLocalVideo(source: VideoSource)
+    func startLocalVideo(source: VideoSource, config: LocalVideoConfiguration)
     func stopLocalVideo()
     func startRemoteVideo()
     func stopRemoteVideo()

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientProtocol.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientProtocol.swift
@@ -50,6 +50,8 @@ import Foundation
     func promotePrimaryMeeting(_ attendeeId: String!, externalUserId: String!, joinToken: String!)
 
     func demoteFromPrimaryMeeting()
+
+    func setSimulcast(_ simulcast: Bool)
 }
 
 extension VideoClient: VideoClientProtocol {}

--- a/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/DefaultAudioVideoControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/DefaultAudioVideoControllerTests.swift
@@ -17,7 +17,6 @@ class DefaultAudioVideoControllerTests: CommonTestCase {
     var clientMetricsCollectorMock: ClientMetricsCollectorMock!
     var videoClientControllerMock: VideoClientControllerMock!
     var videoTileControllerMock: VideoTileControllerMock!
-    var defaultAudioClientMock: DefaultAudioClientMock!
     var defaultAudioVideoController: DefaultAudioVideoController!
 
     override func setUp() {
@@ -203,6 +202,28 @@ class DefaultAudioVideoControllerTests: CommonTestCase {
         XCTAssertNoThrow(try defaultAudioVideoController.startLocalVideo())
 
         verify(videoClientControllerMock.startLocalVideo()).wasCalled()
+    }
+
+    func testStartLocalVideoWithConfig() {
+        let config = LocalVideoConfiguration()
+        XCTAssertNoThrow(try defaultAudioVideoController.startLocalVideo(config: config))
+
+        verify(videoClientControllerMock.startLocalVideo(config: config)).wasCalled()
+    }
+
+    func testStartLocalVideoWithSource() {
+        let cameraCaptureSourceMock: CameraCaptureSourceMock = mock(CameraCaptureSource.self)
+        defaultAudioVideoController.startLocalVideo(source: cameraCaptureSourceMock)
+
+        verify(videoClientControllerMock.startLocalVideo(source: cameraCaptureSourceMock)).wasCalled()
+    }
+
+    func testStartLocalVideoWithSourceAndConfig() {
+        let config = LocalVideoConfiguration()
+        let cameraCaptureSourceMock: CameraCaptureSourceMock = mock(CameraCaptureSource.self)
+        defaultAudioVideoController.startLocalVideo(source: cameraCaptureSourceMock, config: config)
+
+        verify(videoClientControllerMock.startLocalVideo(source: cameraCaptureSourceMock, config: config)).wasCalled()
     }
 
     func testStopLocalVideo() {

--- a/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/DefaultAudioVideoFacadeTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/DefaultAudioVideoFacadeTests.swift
@@ -73,4 +73,47 @@ class DefaultAudioVideoFacadeTests: CommonTestCase {
 
         verify(audioVideoControllerMock.start(audioVideoConfiguration: any(where: { $0.audioMode == .stereo48K && $0.callKitEnabled == false }))).wasCalled()
     }
+
+    func testStartLocalVideo() {
+        XCTAssertNoThrow(try defaultAudioVideoFacade.startLocalVideo())
+
+        verify(audioVideoControllerMock.startLocalVideo()).wasCalled()
+    }
+
+    func testStartLocalVideoWithConfig() {
+        let config = LocalVideoConfiguration()
+        XCTAssertNoThrow(try defaultAudioVideoFacade.startLocalVideo(config: config))
+
+        verify(audioVideoControllerMock.startLocalVideo(config: config)).wasCalled()
+    }
+
+    func testStartLocalVideoWithSource() {
+        let cameraCaptureSourceMock: CameraCaptureSourceMock = mock(CameraCaptureSource.self)
+        defaultAudioVideoFacade.startLocalVideo(source: cameraCaptureSourceMock)
+
+        verify(audioVideoControllerMock.startLocalVideo(source: cameraCaptureSourceMock)).wasCalled()
+    }
+
+    func testStartLocalVideoWithSourceAndConfig() {
+        let config = LocalVideoConfiguration()
+        let cameraCaptureSourceMock: CameraCaptureSourceMock = mock(CameraCaptureSource.self)
+        defaultAudioVideoFacade.startLocalVideo(source: cameraCaptureSourceMock, config: config)
+
+        verify(audioVideoControllerMock.startLocalVideo(source: cameraCaptureSourceMock, config: config)).wasCalled()
+    }
+
+    func testStartContentShare() {
+        let source = ContentShareSource()
+        defaultAudioVideoFacade.startContentShare(source: source)
+
+        verify(contentShareControllerMock.startContentShare(source: source)).wasCalled()
+    }
+
+    func testStartContentSharewithConfig() {
+        let source = ContentShareSource()
+        let config = LocalVideoConfiguration()
+        defaultAudioVideoFacade.startContentShare(source: source, config: config)
+
+        verify(contentShareControllerMock.startContentShare(source: source, config: config)).wasCalled()
+    }
 }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/contentshare/DefaultContentShareControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/contentshare/DefaultContentShareControllerTests.swift
@@ -13,20 +13,21 @@ import XCTest
 class DefaultContentShareControllerTests: XCTestCase {
     var contentShareVideoClientControllerMock: ContentShareVideoClientControllerMock!
     var defaultContentShareController: DefaultContentShareController!
+    var videoSourceMock: VideoSourceMock!
 
     override func setUp() {
+        videoSourceMock = mock(VideoSource.self)
         contentShareVideoClientControllerMock = mock(ContentShareVideoClientController.self)
         defaultContentShareController = DefaultContentShareController(contentShareVideoClientController: contentShareVideoClientControllerMock)
     }
 
     func testStartContentShareWithValidSource() throws {
-        let videoSourceMock: VideoSourceMock! = mock(VideoSource.self)
         let contentShareSource = ContentShareSource()
         contentShareSource.videoSource = videoSourceMock
 
         defaultContentShareController.startContentShare(source: contentShareSource)
 
-        verify(contentShareVideoClientControllerMock.startVideoShare(source: videoSourceMock)).wasCalled()
+        verify(contentShareVideoClientControllerMock.startVideoShare(source: self.videoSourceMock)).wasCalled()
     }
 
     func testStartContentShareWithInvalidSource() throws {
@@ -35,6 +36,16 @@ class DefaultContentShareControllerTests: XCTestCase {
         defaultContentShareController.startContentShare(source: contentShareSource)
 
         verify(contentShareVideoClientControllerMock.startVideoShare(source: any())).wasNeverCalled()
+    }
+
+    func testStartContentShareWithConfig() {
+        let config = LocalVideoConfiguration()
+        let contentShareSource = ContentShareSource()
+        contentShareSource.videoSource = videoSourceMock
+
+        defaultContentShareController.startContentShare(source: contentShareSource, config: config)
+
+        verify(contentShareVideoClientControllerMock.startVideoShare(source: self.videoSourceMock, config: config)).wasCalled()
     }
 
     func testStopContentShare() throws {

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/contentshare/DefaultContentShareVideoClientControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/contentshare/DefaultContentShareVideoClientControllerTests.swift
@@ -45,6 +45,14 @@ class DefaultContentShareVideoClientControllerTests: CommonTestCase {
         verify(videoClientMock.setSending(true)).wasCalled()
     }
 
+    func testStartVideoShareWithConfig() {
+        let config = LocalVideoConfiguration()
+        defaultContentShareVideoClientController.startVideoShare(source: videoSourceMock, config: config)
+
+        verify(videoClientMock.setExternalVideoSource(any())).wasCalled()
+        verify(videoClientMock.setSending(true)).wasCalled()
+    }
+
     func testStartVideoShareAfterStart() {
         given(videoClientMock.start(any(),
                                     token: any(),

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
@@ -149,7 +149,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" directionalLockEnabled="YES" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="alh-Ag-Wwk">
-                                <rect key="frame" x="0.0" y="0.0" width="428" height="926"/>
+                                <rect key="frame" x="0.0" y="44" width="428" height="799"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="GdK-eP-aSg">
                                         <rect key="frame" x="10" y="0.0" width="408" height="570"/>
@@ -283,8 +283,8 @@
                             <constraint firstItem="alh-Ag-Wwk" firstAttribute="leading" secondItem="qB1-9y-yO7" secondAttribute="leading" id="8Og-pA-319"/>
                             <constraint firstItem="GdK-eP-aSg" firstAttribute="leading" secondItem="qB1-9y-yO7" secondAttribute="leading" constant="10" id="D8x-1m-H9Y"/>
                             <constraint firstAttribute="trailing" secondItem="alh-Ag-Wwk" secondAttribute="trailing" id="GPR-BL-Ima"/>
-                            <constraint firstItem="alh-Ag-Wwk" firstAttribute="top" secondItem="qB1-9y-yO7" secondAttribute="top" id="gDh-14-mtj"/>
-                            <constraint firstAttribute="bottom" secondItem="alh-Ag-Wwk" secondAttribute="bottom" id="t56-1d-1rS"/>
+                            <constraint firstItem="alh-Ag-Wwk" firstAttribute="top" secondItem="8aO-2f-9EF" secondAttribute="bottom" id="gDh-14-mtj"/>
+                            <constraint firstItem="zEb-ke-gtH" firstAttribute="top" secondItem="alh-Ag-Wwk" secondAttribute="bottom" id="t56-1d-1rS"/>
                         </constraints>
                     </view>
                     <toolbarItems/>

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
@@ -217,7 +217,10 @@ class VideoModel: NSObject {
                         customVideoSource.addVideoSink(sink: self.backgroundReplacementProcessor)
                         customVideoSource = self.backgroundReplacementProcessor
                     }
-                    self.audioVideoFacade.startLocalVideo(source: customVideoSource)
+                    // customers could set simulcast here
+                    let config = LocalVideoConfiguration()
+                    self.audioVideoFacade.startLocalVideo(source: customVideoSource,
+                                                          config: config)
                 } else {
                     do {
                         try self.audioVideoFacade.startLocalVideo()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [unreleased]
+
+### Added
+* Added support to expose simulcast configuration
+
 ## [0.21.2] - 2022-06-17
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -502,6 +502,11 @@ class MyVideoTileObserver: VideoTileObserver {
 // Use internal camera capture for the local video
 meetingSession.audioVideo.startLocalVideo()
 
+// Use internal camera capture and set configuration for the video, e.g. simulcastEnabled
+// This can be called multiple times to enable/disable simulcast on the fly
+let localVideoConfig = LocalVideoConfiguration(simulcastEnabled: true)
+meetingSession.audioVideo.startLocalVideo(config: localVideoConfig)
+
 // You can switch camera to change the video input device
 meetingSession.audioVideo.switchCamera()
 

--- a/guides/api_overview.md
+++ b/guides/api_overview.md
@@ -149,7 +149,10 @@ You can view content share the same way that you view a remote attendee's video.
 
 Video permissions are required for sending the local attendee's video.
 
-To start sending the local attendee's video, call meetingSession.audioVideo.[startLocalVideo()](https://aws.github.io/amazon-chime-sdk-ios/Protocols/AudioVideoControllerFacade.html#/c:@M@AmazonChimeSDK@objc(pl)AudioVideoControllerFacade(im)startLocalVideoAndReturnError:).
+To start sending the local attendee's video, call meetingSession.audioVideo.[startLocalVideo()](https://aws.github.io/amazon-chime-sdk-ios/Protocols/AudioVideoControllerFacade.html#/c:@M@AmazonChimeSDK@objc(pl)AudioVideoControllerFacade(im)startLocalVideoAndReturnError:). 
+
+To start sending video with a local video configuration, call meetingSession.audioVideo.startLocalVideo(config:).
+To start local video with a provided custom `VideoSource`, call meetingSession.audioVideo.startLocalVideo(source:).  
 
 To stop sending the local attendee's video, call meetingSession.audioVideo.[stopLocalVideo()](https://aws.github.io/amazon-chime-sdk-ios/Protocols/AudioVideoControllerFacade.html#/c:@M@AmazonChimeSDK@objc(pl)AudioVideoControllerFacade(im)stopLocalVideo).
 


### PR DESCRIPTION
## ℹ️ Description
Expose simulcast configuration to customers by adding an API for mobile SDK to set simulcast in video client.

### Issue #, if available
https://sim.amazon.com/issues/Chime-49405

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [x] README update
    - [x] CHANGELOG update
    - [x] guildes update
- [ ] This change requires a dependency update
    - [x] Amazon Chime SDK Media
    - [ ] Other (update corresonding legal documents)

## 🧪 How Has This Been Tested?
Turn on front and back cameras at the same time(back camera through contentshare), then start recording When simulcast is enabled, the recording action will fail, otherwise it succeed.

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [x] Unit tests pass
- [x] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [x] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
