### PR TITLE
Fix audio video config propagation in demo app

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoConfiguration.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoConfiguration.swift
@@ -43,6 +43,13 @@ import Foundation
         self.init(audioMode: audioMode, callKitEnabled: callKitEnabled, enableAudioRedundancy: enableAudioRedundancy, videoMaxResolution: VideoResolution.videoResolutionHD)
     }
 
+    convenience public init(audioVideoConfig: AudioVideoConfiguration, videoMaxResolution: VideoResolution) {
+        self.init(audioMode: audioVideoConfig.audioMode,
+                  callKitEnabled: audioVideoConfig.callKitEnabled,
+                  enableAudioRedundancy: audioVideoConfig.enableAudioRedundancy,
+                  videoMaxResolution: videoMaxResolution)
+    }
+
     public init(audioMode: AudioMode, callKitEnabled: Bool, enableAudioRedundancy: Bool, videoMaxResolution: VideoResolution) {
         self.audioMode = audioMode
         self.callKitEnabled = callKitEnabled

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoConfiguration.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoConfiguration.swift
@@ -13,7 +13,7 @@ import Foundation
     public let audioMode: AudioMode
     public let callKitEnabled: Bool
     public let enableAudioRedundancy: Bool
-    public var videoMaxResolution: VideoResolution
+    public let videoMaxResolution: VideoResolution
 
     convenience override public init() {
         self.init(audioMode: .stereo48K, callKitEnabled: false, enableAudioRedundancy: true, videoMaxResolution: VideoResolution.videoResolutionHD)

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoConfiguration.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/AudioVideoConfiguration.swift
@@ -13,7 +13,7 @@ import Foundation
     public let audioMode: AudioMode
     public let callKitEnabled: Bool
     public let enableAudioRedundancy: Bool
-    public let videoMaxResolution: VideoResolution
+    public var videoMaxResolution: VideoResolution
 
     convenience override public init() {
         self.init(audioMode: .stereo48K, callKitEnabled: false, enableAudioRedundancy: true, videoMaxResolution: VideoResolution.videoResolutionHD)
@@ -41,13 +41,6 @@ import Foundation
 
     convenience public init(audioMode: AudioMode, callKitEnabled: Bool, enableAudioRedundancy: Bool) {
         self.init(audioMode: audioMode, callKitEnabled: callKitEnabled, enableAudioRedundancy: enableAudioRedundancy, videoMaxResolution: VideoResolution.videoResolutionHD)
-    }
-
-    convenience public init(audioVideoConfig: AudioVideoConfiguration, videoMaxResolution: VideoResolution) {
-        self.init(audioMode: audioVideoConfig.audioMode,
-                  callKitEnabled: audioVideoConfig.callKitEnabled,
-                  enableAudioRedundancy: audioVideoConfig.enableAudioRedundancy,
-                  videoMaxResolution: videoMaxResolution)
     }
 
     public init(audioMode: AudioMode, callKitEnabled: Bool, enableAudioRedundancy: Bool, videoMaxResolution: VideoResolution) {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/JoiningViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/JoiningViewController.swift
@@ -62,9 +62,7 @@ class JoiningViewController: UIViewController, UITextFieldDelegate {
 
         let enableAudioRedundancy = audioRedundancySwitch.isOn
 
-        joinMeeting(audioVideoConfig: AudioVideoConfiguration(audioMode: audioMode, callKitEnabled: callKitOption != .disabled, enableAudioRedundancy: enableAudioRedundancy),
-                    callKitOption: callKitOption
-        )
+        joinMeeting(audioMode: audioMode, callKitOption: callKitOption, enableAudioRedundancy: enableAudioRedundancy)
     }
 
     @IBAction func debugSettingsButtonClicked (_: UIButton) {
@@ -104,7 +102,7 @@ class JoiningViewController: UIViewController, UITextFieldDelegate {
         }
     }
 
-    func joinMeeting(audioVideoConfig: AudioVideoConfiguration, callKitOption: CallKitOption) {
+    func joinMeeting(audioMode: AudioMode, callKitOption: CallKitOption, enableAudioRedundancy: Bool) {
         view.endEditing(true)
         let meetingId = meetingIdTextField.text ?? ""
         let name = nameTextField.text ?? ""
@@ -119,8 +117,9 @@ class JoiningViewController: UIViewController, UITextFieldDelegate {
 
         MeetingModule.shared().prepareMeeting(meetingId: meetingId,
                                               selfName: name,
-                                              audioVideoConfig: audioVideoConfig,
-                                              option: callKitOption,
+                                              audioMode: audioMode,
+                                              callKitOption: callKitOption,
+                                              enableAudioRedundancy: enableAudioRedundancy,
                                               overriddenEndpoint: debugSettingsModel.endpointUrl,
                                               primaryExternalMeetingId: debugSettingsModel.primaryExternalMeetingId) { success in
             DispatchQueue.main.async {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -142,12 +142,17 @@ class MeetingModel: NSObject {
         self.selfName = selfName
         self.callKitOption = callKitOption
         self.meetingSessionConfig = meetingSessionConfig
-        if (meetingSessionConfig.meetingFeatures.videoMaxResolution == VideoResolution.videoDisabled) {
-            self.audioVideoConfig = AudioVideoConfiguration(videoMaxResolution: VideoResolution.videoDisabled)
-        } else if (meetingSessionConfig.meetingFeatures.videoMaxResolution == VideoResolution.videoResolutionHD) {
-            self.audioVideoConfig = AudioVideoConfiguration(videoMaxResolution: VideoResolution.videoResolutionHD)
+        if (meetingSessionConfig.meetingFeatures.videoMaxResolution == VideoResolution.videoDisabled
+            || meetingSessionConfig.meetingFeatures.videoMaxResolution == VideoResolution.videoResolutionHD
+            || meetingSessionConfig.meetingFeatures.videoMaxResolution == VideoResolution.videoResolutionFHD
+        ) {
+            self.audioVideoConfig = AudioVideoConfiguration(
+                audioVideoConfig: audioVideoConfig,
+                videoMaxResolution: meetingSessionConfig.meetingFeatures.videoMaxResolution)
         } else {
-            self.audioVideoConfig = AudioVideoConfiguration(videoMaxResolution: VideoResolution.videoResolutionFHD)
+            self.audioVideoConfig = AudioVideoConfiguration(
+                audioVideoConfig: audioVideoConfig,
+                videoMaxResolution: VideoResolution.videoResolutionHD)
         }
 
         let url = AppConfiguration.url.hasSuffix("/") ? AppConfiguration.url : "\(AppConfiguration.url)/"

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -143,12 +143,6 @@ class MeetingModel: NSObject {
         self.callKitOption = callKitOption
         self.meetingSessionConfig = meetingSessionConfig
         self.audioVideoConfig = audioVideoConfig
-        if (meetingSessionConfig.meetingFeatures.videoMaxResolution == VideoResolution.videoDisabled
-            || meetingSessionConfig.meetingFeatures.videoMaxResolution == VideoResolution.videoResolutionHD
-            || meetingSessionConfig.meetingFeatures.videoMaxResolution == VideoResolution.videoResolutionFHD
-        ) {
-            self.audioVideoConfig.videoMaxResolution = meetingSessionConfig.meetingFeatures.videoMaxResolution
-        }
 
         let url = AppConfiguration.url.hasSuffix("/") ? AppConfiguration.url : "\(AppConfiguration.url)/"
         self.postLogger = PostLogger(name: "SDKEvents", configuration: meetingSessionConfig, url: "\(url)log_meeting_event")

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -142,17 +142,12 @@ class MeetingModel: NSObject {
         self.selfName = selfName
         self.callKitOption = callKitOption
         self.meetingSessionConfig = meetingSessionConfig
+        self.audioVideoConfig = audioVideoConfig
         if (meetingSessionConfig.meetingFeatures.videoMaxResolution == VideoResolution.videoDisabled
             || meetingSessionConfig.meetingFeatures.videoMaxResolution == VideoResolution.videoResolutionHD
             || meetingSessionConfig.meetingFeatures.videoMaxResolution == VideoResolution.videoResolutionFHD
         ) {
-            self.audioVideoConfig = AudioVideoConfiguration(
-                audioVideoConfig: audioVideoConfig,
-                videoMaxResolution: meetingSessionConfig.meetingFeatures.videoMaxResolution)
-        } else {
-            self.audioVideoConfig = AudioVideoConfiguration(
-                audioVideoConfig: audioVideoConfig,
-                videoMaxResolution: VideoResolution.videoResolutionHD)
+            self.audioVideoConfig.videoMaxResolution = meetingSessionConfig.meetingFeatures.videoMaxResolution
         }
 
         let url = AppConfiguration.url.hasSuffix("/") ? AppConfiguration.url : "\(AppConfiguration.url)/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 * Fixed content share doesn't resume correctly after auto reconnection
-* Fix audio video config propagation
+* [Demo] Fix audio video config propagation
 
 ## [0.24.0] - 2023-12-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 * Fixed content share doesn't resume correctly after auto reconnection
+* Fix audio video config propagation
 
 ## [0.24.0] - 2023-12-20
 


### PR DESCRIPTION
## ℹ️ Description
Current demo app logic calls `AudioVideoConfiguration(videoMaxResolution)` when setting meeting max resolution and this function will override other config selected with default value (i.e., `audioMode: stereo48K, callKitEnabled: false, enableAudioRedundancy: true`). This change fixes this config propagation issue.

### Issue #, if available

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*
Smoke tested to verify config is properly propagated.

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
