### PR TITLE
Grouped tests in DefaultAudioClientObserverTests

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientObserverTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientObserverTests.swift
@@ -420,6 +420,7 @@ extension DefaultAudioClientObserverTests{
 
         wait(for: [expect], timeout: defaultTimeout)
     }
+    
     func testTranscriptEventsReceived_receivedTranscript() {
         let item = TranscriptItemInternal(type: TranscriptItemTypeInternal.pronunciation,
                                           startTimeMs: timestampMs,

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientObserverTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientObserverTests.swift
@@ -252,7 +252,10 @@ class DefaultAudioClientObserverTests: XCTestCase {
         defaultAudioClientObserver.audioMetricsChanged(metrics)
         verify(clientMetricsCollectorMock.processAudioClientMetrics(metrics: any())).wasCalled()
     }
+}
 
+// MARK: - Signal Strength Tests
+extension DefaultAudioClientObserverTests{
     func testSignalStrengthChanged_signalStrengthDidChange() {
         let signals = [AttendeeUpdate(profileId: attendeeId, externalUserId: externalUserId, data: 0)]
         defaultAudioClientObserver.signalStrengthChanged(signals as [Any])
@@ -285,7 +288,10 @@ class DefaultAudioClientObserverTests: XCTestCase {
 
         wait(for: [expect], timeout: defaultTimeout)
     }
+}
 
+// MARK: - Volume State Tests
+extension DefaultAudioClientObserverTests{
     func testVolumeStateChanged_volumeDidChange() {
         let volumes = [AttendeeUpdate(profileId: attendeeId, externalUserId: externalUserId, data: 2)]
         defaultAudioClientObserver.volumeStateChanged(volumes as [Any])
@@ -341,7 +347,10 @@ class DefaultAudioClientObserverTests: XCTestCase {
 
         wait(for: [expect], timeout: defaultTimeout)
     }
+}
 
+// MARK: - Attendees Presence Tests
+extension DefaultAudioClientObserverTests{
     func testAttendeesPresenceChanged_attendeesDidJoin() {
         let attendees = [AttendeeUpdate(profileId: attendeeId, externalUserId: externalUserId, data: 1)]
         defaultAudioClientObserver.attendeesPresenceChanged(attendees as [Any])
@@ -388,7 +397,10 @@ class DefaultAudioClientObserverTests: XCTestCase {
 
         wait(for: [expect], timeout: defaultTimeout)
     }
+}
 
+// MARK: - Transcript Event Tests
+extension DefaultAudioClientObserverTests{
     func testTranscriptEventsReceived_receivedTranscriptionStatus() {
         let statusStarted = TranscriptionStatusInternal(type: TranscriptionStatusTypeInternal.started,
                                                         eventTimeMs: timestampMs,
@@ -408,7 +420,6 @@ class DefaultAudioClientObserverTests: XCTestCase {
 
         wait(for: [expect], timeout: defaultTimeout)
     }
-
     func testTranscriptEventsReceived_receivedTranscript() {
         let item = TranscriptItemInternal(type: TranscriptItemTypeInternal.pronunciation,
                                           startTimeMs: timestampMs,


### PR DESCRIPTION
## ℹ️ Description
Grouped tests in DefaultAudioClientObserverTests into extensions to fix body length violation.

### Issue #, if available

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
