### PR TITLE
use codec selection API

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
+++ b/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
@@ -281,6 +281,7 @@
 		D863BE3529BAD8DA00D9DE9E /* AnyCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D863BE3429BAD8DA00D9DE9E /* AnyCodableTests.swift */; };
 		D863BE3729BAF68B00D9DE9E /* EventAttributeUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D863BE3629BAF68B00D9DE9E /* EventAttributeUtilsTests.swift */; };
 		D8FE1FE629B9232400A62E72 /* AnyCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FE1FE529B9232400A62E72 /* AnyCodable.swift */; };
+		E09CE8EB29887916001C5093 /* VideoCodecCapability.swift in Sources */ = {isa = PBXBuildFile; fileRef = E09CE8EA29887916001C5093 /* VideoCodecCapability.swift */; };
 		ED300F2A284877AC00497568 /* LocalVideoConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED300F29284877AC00497568 /* LocalVideoConfiguration.swift */; };
 		F81104AC276190AA003D17AD /* VideoPriority.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81104A8276190A9003D17AD /* VideoPriority.swift */; };
 		F81104AD276190AA003D17AD /* RemoteVideoSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = F81104A9276190A9003D17AD /* RemoteVideoSource.swift */; };
@@ -583,6 +584,7 @@
 		D863BE3429BAD8DA00D9DE9E /* AnyCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodableTests.swift; sourceTree = "<group>"; };
 		D863BE3629BAF68B00D9DE9E /* EventAttributeUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventAttributeUtilsTests.swift; sourceTree = "<group>"; };
 		D8FE1FE529B9232400A62E72 /* AnyCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodable.swift; sourceTree = "<group>"; };
+		E09CE8EA29887916001C5093 /* VideoCodecCapability.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoCodecCapability.swift; sourceTree = "<group>"; };
 		ED300F29284877AC00497568 /* LocalVideoConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalVideoConfiguration.swift; sourceTree = "<group>"; };
 		F81104A8276190A9003D17AD /* VideoPriority.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoPriority.swift; sourceTree = "<group>"; };
 		F81104A9276190A9003D17AD /* RemoteVideoSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteVideoSource.swift; sourceTree = "<group>"; };
@@ -930,6 +932,7 @@
 		5A631A4024297BB200C8DAF3 /* video */ = {
 			isa = PBXGroup;
 			children = (
+				E09CE8EA29887916001C5093 /* VideoCodecCapability.swift */,
 				CFA2A14428074E2A008FDFF5 /* backgroundfilter */,
 				C4590E2B253E03530035F4E0 /* capture */,
 				F81104A9276190A9003D17AD /* RemoteVideoSource.swift */,
@@ -1753,6 +1756,7 @@
 				0023075A2630E39C0074947E /* HttpMethod.swift in Sources */,
 				B418164724B7EDA800FA62BF /* SendDataMessageError.swift in Sources */,
 				0064165D26290C3100626EB8 /* DirtyEventDao.swift in Sources */,
+				E09CE8EB29887916001C5093 /* VideoCodecCapability.swift in Sources */,
 				003B588D23E22CD6002493AB /* SessionStateControllerAction.swift in Sources */,
 				C5FBFB85281DCBAC004C85CA /* NoopSegmentationProcessor.swift in Sources */,
 				002F8FE225BF984B00006F46 /* MeetingStatsCollector.swift in Sources */,

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoControllerFacade.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoControllerFacade.swift
@@ -178,4 +178,16 @@ import Foundation
     /// may result in `PrimaryMeetingPromotionObserver.didPromoteToPrimaryMeeting` but there is no need to wait for that callback
     /// to revert UX, etc.
     func demoteFromPrimaryMeeting()
+
+     /// Set codec preferences for this clients send stream in order of most preferred to least preferred. The controller will
+     /// fallback for one of two reasons
+     /// - The codec is not supported by the browser
+     /// - Another client that has joined the conference does not support receiving the video. Note that if another client does not support
+     ///   any of the codecs provided the sender will not fallback, and that client will not be able to receive from this sender.
+     ///
+     /// If there is no overlap between what is passed in and what is supported by the browser, this function
+     /// may not have any effect, and the default set of codecs for this browser will be used.
+     ///
+     /// - Parameter preferences: list of VideoCodecCapability in order of preference
+    func setVideoCodecSendPreferences(preferences: [VideoCodecCapability])
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoController.swift
@@ -201,4 +201,8 @@ import Foundation
         primaryMeetingPromotionObserver?.didDemoteFromPrimaryMeeting(
             status: MeetingSessionStatus(statusCode: MeetingSessionStatusCode.ok))
     }
+
+    public func setVideoCodecSendPreferences(preferences: [VideoCodecCapability]) {
+        videoClientController.setVideoCodecSendPreferences(preferences: preferences)
+    }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
@@ -169,6 +169,10 @@ import Foundation
         contentShareController.stopContentShare()
     }
 
