### PR TITLE
Enable Bluetooth A2DP in demo app to allow Bluetooth speakers to be used as audio outputs

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModule.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModule.swift
@@ -250,7 +250,10 @@ class MeetingModule {
         do {
             if audioSession.category != .playAndRecord {
                 try audioSession.setCategory(AVAudioSession.Category.playAndRecord,
-                                             options: AVAudioSession.CategoryOptions.allowBluetooth)
+                                             options: [
+                                                AVAudioSession.CategoryOptions.allowBluetooth,
+                                                AVAudioSession.CategoryOptions.allowBluetoothA2DP
+                                             ])
                 try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
             }
             if audioSession.mode != .voiceChat {


### PR DESCRIPTION
## ℹ️ Description
Enable Bluetooth A2DP in demo app to allow Bluetooth speakers to be used as audio outputs

### Issue #, if available
n/a

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
Connected a Bluetooth speaker to my iPhone and tested out the demo app. I verified that I could use the Bluetooth speaker as an audio output in both `Input And Output` and `Output Only` mode.

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
