### PR TITLE
Fixed a crash caused by AVCaptureSession in DefaultCameraCaptureSource when repeatedly toggling camera on/off.

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/capture/DefaultCameraCaptureSource.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/capture/DefaultCameraCaptureSource.swift
@@ -146,6 +146,13 @@ import UIKit
         }
         session.commitConfiguration()
         updateOrientation()
+        // `session.startRunning()` should be called after `session.commitConfiguration()` is complete.
+        // However, occacsionally `commitConfiguration()` runs asynchronously, so when `startRunning()`
+        // is called, `commitConfiguration()` is still in progress and the state is still `uncommited`.
+        // This can be reproduced by repeatedly switching or toggling the camera using the RN demo.
+        // Adding a 100ms delay ensures that `session.commitConfiguration()` is complete before calling
+        // `session.startRunning()`.
+        Thread.sleep(forTimeInterval: 0.1)
         session.startRunning()
 
         // If the torch was currently on, starting the sessions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Fixed
+* Fixed a crash caused by AVCaptureSession in DefaultCameraCaptureSource when repeatedly toggling camera on/off.
+
 ## [0.26.1] - 2024-08-15
 
 ### Fixed


### PR DESCRIPTION
## ℹ️ Description
 - When repeatedly toggling camera on/off using RN demo, the SDK will crash caused by AVCaptureSession in DefaultCameraCaptureSource. Adding a 100ms delay ensures that `session.commitConfiguration()` is complete before calling `session.startRunning()`.

### Issue #, if available

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
