### PR TITLE
change maxSupportedVideoFrameRate to 30

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/capture/DefaultCameraCaptureSource.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/capture/DefaultCameraCaptureSource.swift
@@ -225,9 +225,7 @@ import UIKit
         let newAVFormat = captureDevice.formats.min { avFormatA, avFormatB in
             let formatA = VideoCaptureFormat.fromAVCaptureDeviceFormat(format: avFormatA)
             let formatB = VideoCaptureFormat.fromAVCaptureDeviceFormat(format: avFormatB)
-            let diffA = abs(formatA.width - format.width) + abs(formatA.height - format.height)
-            let diffB = abs(formatB.width - format.width) + abs(formatB.height - format.height)
-            return diffA < diffB
+            return closestFormat(formatA: formatA, formatB: formatB)
         }
         guard let chosenFormat = newAVFormat, chosenFormat != captureDevice.activeFormat else {
             captureDevice.unlockForConfiguration()
@@ -237,6 +235,15 @@ import UIKit
         captureDevice.unlockForConfiguration()
     }
 
+    func closestFormat(formatA: VideoCaptureFormat, formatB: VideoCaptureFormat) -> Bool {
+        let diffA = abs(formatA.width - format.width) + abs(formatA.height - format.height)
+        let diffB = abs(formatB.width - format.width) + abs(formatB.height - format.height)
+        if diffA == diffB {
+            return abs(formatA.maxFrameRate - format.maxFrameRate) < abs(formatB.maxFrameRate - format.maxFrameRate)
+        }
+        return diffA < diffB
+    }
+    
     @objc private func deviceOrientationDidChange(notification: NSNotification) {
         captureQueue.async {
             self.updateOrientation()

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/utils/Constants.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/utils/Constants.swift
@@ -22,7 +22,7 @@ import Foundation
     static let traceLevel: UInt32 = LOGGER_TRACE.rawValue
     static let dataMessageMaxDataSizeInByte = 2048
     static let dataMessageTopicRegex = "^[a-zA-Z0-9_-]{1,36}$"
-    static let maxSupportedVideoFrameRate = 15
+    static let maxSupportedVideoFrameRate = 30
     static let maxSupportedVideoHeight = 720
     static let maxSupportedVideoWidth = maxSupportedVideoHeight / 9 * 16
 }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/video/capture/DefautCameraCaptureSourceTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/video/capture/DefautCameraCaptureSourceTests.swift
@@ -59,6 +59,13 @@ class DefaultCameraCaptureSourceTests: XCTestCase {
         wait(for: [expect], timeout: defaultTimeout)
         AVCaptureSession.swizzleCanAddFalse()
     }
+
+    func testClosestFormat() {
+        XCTAssertEqual(defaultCameraCaptureSource.closestFormat(
+            formatA: VideoCaptureFormat(width: 1280, height: 720, maxFrameRate: 30),
+            formatB: VideoCaptureFormat(width: 1280, height: 720, maxFrameRate: 15)
+        ), true)
+    }
 }
 
 extension AVCaptureSession {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [unreleased]
+### Fixed
+* [Demo] Fixed frame rate display in device selection view
+
+### Changed
+* Changed `updateDeviceCaptureFormat` to match fps after resolution
 ## [0.22.0] - 2022-07-14
 
 ### Fixed


### PR DESCRIPTION
## ℹ️ Description
change maxSupportedVideoFrameRate to 30, also change updateDeviceCaptureFormat to match fps

### Issue #, if available

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guildes update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresonding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
