### PR TITLE
fixed video capacity bug

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoObserver.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoObserver.swift
@@ -92,4 +92,7 @@ import Foundation
     ///
     /// - Parameter sources: Array of video sources that are unavailable
     func remoteVideoSourcesDidBecomeUnavailable(sources: [RemoteVideoSource])
+    
+    /// Called on the main thread when video capacity status is updated.
+    func cameraSendAvailabilityDidChange(available: Bool)
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoObserver.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoObserver.swift
@@ -94,5 +94,7 @@ import Foundation
     func remoteVideoSourcesDidBecomeUnavailable(sources: [RemoteVideoSource])
     
     /// Called on the main thread when video capacity status is updated.
+    ///
+    /// - Parameter sources: True if camera send is available (due to video capacity status), False if not.
     func cameraSendAvailabilityDidChange(available: Bool)
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoObserver.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoObserver.swift
@@ -95,6 +95,6 @@ import Foundation
     
     /// Called on the main thread when video capacity status is updated.
     ///
-    /// - Parameter sources: True if camera send is available (due to video capacity status), False if not.
+    /// - Parameter available: True if camera send is available (due to video capacity status), False if not.
     func cameraSendAvailabilityDidChange(available: Bool)
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/utils/http/HttpUtils.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/utils/http/HttpUtils.swift
@@ -30,7 +30,7 @@ class HttpUtils {
                         headers: headers,
                         urlSession: urlSession) { data, error in
             if error == nil ||
-                !httpRetryPolicy.isRetryableCode(responseCode: (error as? NSError)?.code ?? 0) ||
+                !httpRetryPolicy.isRetryableCode(responseCode: (error as NSError?)?.code ?? 0) ||
                 httpRetryPolicy.isRetryCountLimitReached() {
                 completion(data, error)
                 return

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
@@ -199,7 +199,12 @@ extension DefaultVideoClientController: VideoClientDelegate {
     }
 
     public func videoClient(_ client: VideoClient?, cameraSendIsAvailable available: Bool) {
-        logger.info(msg: "videoClientCameraSendIsAvailable")
+        logger.info(msg: "videoClientCameraSendIsAvailable \(available)")
+        ObserverUtils.forEach(observers: videoObservers) { (observer: AudioVideoObserver) in
+            observer.cameraSendAvailabilityDidChange(
+                available: available
+            )
+        }
     }
 
     public func videoClientRequestTurnCreds(_ videoClient: VideoClient?) {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -482,6 +482,11 @@ extension MeetingModel: AudioVideoObserver {
             logWithFunctionName(message: "\(sessionStatus.statusCode)")
         }
     }
+    
+    func cameraSendAvailabilityDidChange(available : Bool) {
+        logWithFunctionName(message: "Camera Send Available: \(available)")
+        videoModel.cameraSendIsAvailable = available
+    }
 }
 
 // MARK: RealtimeObserver

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -524,8 +524,12 @@ class MeetingViewController: UIViewController {
     }
 
     @IBAction func cameraButtonClicked(_: UIButton) {
-        cameraButton.isSelected.toggle()
-        meetingModel?.videoModel.isLocalVideoActive = cameraButton.isSelected
+        if meetingModel?.videoModel.cameraSendIsAvailable == true || cameraButton.isSelected {
+            cameraButton.isSelected.toggle()
+            meetingModel?.videoModel.isLocalVideoActive = cameraButton.isSelected
+        } else {
+            meetingModel?.notifyHandler?("Cannot Enable Video. Meeting At Capacity.")
+        }
     }
 
     @IBAction func leaveButtonClicked(_: UIButton) {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
@@ -29,6 +29,8 @@ class VideoModel: NSObject {
     private let backgroundBlurProcessor: BackgroundBlurVideoFrameProcessor
     private var backgroundReplacementProcessor: BackgroundReplacementVideoFrameProcessor
     private var backgroundImage: UIImage?
+    
+    var cameraSendIsAvailable: Bool = false
 
     init(audioVideoFacade: AudioVideoFacade, eventAnalyticsController: EventAnalyticsController) {
         self.audioVideoFacade = audioVideoFacade

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
+## Unreleased
+
+### Added
+* Added functionality to observe video capacity status when added or removed
+* [Demo] Updated demo to use new functionality to prevent camera from toggling at video limit
+
 ## [0.22.2] - 2022-08-12
 
 ### Added
 * Added support to set max bit rate for local video and content share
 * [Demo] Add video configuration options to set max bit rate for local video in meeting
-
 
 ## [0.22.1] - 2022-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
-### Added
-* Added functionality to observe video capacity status when added or removed
+### Fixed
+* Fixed bugs that occured at video capacity
 * [Demo] Updated demo to use new functionality to prevent camera from toggling at video limit
 
 ## [0.22.2] - 2022-08-12


### PR DESCRIPTION
## ℹ️ Description
Original Problems:
- If iOS is sending video with local video on, and video capacity status is added, iOS will stop sending video and turn off local video
- If iOS is not sending video, and enables video, causing video capacity status to be added, iOS will stop sending video and turn off local video
- In some cases at video limit, iOS will turn on local video without actually sending video
- In some cases at video limit, iOS will be unable to turn off local video

Many of these problems were fixed in an update to Media Client. These SDK changes expose an observer to allow the app to monitor capacity status. Demo app was also updated to prevent camera toggle button from enabling and local video from turning on when at video capacity.

### Issue #, if available
https://github.com/aws/amazon-chime-sdk-ios/issues/351

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
    - [ ] README update
    - [x] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
Changes tested on both Android and iOS. This is the second step after a Media Client change that exposed cameraSendIsAvailable(). Video Capacity was 100. Used a Load Test to put 98 robots into a test meeting with their video turned on and opened two additional manual tabs on Chrome and entered the meeting on each mobile device separately. 

Test cases:
Attempt to enable camera when current videos are already 100
Enable camera as 99th video participant, then add one more Chrome video participant
Enable camera as 100th video participant, then check that 101st participant is unable to enable camera
Check race condition by having 99 video participants, then simultaneously attempting to enable camera on Chrome and Mobile--repeat 10-20 times.
Test cases all pass.

### Additional Manual Test
- [x] Pause and resume remote video
- [x] Switch local camera
- [x] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
