### PR TITLE
[Chime-57624] Audio Issues on Chime Mobile: Added new statuses for au…

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/session/MeetingSessionStatusCode.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/session/MeetingSessionStatusCode.swift
@@ -54,6 +54,12 @@ import Foundation
     /// When maximum concurrent video channel reached
     case videoAtCapacityViewOnly = 206
 
+    /// Designated input device is not responding and timed out.
+    case audioInputDeviceNotResponding = 82
+
+    /// Designated output device is not responding and timed out.
+    case audioOutputDeviceNotResponding = 83
+
     public var description: String {
         switch self {
         case .ok:
@@ -86,6 +92,10 @@ import Foundation
             return "unknown"
         case .videoAtCapacityViewOnly:
             return "videoAtCapacityViewOnly"
+        case .audioInputDeviceNotResponding:
+            return "audioInputDeviceNotResponding"
+        case .audioOutputDeviceNotResponding:
+            return "audioOutputDeviceNotResponding"
         }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Added
+* Added additional session statuses for audio device I/O timeouts.
+
 ## [0.22.6] - 2022-12-02
 
 ## [0.22.5] - 2022-11-16


### PR DESCRIPTION
…dio device I/O failures

This PR was created on behalf of @rnewhouse-amazon, who is the original author.

## ℹ️ Description
The Chime team was tracking incidents of AudioSessionStop callbacks with a null MeetingSessionStatusCode on Android and traced the null MeetingSessionStatusCode to the following log event:
AudioClient State raw value: 7 Unknown Status raw value: 82
These were being triggered by a AudioClient failed state of AudioClient.AUDIO_CLIENT_STATE_DISCONNECTED_ABNORMAL with an unknown status code of 82 which maps to AUDIO_CLIENT_ERR_INPUT_DEVICE_NOT_RESPONDING.

This PR ensures we have parity between the two platforms.

### Issue #, if available
[aws/amazon-chime-sdk-android#523](https://github.com/aws/amazon-chime-sdk-android/issues/523) 

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [x] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [x] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [x] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [x] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
