### PR TITLE
Disambiguate DefaultVideoClientController logs for uninitialized videoClient

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
@@ -405,7 +405,7 @@ extension DefaultVideoClientController: VideoClientController {
 
     private func setVideoSource(source: VideoSource, config: LocalVideoConfiguration) {
         guard videoClientState != .uninitialized else {
-            logger.fault(msg: "VideoClient is not initialized so returning without doing anything")
+            logger.fault(msg: "VideoClient is not initialized so returning without doing anything in setVideoSource")
             return
         }
 
@@ -430,7 +430,7 @@ extension DefaultVideoClientController: VideoClientController {
 
     public func stopLocalVideo() {
         guard videoClientState != .uninitialized else {
-            logger.fault(msg: "VideoClient is not initialized so returning without doing anything")
+            logger.fault(msg: "VideoClient is not initialized so returning without doing anything in stopLocalVideo")
             return
         }
         logger.info(msg: "Stopping local video")
@@ -440,7 +440,7 @@ extension DefaultVideoClientController: VideoClientController {
 
     public func startRemoteVideo() {
         guard videoClientState != .uninitialized else {
-            logger.fault(msg: "VideoClient is not initialized so returning without doing anything")
+            logger.fault(msg: "VideoClient is not initialized so returning without doing anything in startRemoteVideo")
             return
         }
         logger.info(msg: "Starting remote video")
@@ -449,7 +449,7 @@ extension DefaultVideoClientController: VideoClientController {
 
     public func stopRemoteVideo() {
         guard videoClientState != .uninitialized else {
-            logger.fault(msg: "VideoClient is not initialized so returning without doing anything")
+            logger.fault(msg: "VideoClient is not initialized so returning without doing anything in stopRemoteVideo")
             return
         }
         logger.info(msg: "Stopping remote video")
@@ -497,7 +497,7 @@ extension DefaultVideoClientController: VideoClientController {
 
     public func updateVideoSourceSubscriptions(addedOrUpdated: Dictionary<RemoteVideoSource, VideoSubscriptionConfiguration>, removed: Array<RemoteVideoSource>) {
         guard videoClientState != .uninitialized else {
-            logger.fault(msg: "VideoClient is not initialized so returning without doing anything")
+            logger.fault(msg: "VideoClient is not initialized so returning without doing anything in updateVideoSourceSubscriptions")
             return
         }
         logger.info(msg: "Updating video subscriptions")


### PR DESCRIPTION
…oClient

## ℹ️ Description
Disambiguate DefaultVideoClientController logs for uninitialized videoClient

### Issue #, if available
NA

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
Haven't tested yet due to some unrelated build issues but low risk and log line update

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