+    public func setVideoCodecSendPreferences(preferences: [VideoCodecCapability]) {
+        audioVideoController.setVideoCodecSendPreferences(preferences: preferences)
+    }
+
     // MARK: DeviceController
 
     public func listAudioDevices() -> [MediaDevice] {

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/contentshare/ContentShareController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/contentshare/ContentShareController.swift
@@ -56,4 +56,16 @@ import Foundation
     ///
     /// - Parameter observer: observer to be removed for events
     func removeContentShareObserver(observer: ContentShareObserver)
+    
+    /// Set codec preferences for this clients send stream in order of most preferred to least preferred. The controller will
+    /// fallback for one of two reasons
+    /// - The codec is not supported by the browser
+    /// - Another client that has joined the conference does not support receiving the video. Note that if another client does not support
+    ///   any of the codecs provided the sender will not fallback, and that client will not be able to receive from this sender.
+    ///
+    /// If there is no overlap between what is passed in and what is supported by the browser, this function
+    /// may not have any effect, and the default set of codecs for this browser will be used.
+    ///
+    /// - Parameter preferences: list of VideoCodecCapability in order of preference
+   func setVideoCodecSendPreferences(preferences: [VideoCodecCapability])
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/contentshare/DefaultContentShareController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/contentshare/DefaultContentShareController.swift
@@ -42,4 +42,8 @@ import Foundation
     public func removeContentShareObserver(observer: ContentShareObserver) {
         contentShareVideoClientController.unsubscribeFromVideoClientStateChange(observer: observer)
     }
+    
+    public func setVideoCodecSendPreferences(preferences: [VideoCodecCapability]) {
+        contentShareVideoClientController.setVideoCodecSendPreferences(preferences: preferences)
+    }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/VideoCodecCapability.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/VideoCodecCapability.swift
@@ -1,0 +1,45 @@
+//
+//  VideoCodecCapability.swift
+//  AmazonChimeSDK
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+
+@objcMembers public class VideoCodecCapability: NSObject {
+    public var name: String = ""
+    public var clockRate: Int32 = 0
+    public var parameters: [String: String] = [:]
+
+    public init(name: String, clockRate: Int32, params: [String: String]) {
+        self.name = name
+        self.clockRate = clockRate
+        self.parameters = params
+    }
+
+    public static func vp8() -> VideoCodecCapability {
+        return VideoCodecCapability(name: "VP8", clockRate: 90000, params: [:])
+    }
+
+    public static func h264ConstrainedBaselineProfile() -> VideoCodecCapability {
+        return VideoCodecCapability(
+            name: "H264",
+            clockRate: 90000,
+            params: ["level-asymmetry-allowed": "1", "packetization-mode": "1", "profile-level-id": "42e01f"]
+        )
+    }
+    
+    public static func vp9() -> VideoCodecCapability {
+        return VideoCodecCapability(
+            name: "VP9",
+            clockRate: 90000,
+            params: ["profile-id": "0"]
+        )
+    }
+    
+    public static func av1() -> VideoCodecCapability {
+        VideoCodecCapability(name: "AV1", clockRate: 90000, params: [:])
+    }
+}

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/ContentShareVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/ContentShareVideoClientController.swift
@@ -14,4 +14,5 @@ import Foundation
     func stopVideoShare()
     func subscribeToVideoClientStateChange(observer: ContentShareObserver)
     func unsubscribeFromVideoClientStateChange(observer: ContentShareObserver)
+    func setVideoCodecSendPreferences(preferences: [VideoCodecCapability])
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/DefaultContentShareVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/DefaultContentShareVideoClientController.swift
@@ -155,7 +155,19 @@ extension DefaultContentShareVideoClientController: VideoClientDelegate {
         guard let metrics = metrics else { return }
         clientMetricsCollector.processContentShareVideoClientMetrics(metrics: metrics)
     }
-
+    
+    public func setVideoCodecSendPreferences(preferences: [VideoCodecCapability]) {
+        var codecCapabilties = [VideoCodecCapabilitiesInternal]()
+        preferences.forEach { preference in codecCapabilties.append(
+            VideoCodecCapabilitiesInternal(
+                name: preference.name,
+                clockRate: preference.clockRate,
+                parameters: preference.parameters as [AnyHashable: Any]
+            )
+        )}
+        videoClient.setVideoCodecPreferences(codecCapabilties)
+    }
+    
     private func resetContentShareVideoClientMetrics() {
         clientMetricsCollector.processContentShareVideoClientMetrics(metrics: [:])
     }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
@@ -579,4 +579,16 @@ extension DefaultVideoClientController: VideoClientController {
         }
         videoClient?.demoteFromPrimaryMeeting()
     }
