### PR TITLE
Fix crash

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/DefaultContentShareVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/DefaultContentShareVideoClientController.swift
@@ -100,6 +100,7 @@ import Foundation
 
     private func stopVideoClient() {
         videoClient.stop()
+        isSharing = false
         videoClient.delegate = nil
     }
 


### PR DESCRIPTION
## ℹ️ Description
Fix crash due to https://github.com/aws/amazon-chime-sdk-ios/pull/635 - since we move the logic of cleaning up from callback to stop API, we will need to update the status of sharing as well, not updating it would mess up the next time sharing and cause crash.

### Issue #, if available

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
QA tested

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
