### PR TITLE
Revert "Fix content share resume after reconnection (#635)"

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/DefaultContentShareVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/DefaultContentShareVideoClientController.swift
@@ -100,7 +100,6 @@ import Foundation
 
     private func stopVideoClient() {
         videoClient.stop()
-        videoClient.delegate = nil
     }
 
     public func subscribeToVideoClientStateChange(observer: ContentShareObserver) {
@@ -151,6 +150,7 @@ extension DefaultContentShareVideoClientController: VideoClientDelegate {
             observer.contentShareDidStop(status: ContentShareStatus(statusCode: .videoServiceFailed))
         }
         isSharing = false
+        cleanUp()
     }
 
     public func videoClientDidStop(_ client: VideoClient?) {
@@ -160,6 +160,7 @@ extension DefaultContentShareVideoClientController: VideoClientDelegate {
             observer.contentShareDidStop(status: ContentShareStatus(statusCode: .ok))
         }
         isSharing = false
+        cleanUp()
     }
 
     public func videoClientMetricsReceived(_ metrics: [AnyHashable: Any]?) {
@@ -169,5 +170,9 @@ extension DefaultContentShareVideoClientController: VideoClientDelegate {
 
     private func resetContentShareVideoClientMetrics() {
         clientMetricsCollector.processContentShareVideoClientMetrics(metrics: [:])
+    }
+    
+    private func cleanUp() {
+        videoClient.delegate = nil
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientProtocol.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientProtocol.swift
@@ -11,7 +11,6 @@ import AmazonChimeSDKMedia
 import Foundation
 
 @objc public protocol VideoClientProtocol {
-    // TODO: look into make delegate weak preference
     var delegate: VideoClientDelegate! { get set }
 
     static func globalInitialize()

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/InAppScreenCaptureModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/InAppScreenCaptureModel.swift
@@ -66,13 +66,11 @@ extension InAppScreenCaptureModel: CaptureSourceObserver {
 }
 
 extension InAppScreenCaptureModel: ContentShareObserver {
-    func contentShareDidStart() {
-        logger.info(msg: "InAppScreenCaptureSource: contentShareDidStart")
-        isSharing = true
-    }
+    func contentShareDidStart() {}
 
     func contentShareDidStop(status: ContentShareStatus) {
-        logger.info(msg: "InAppScreenCaptureSource: contentShareDidStop")
-        isSharing = false
+        if isSharing {
+            isSharing = false
+        }
     }
 }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -600,7 +600,7 @@ extension MeetingModel: MetricsObserver {
             return
         }
         metricsModel.updateAppMetrics(metrics: metrics)
-        logger.debug(debugFunction: { return "Media metrics have been received: \(observableMetrics)"})
+        logger.info(msg: "Media metrics have been received: \(observableMetrics)")
         if activeMode == .metrics {
             metricsModel.metricsUpdatedHandler?()
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-## Unreleased
-
-### Fixed
-* Fixed content share doesn't resume correctly after auto reconnection
-* [Demo] Fix audio video config propagation
-
 ## [0.24.0] - 2023-12-20
 
 ### Added


### PR DESCRIPTION
## ℹ️ Description
Revert https://github.com/aws/amazon-chime-sdk-ios/pull/635 because of it's side affect - not able to receive didStop callback after calling stopContentShare.

### Issue #, if available

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
