### PR TITLE
Add Obj-C support for BackgroundReplacement

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/backgroundfilter/backgroundreplacement/BackgroundReplacementConfiguration.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/backgroundfilter/backgroundreplacement/BackgroundReplacementConfiguration.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-@objcMembers public class BackgroundReplacementConfiguration {
+@objcMembers public class BackgroundReplacementConfiguration: NSObject {
     let backgroundReplacementImage: UIImage
     let logger: Logger
     let backgroundFilterProcessor: BackgroundFilterProcessor

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/backgroundfilter/backgroundreplacement/BackgroundReplacementVideoFrameProcessor.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/backgroundfilter/backgroundreplacement/BackgroundReplacementVideoFrameProcessor.swift
@@ -12,7 +12,7 @@ import UIKit
 
 /// `BackgroundReplacementVideoFrameProcessor` is a processor which receives video frames via `VideoSource`
 ///  and then creates the foreground image which is rendered on top of a background image.
-@objcMembers public class BackgroundReplacementVideoFrameProcessor: VideoSource, VideoSink {
+@objcMembers public class BackgroundReplacementVideoFrameProcessor: NSObject, VideoSource, VideoSink {
     public var videoContentHint = VideoContentHint.motion
 
     /// Context used for processing and rendering the final output image.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Fixed
+* Add Obj-C support for BackgroundReplacementConfiguration and BackgroundReplacementVideoFrameProcessor
+
 ## [0.26.0] - 2024-07-18
 
 ### Added


### PR DESCRIPTION
## ℹ️ Description
Add Obj-C support for BackgroundReplacementConfiguration and BackgroundReplacementVideoFrameProcessor

### Issue #, if available

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
    - [ ] README update
    - [x] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
Verified locally that BackgroundReplacementConfiguration and BackgroundReplacementVideoFrameProcessor are available to Obc-C now.

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
