### PR TITLE
Enable a capture session’s isMultitaskingCameraAccessEnabled property

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/capture/DefaultCameraCaptureSource.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/capture/DefaultCameraCaptureSource.swift
@@ -124,8 +124,9 @@ import UIKit
             return
         }
         session.beginConfiguration()
-
-        session.isMultitaskingCameraAccessEnabled = session.isMultitaskingCameraAccessSupported
+        if #available(iOS 16.0, *) {
+            session.isMultitaskingCameraAccessEnabled = session.isMultitaskingCameraAccessSupported
+        }
         
         guard let deviceInput = try? AVCaptureDeviceInput(device: captureDevice),
             session.canAddInput(deviceInput) else {

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/capture/DefaultCameraCaptureSource.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/capture/DefaultCameraCaptureSource.swift
@@ -125,6 +125,8 @@ import UIKit
         }
         session.beginConfiguration()
 
+        session.isMultitaskingCameraAccessEnabled = session.isMultitaskingCameraAccessSupported
+        
         guard let deviceInput = try? AVCaptureDeviceInput(device: captureDevice),
             session.canAddInput(deviceInput) else {
             session.commitConfiguration()


### PR DESCRIPTION
In iOS 16 and later, you can use the camera in Picture in Picture mode by enabling a capture session’s isMultitaskingCameraAccessEnabled property. 