### PR TITLE
Fix supportedVideoFormat out of index exception in demo

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DeviceSelectionModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DeviceSelectionModel.swift
@@ -48,6 +48,10 @@ class DeviceSelectionModel {
     }
 
     var selectedVideoFormat: VideoCaptureFormat? {
+        let supportedVideoFormat = self.supportedVideoFormat
+        guard supportedVideoFormat.count >= selectedVideoDeviceIndex + 1 else {
+            return nil
+        }
         return supportedVideoFormat[selectedVideoDeviceIndex][selectedVideoFormatIndex]
     }
 


### PR DESCRIPTION
## ℹ️ Description
Fix the a demo crash on simulator due to out of index exception.

### Issue #, if available

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
 - Manually tested locally by starting a meeting

### Additional Manual Test
- [X] Pause and resume remote video
- [X] Switch local camera
- [X] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
