### PR TITLE
Send meetingStatus to ingestion service

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
@@ -141,7 +141,7 @@ extension DefaultAudioClientController: AudioClientController {
             Self.state = .started
         } else {
             logger.error(msg: "Cannot start audio client with status = \(status.rawValue)")
-            eventAnalyticsController.publishEvent(name: .meetingStartFailed)
+            eventAnalyticsController.publishEvent(name: .meetingStartFailed, attributes: [EventAttributeName.meetingStatus: audioClientObserver.audioStatus])
             cleanup()
             throw MediaError.audioFailedToStart
         }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientObserver.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientObserver.swift
@@ -462,5 +462,7 @@ extension DefaultAudioClientObserver: AudioClientObserver {
     func setPrimaryMeetingPromotionObserver(observer: PrimaryMeetingPromotionObserver) {
         primaryMeetingPromotionObserver = observer
     }
+    
+    var audioStatus: MeetingSessionStatusCode  { return self.currentAudioStatus }
 }
 // swiftlint:enable type_body_length

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientObserver.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientObserver.swift
@@ -17,4 +17,5 @@ import Foundation
     func subscribeToTranscriptEvent(observer: TranscriptEventObserver)
     func unsubscribeFromTranscriptEvent(observer: TranscriptEventObserver)
     func setPrimaryMeetingPromotionObserver(observer: PrimaryMeetingPromotionObserver)
+    var audioStatus: MeetingSessionStatusCode { get }
 }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientControllerTests.swift
@@ -53,6 +53,8 @@ class DefaultAudioClientControllerTests: CommonTestCase {
                                            audioMode: any(),
                                            audioDeviceCapabilities: any(),
                                            enableAudioRedundancy: any())).willReturn(AUDIO_CLIENT_OK)
+        
+        given(audioClientObserverMock.audioStatus).willReturn(MeetingSessionStatusCode.ok)
 
         defaultAudioClientController = DefaultAudioClientController(audioClient: audioClientMock,
                                                                     audioClientObserver: audioClientObserverMock,
@@ -348,6 +350,7 @@ class DefaultAudioClientControllerTests: CommonTestCase {
                                             enableAudioRedundancy: true)).wasCalled()
         XCTAssertEqual(.initialized, DefaultAudioClientController.state)
         verify(audioLockMock.unlock()).wasCalled()
+        verify(eventAnalyticsControllerMock.publishEvent(name: .meetingStartFailed, attributes: [EventAttributeName.meetingStatus: any()])).wasCalled()
     }
 
     func testSetVoiceFocusEnabled_success() {


### PR DESCRIPTION
## ℹ️ Description
Route meetingStatus to ingestion service for meeting start and failed events.

### Issue #, if available

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
Tested the demo and checked ingestion logs

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
