### PR TITLE
Add logs when failed to start audio client and update documentation

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoControllerFacade.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoControllerFacade.swift
@@ -17,6 +17,8 @@ import Foundation
     ///
     /// - Parameter audioVideoConfiguration: The configuration used for Audio & Video
     /// - Throws: `PermissionError.audioPermissionError` if `RecordPermission` is not given
+    /// - Throws: `MediaError.audioFailedToStart` if audio client failed to start
+    /// - Throws: `MediaError.illegalState` if audio client is already started before calling start()
     func start(audioVideoConfiguration: AudioVideoConfiguration) throws
 
     /// Start AudioVideo Controller
@@ -25,11 +27,15 @@ import Foundation
     /// This parameter is used to determine how audio session interruptions should be handled,
     /// in scenarios such as receving another phone call during the VoIP call.
     /// - Throws: `PermissionError.audioPermissionError` if `RecordPermission` is not given
+    /// - Throws: `MediaError.audioFailedToStart` if audio client failed to start
+    /// - Throws: `MediaError.illegalState` if audio client is already started before calling start()
     func start(callKitEnabled: Bool) throws
 
     /// Start AudioVideo Controller
     ///
     /// - Throws: `PermissionError.audioPermissionError` if `RecordPermission` is not given
+    /// - Throws: `MediaError.audioFailedToStart` if audio client failed to start
+    /// - Throws: `MediaError.illegalState` if audio client is already started before calling start()
     func start() throws
 
     /// Stop AudioVideo Controller. This will exit the meeting
@@ -53,7 +59,7 @@ import Foundation
     /// This function will only have effect if `start` has already been called
     /// If maxBitRateKbps is not set, it will be self adjusted depending on number of users and videos in the meeting
     ///
-    /// Parameter config: configurations of emitted video stream, e.g. simulcast, maxBitRateKbps
+    /// - Parameter config: configurations of emitted video stream, e.g. simulcast, maxBitRateKbps
     /// - Throws: `PermissionError.videoPermissionError` if video permission of `AVCaptureDevice` is not granted
     func startLocalVideo(config: LocalVideoConfiguration) throws
 

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
@@ -126,6 +126,7 @@ extension DefaultAudioClientController: AudioClientController {
         if status == AUDIO_CLIENT_OK {
             Self.state = .started
         } else {
+            logger.error(msg: "Cannot start audio client with status = \(status.rawValue)")
             eventAnalyticsController.publishEvent(name: .meetingStartFailed)
             cleanup()
             throw MediaError.audioFailedToStart


### PR DESCRIPTION
## ℹ️ Description
Add logs when failed to start audio client and update documentation

### Issue #, if available
V700354804

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
