### PR TITLE
remove '~>' option from AmazonChimeSDKMedia-Bitcode and AmazonChimeSDKMedia-No-Bitcode

### DIFF
--- a/AmazonChimeSDK-Bitcode.podspec
+++ b/AmazonChimeSDK-Bitcode.podspec
@@ -10,5 +10,5 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '10.0'
   s.vendored_frameworks = "AmazonChimeSDK.xcframework"
   s.swift_version    = '5.0'
-  s.dependency 'AmazonChimeSDKMedia-Bitcode', '~> 0.17.10'
+  s.dependency 'AmazonChimeSDKMedia-Bitcode', '0.17.10'
 end

--- a/AmazonChimeSDK-No-Bitcode.podspec
+++ b/AmazonChimeSDK-No-Bitcode.podspec
@@ -10,5 +10,5 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '10.0'
   s.vendored_frameworks = "AmazonChimeSDK.xcframework"
   s.swift_version    = '5.0'
-  s.dependency 'AmazonChimeSDKMedia-No-Bitcode', '~> 0.17.10'
+  s.dependency 'AmazonChimeSDKMedia-No-Bitcode', '0.17.10'
 end


### PR DESCRIPTION
## ℹ️ Description
remove '~>' option on `AmazonChimeSDKMedia-Bitcode` and `AmazonChimeSDKMedia-No-Bitcode` from podspec
~> option can make debug difficult and that's why I created PR to remove it



### Issue #, if available

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