+
+    func setVideoCodecSendPreferences(preferences: [VideoCodecCapability]) {
+        var codecCapabilties = [VideoCodecCapabilitiesInternal]()
+        preferences.forEach { preference in codecCapabilties.append(
+            VideoCodecCapabilitiesInternal(
+                name: preference.name,
+                clockRate: preference.clockRate,
+                parameters: preference.parameters as [AnyHashable: Any]
+            )
+        )}
+        videoClient?.setVideoCodecPreferences(codecCapabilties)
+    }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientController.swift
@@ -34,4 +34,5 @@ import Foundation
     func promoteToPrimaryMeeting(credentials: MeetingSessionCredentials,
                                  observer: PrimaryMeetingPromotionObserver)
     func demoteFromPrimaryMeeting()
+    func setVideoCodecSendPreferences(preferences: [VideoCodecCapability])
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientProtocol.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientProtocol.swift
@@ -54,6 +54,8 @@ import Foundation
     func setSimulcast(_ simulcast: Bool)
 
     func setMaxBitRateKbps(_ maxBitRate: UInt32)
+
+    func setVideoCodecPreferences(_ codecPreferences: [Any]!)
 }
 
 extension VideoClient: VideoClientProtocol {}

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
@@ -151,7 +151,7 @@
                                 <rect key="frame" x="0.0" y="59" width="430" height="790"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="GdK-eP-aSg">
-                                        <rect key="frame" x="10" y="0.0" width="410" height="570"/>
+                                        <rect key="frame" x="10" y="0.0" width="410" height="680"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Audio Device" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jt4-1L-aqf" userLabel="Audio Device Label">
                                                 <rect key="frame" x="0.0" y="0.0" width="410" height="40"/>
@@ -204,8 +204,25 @@
                                                     <constraint firstAttribute="height" constant="70" id="Pwg-fu-poq"/>
                                                 </constraints>
                                             </pickerView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Video Preview" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dWN-Ug-VVk" userLabel="Video Preview Label">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Video Codec" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0xC-kE-1KO" userLabel="Video Codec Label">
                                                 <rect key="frame" x="0.0" y="330" width="410" height="40"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="Video Codec Label"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="40" id="WnU-Ev-o6s"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zDl-aZ-L0a" userLabel="Video Codec Picker">
+                                                <rect key="frame" x="0.0" y="370" width="410" height="70"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="Video Codec Picker"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="70" id="Rek-eZ-JrJ"/>
+                                                </constraints>
+                                            </pickerView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Video Preview" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dWN-Ug-VVk" userLabel="Video Preview Label">
+                                                <rect key="frame" x="0.0" y="440" width="410" height="40"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="Video Preview Label"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="40" id="m4H-yk-Drd"/>
@@ -215,7 +232,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="7bL-3M-Nob" customClass="DefaultVideoRenderView" customModule="AmazonChimeSDK">
-                                                <rect key="frame" x="0.0" y="370" width="410" height="150"/>
+                                                <rect key="frame" x="0.0" y="480" width="410" height="150"/>
                                                 <color key="backgroundColor" systemColor="scrollViewTexturedBackgroundColor"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="Video Preview View"/>
                                                 <constraints>
@@ -223,7 +240,7 @@
                                                 </constraints>
                                             </imageView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kR4-E2-BAx">
-                                                <rect key="frame" x="0.0" y="520" width="410" height="50"/>
+                                                <rect key="frame" x="0.0" y="630" width="410" height="50"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qc7-Qf-8m1" userLabel="Join Meeting">
                                                         <rect key="frame" x="105" y="5" width="200" height="40"/>
@@ -292,6 +309,7 @@
                         <outlet property="audioDeviceLabel" destination="Jt4-1L-aqf" id="po2-eh-wum"/>
                         <outlet property="audioDevicePicker" destination="ibL-Lh-i5w" id="Ni4-3h-Ayi"/>
                         <outlet property="joinButton" destination="Qc7-Qf-8m1" id="leg-wf-FcV"/>
