### PR TITLE
[Demo] Fix a few video view issue in demo app

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -66,11 +66,7 @@ class MeetingModel: NSObject {
                 if wasLocalVideoOn {
                     videoModel.isLocalVideoActive = true
                 }
-                if activeMode == .video {
-                    videoModel.updateAllRemoteVideosInCurrentPageExceptUserPausedVideos()
-                } else if activeMode == .screenShare{
-                    videoModel.addContentShareVideoSource()
-                }
+                updateRemoteVideoSourceSelection()
             }
             videoModel.updateVideoSourceSubscription()
         }
@@ -80,15 +76,7 @@ class MeetingModel: NSObject {
 
     var activeMode: ActiveMode = .roster {
         didSet {
-            if activeMode == .video {
-                videoModel.removeRemoteVideosNotInCurrentPage()
-                videoModel.updateAllRemoteVideosInCurrentPageExceptUserPausedVideos()
-            } else if activeMode == .screenShare{
-                videoModel.removeNonContentShareVideoSources()
-                videoModel.addContentShareVideoSource()
-            } else {
-                videoModel.unsubscribeAllRemoteVideos()
-            }
+            updateRemoteVideoSourceSelection()
             videoModel.updateVideoSourceSubscription()
             activeModeDidSetHandler?(activeMode)
         }
@@ -384,6 +372,18 @@ class MeetingModel: NSObject {
         }
         return call
     }
+
+    private func updateRemoteVideoSourceSelection() {
+        if activeMode == .video {
+            videoModel.removeRemoteVideosNotInCurrentPage()
+            videoModel.updateAllRemoteVideosInCurrentPageExceptUserPausedVideos()
+        } else if activeMode == .screenShare {
+            videoModel.removeNonContentShareVideoSources()
+            videoModel.addContentShareVideoSource()
+        } else {
+            videoModel.unsubscribeAllRemoteVideos()
+        }
+    }
 }
 
 // MARK: AudioVideoObserver
@@ -469,11 +469,7 @@ extension MeetingModel: AudioVideoObserver {
             // Initialize with defaults in case we want to update through UI
             videoModel.addVideoSource(source: source, config: VideoSubscriptionConfiguration())
         }
-        if activeMode == .video {
-            videoModel.updateAllRemoteVideosInCurrentPageExceptUserPausedVideos()
-        } else if activeMode == .screenShare {
-            videoModel.addContentShareVideoSource()
-        }
+        updateRemoteVideoSourceSelection()
         videoModel.updateVideoSourceSubscription()
     }
     

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -79,7 +79,6 @@ class MeetingModel: NSObject {
         didSet {
             videoModel.unsubscribeAllRemoteVideos()
             if activeMode == .video {
-                videoModel.removeContentShareVideoSources()
                 videoModel.removeRemoteVideosNotInCurrentPage()
                 videoModel.addAllRemoteVideosInCurrentPageExceptUserPausedVideos()
             } else if activeMode == .screenShare{

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -152,7 +152,8 @@ class MeetingViewController: UIViewController {
         }
         meetingModel.videoModel.videoSubscriptionUpdatedHandler = { [weak self, weak meetingModel] in
             guard let strongSelf = self, let meetingModel = meetingModel else { return }
-            meetingModel.videoModel.addAllRemoteVideosInCurrentPageExceptUserPausedVideos()
+            meetingModel.videoModel.removeRemoteVideosNotInCurrentPage()
+            meetingModel.videoModel.updateAllRemoteVideosInCurrentPageExceptUserPausedVideos()
             strongSelf.prevVideoPageButton.isEnabled = meetingModel.videoModel.canGoToPrevRemoteVideoPage
             strongSelf.nextVideoPageButton.isEnabled = meetingModel.videoModel.canGoToNextRemoteVideoPage
             strongSelf.videoCollection.reloadData()
@@ -564,11 +565,13 @@ class MeetingViewController: UIViewController {
     @IBAction func prevPageButtonClicked(_: UIButton) {
         meetingModel?.videoModel.getPreviousRemoteVideoPage()
         meetingModel?.videoModel.videoSubscriptionUpdatedHandler?()
+        meetingModel?.videoModel.updateVideoSourceSubscription()
     }
 
     @IBAction func nextPageButtonClicked(_: UIButton) {
         meetingModel?.videoModel.getNextRemoteVideoPage()
         meetingModel?.videoModel.videoSubscriptionUpdatedHandler?()
+        meetingModel?.videoModel.updateVideoSourceSubscription()
     }
 
     @objc private func keyboardShowHandler(notification: NSNotification) {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 * Fixed data message handling null terminator when sending
+* [Demo] Fix a few video view issue in demo app
 
 ## [0.22.4] - 2022-10-20
 


### PR DESCRIPTION
## ℹ️ Description
This PR aims to fix several video view related issues in demo app:

#### Initial render experiences 3 second delay when remote video starts
- Root cause: When switching to video view tab, the function `updateVideoSourceSubscriptions` is called, and as a result, the auto subscribe functionality is disabled. Then if a remote video starts, the demo app would wait for a frame to start a video tile to view video. On the other hand, a video tile is needed to start subscription and receive a frame. This chicken and egg problem would remain until a three-second render timeout is triggered.
- Fix: We maintain a map in `VideoModel` to store newly added remote video sources without a video source. When a new remote video source is added, we refresh the current page of video and if there is unused video tiles remaining, we start subscription for pending video sources and add the corresponding video tiles to the current page.

#### Content share video freezes if content share is started when viewing tabs other than screen share
- Root cause: If content share is started when not viewing the screen share tab, the content share video tile would be added but the subscription to content video source is not activated as screen tab is not being viewed. When switching to screen tab at a later time, there is no logic to start subscription of the video source. Therefore, video would freeze after switching to the tab.
- Fix: Add a function to actively subscribe to content video source and disable subscription for other video source when switching to content share.

#### Content subscription is not stopped when switching away from screen share viewing tab to video tab
- Root cause: When switching to video tab, `addAllRemoteVideosInCurrentPageExceptUserPausedVideos`would be called. However, the function does not touch content share video sources and the subscription remains active after switching away from screen tab.
- Fix: Stop content subscription when switching out of the tab.

#### Content share freezes if a new remote video starts
- Root cause: When a new video tile is added, it calls `unsubscribeAllRemoteVideos` if not on video tab. This will stop subscription for screen share is screen tab is actively viewed. As such, screen share would freeze.
- Fix: Call `removeNonContentShareVideoSources` instead of `unsubscribeAllRemoteVideos` when adding a new video tile if not viewing video tab.


### Issue #, if available

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [x] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

Testing steps
1. Let two JS SDK client _A_ and _B_ together with IOS demo client _C_ joining a meeting.
2. Switch to video tab on _C_.
3. Start video on _A_.
4. Verify video delay on _C_ in not noticeably slower than on _B_.
5. Switch to screen tab on _C_.
6. Start screen share on _A_.
7. Verify content share view delay on _C_ in not noticeably slower than on _B_.
8. Stop screen share on _A_.
9. Switch to roster tab on _C_.
10. Start screen share on _A_ and wait for 5 seconds.
11. Switch to screen tab on _C_.
12. Verify _C_ can view content share without freezing video.
13. Stop and restart camera on _A_.
14. Wait for 5 seconds and verify content share on _C_ is not freezed.

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
