### PR TITLE
Fix data message sending non UTF-8 bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Fixed
+* Fixed data message sending non-UTF8 bytes issue
+
 ## [0.22.3] - 2022-09-08
 
 ### Fixed


### PR DESCRIPTION
## ℹ️ Description
Fixed the data message issue that the SDK can't send bytes that are not able to encoded with UTF-8.

### Issue #, if available
SDKSupportOps-2734

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
    - [ ] README update
    - [x] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
Sent the problematic bytes and verified they can be received:
```
2022-10-04 10:31:33.750075-0700 AmazonChimeSDKDemo[40668:343750] [INFO] MeetingModel - linsang: videoClientDataMessageReceived: size: 8, content: {length = 8, bytes = 0x6166617765667766}
2022-10-04 10:31:38.055756-0700 AmazonChimeSDKDemo[40668:343750] [INFO] MeetingModel - linsang: videoClientDataMessageReceived: size: 8, content: {length = 8, bytes = 0xf09f87abf09f87b7}
2022-10-04 10:31:39.968002-0700 AmazonChimeSDKDemo[40668:343750] [INFO] MeetingModel - linsang: videoClientDataMessageReceived: size: 8, content: {length = 8, bytes = 0x418df0db8bb43042}
2022-10-04 10:31:46.548771-0700 AmazonChimeSDKDemo[40668:343750] [INFO] MeetingModel - linsang: videoClientDataMessageReceived: size: 7, content: {length = 7, bytes = 0x9f87abf09f87b7}
```

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