+                        <outlet property="videoCodecPicker" destination="zDl-aZ-L0a" id="VPc-Cg-Cnz"/>
                         <outlet property="videoDevicePicker" destination="93n-jX-4CD" id="I7q-g4-uRR"/>
                         <outlet property="videoFormatPicker" destination="RkV-de-ZhY" id="3US-R8-dMl"/>
                         <outlet property="videoPreviewImageView" destination="7bL-3M-Nob" id="Kr8-Fw-sqX"/>

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DeviceSelectionModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DeviceSelectionModel.swift
@@ -12,6 +12,7 @@ import Foundation
 class DeviceSelectionModel {
     let audioDevices: [MediaDevice]
     let videoDevices: [MediaDevice]
+    let codecs: [[VideoCodecCapability]]
     let cameraCaptureSource: DefaultCameraCaptureSource
     let audioVideoConfig: AudioVideoConfiguration
 
@@ -36,6 +37,10 @@ class DeviceSelectionModel {
         }
     }
 
+    var selectedCodecIndex = 0
+    var selectedCodec: [VideoCodecCapability] {
+        return codecs[selectedCodecIndex]
+    }
     var selectedAudioDevice: MediaDevice {
         return audioDevices[selectedAudioDeviceIndex]
     }
@@ -62,6 +67,10 @@ class DeviceSelectionModel {
         audioDevices = deviceController.listAudioDevices()
         // Reverse these so the front camera is the initial choice
         videoDevices = MediaDevice.listVideoDevices().reversed()
+        codecs = [
+            [VideoCodecCapability.h264ConstrainedBaselineProfile(), VideoCodecCapability.vp8()],
+            [VideoCodecCapability.vp8(), VideoCodecCapability.h264ConstrainedBaselineProfile()]
+        ]
         self.cameraCaptureSource = cameraCaptureSource
         self.audioVideoConfig = audioVideoConfig
         cameraCaptureSource.device = selectedVideoDevice

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DeviceSelectionViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DeviceSelectionViewController.swift
@@ -14,6 +14,7 @@ class DeviceSelectionViewController: UIViewController {
     @IBOutlet var audioDevicePicker: UIPickerView!
     @IBOutlet var videoDevicePicker: UIPickerView!
     @IBOutlet var videoFormatPicker: UIPickerView!
+    @IBOutlet var videoCodecPicker: UIPickerView!
     @IBOutlet var videoPreviewImageView: DefaultVideoRenderView!
     @IBOutlet var joinButton: UIButton!
 
@@ -28,6 +29,8 @@ class DeviceSelectionViewController: UIViewController {
         videoDevicePicker.dataSource = self
         videoFormatPicker.delegate = self
         videoFormatPicker.dataSource = self
+        videoCodecPicker.delegate = self
+        videoCodecPicker.dataSource = self
 
         videoPreviewImageView.mirror = model?.shouldMirrorPreview ?? false
         model?.cameraCaptureSource.addVideoSink(sink: videoPreviewImageView)
@@ -66,6 +69,11 @@ extension DeviceSelectionViewController: UIPickerViewDelegate {
             }
             let format = formats[row]
             return "\(format.width) x \(format.height) @ \(format.maxFrameRate)"
+        } else if pickerView == videoCodecPicker {
+            if row > model.codecs.count {
+                return nil
+            }
+            return model.codecs[row].map{ $0.name }.joined(separator: ", ")
         } else {
             return nil
         }
@@ -93,6 +101,8 @@ extension DeviceSelectionViewController: UIPickerViewDelegate {
                 return
             }
             model.selectedVideoFormatIndex = row
+        } else if pickerView == videoCodecPicker {
+            model.selectedCodecIndex = row
         } else {
             return
         }
@@ -117,6 +127,8 @@ extension DeviceSelectionViewController: UIPickerViewDataSource {
                 return 0
             }
             return model.supportedVideoFormat[model.selectedVideoDeviceIndex].count
+        } else if pickerView == videoCodecPicker {
+            return model.codecs.count
         } else {
             return 0
         }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -490,6 +490,8 @@ extension MeetingModel: AudioVideoObserver {
         default:
             logWithFunctionName(message: "\(sessionStatus.statusCode)")
         }
+        videoModel.audioVideoFacade.setVideoCodecSendPreferences(preferences: deviceSelectionModel.selectedCodec)
+        screenShareModel.inAppCaptureModel.contentShareController.setVideoCodecSendPreferences(preferences: deviceSelectionModel.selectedCodec)
     }
     
     func cameraSendAvailabilityDidChange(available : Bool) {


### PR DESCRIPTION
## ℹ️ Description
use codec selection API on media to allow user specific send codec preference

### Issue #, if available

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*
use different VideoCodecPreference enumeration and checked sending codec

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
