### PR TITLE
Fix handling of terminator

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
@@ -552,6 +552,7 @@ extension DefaultVideoClientController: VideoClientController {
 
                 videoClient?.sendDataMessage(topic,
                                              data: buffer,
+                                             dataLen: UInt32(container.count),
                                              lifetimeMs: lifetimeMs)
             }
         } else {

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientProtocol.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientProtocol.swift
@@ -42,7 +42,7 @@ import Foundation
 
     func videoLogCallBack(_ logLevel: video_client_loglevel_t, msg: String!)
 
-    func sendDataMessage(_ topic: String!, data: UnsafePointer<Int8>!, lifetimeMs: Int32)
+    func sendDataMessage(_ topic: String!, data: UnsafePointer<Int8>!, dataLen: UInt32, lifetimeMs: Int32)
 
     func updateVideoSourceSubscriptions(_ addedOrUpdated: [AnyHashable: Any]!,
                                         withRemoved: [Any]!)
@@ -52,7 +52,7 @@ import Foundation
     func demoteFromPrimaryMeeting()
 
     func setSimulcast(_ simulcast: Bool)
-    
+
     func setMaxBitRateKbps(_ maxBitRate: UInt32)
 }
 

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/video/DefaultVideoClientControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/video/DefaultVideoClientControllerTests.swift
@@ -42,7 +42,7 @@ class DefaultVideoClientControllerTests: CommonTestCase {
         XCTAssertNoThrow(try defaultVideoClientController.sendDataMessage(topic: topic, data: testMessage))
 
         verify(loggerMock.error(msg: "Cannot send data message because videoClientState=uninitialized")).wasCalled()
-        verify(videoClientMock.sendDataMessage(any(), data: any(), lifetimeMs: any())).wasNeverCalled()
+        verify(videoClientMock.sendDataMessage(any(), data: any(), dataLen: any(), lifetimeMs: any())).wasNeverCalled()
     }
 
     func testSendDataMessage_negativeLifetimeMs() {
@@ -51,7 +51,7 @@ class DefaultVideoClientControllerTests: CommonTestCase {
             XCTAssertEqual(error as? SendDataMessageError, SendDataMessageError.negativeLifetimeParameter)
         }
 
-        verify(videoClientMock.sendDataMessage(any(), data: any(), lifetimeMs: any())).wasNeverCalled()
+        verify(videoClientMock.sendDataMessage(any(), data: any(), dataLen: any(), lifetimeMs: any())).wasNeverCalled()
     }
 
     func testSendDataMessage_invalidTopic() {
@@ -60,28 +60,28 @@ class DefaultVideoClientControllerTests: CommonTestCase {
             XCTAssertEqual(error as? SendDataMessageError, SendDataMessageError.invalidTopic)
         }
 
-        verify(videoClientMock.sendDataMessage(any(), data: any(), lifetimeMs: any())).wasNeverCalled()
+        verify(videoClientMock.sendDataMessage(any(), data: any(), dataLen: any(), lifetimeMs: any())).wasNeverCalled()
     }
 
     func testSendDataMessage_sendString() {
         defaultVideoClientController.start()
         XCTAssertNoThrow(try defaultVideoClientController.sendDataMessage(topic: topic, data: testMessage))
 
-        verify(videoClientMock.sendDataMessage(self.topic, data: any(), lifetimeMs: 0)).wasCalled()
+        verify(videoClientMock.sendDataMessage(self.topic, data: any(), dataLen: any(), lifetimeMs: 0)).wasCalled()
     }
 
     func testSendDataMessage_sendByteArray() {
         defaultVideoClientController.start()
         XCTAssertNoThrow(try defaultVideoClientController.sendDataMessage(topic: topic, data: [116, 101, 115, 116]))
 
-        verify(videoClientMock.sendDataMessage(self.topic, data: any(), lifetimeMs: 0)).wasCalled()
+        verify(videoClientMock.sendDataMessage(self.topic, data: any(), dataLen: any(), lifetimeMs: 0)).wasCalled()
     }
 
     func testSendDataMessage_sendJson() {
         defaultVideoClientController.start()
         XCTAssertNoThrow(try defaultVideoClientController.sendDataMessage(topic: topic, data: ["key": "value"]))
 
-        verify(videoClientMock.sendDataMessage(self.topic, data: any(), lifetimeMs: 0)).wasCalled()
+        verify(videoClientMock.sendDataMessage(self.topic, data: any(), dataLen: any(), lifetimeMs: 0)).wasCalled()
     }
 
     func testSendDataMessage_sendInvalidData() {
@@ -90,7 +90,7 @@ class DefaultVideoClientControllerTests: CommonTestCase {
             XCTAssertEqual(error as? SendDataMessageError, SendDataMessageError.invalidData)
         }
 
-        verify(videoClientMock.sendDataMessage(self.topic, data: any(), lifetimeMs: 0)).wasNeverCalled()
+        verify(videoClientMock.sendDataMessage(self.topic, data: any(), dataLen: any(), lifetimeMs: 0)).wasNeverCalled()
     }
 
     func testSendLocalVideo() {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-## Unreleased
+## [Unreleased]
 
 ### Fixed
-* Fixed data message handling null terminator
+* Fixed data message handling null terminator when sending
 
 ## [0.22.4] - 2022-10-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 * Fixed data message sending non-UTF8 bytes issue
+* Fixed data message handling null terminator
 
 ## [0.22.3] - 2022-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
+## Unreleased
+
+### Fixed
+* Fixed data message handling null terminator
+
 ## [0.22.4] - 2022-10-20
 
 ### Fixed
 * Fixed data message sending non-UTF8 bytes issue
-* Fixed data message handling null terminator
 
 ## [0.22.3] - 2022-09-08
 


### PR DESCRIPTION
## ℹ️ Description
*provide a summary of the changes and the related issue, relevant motivation and context*

### Issue #, if available

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*
Changed the demo code to add null byte and confirm that it can also receive the data.
```
let badBytes = Data(bytes: [0x41, 0x8D, 0xF0, 0x00, 0x8B, 0xB4, 0x30, 0x42] as [UInt8], count: 8)

try currentMeetingSession
    .audioVideo
    .realtimeSendDataMessage(topic: "chat",
                             data: badBytes,
                             lifetimeMs: 1000)
```


### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
