### PR TITLE
Revert "End demo meeting faster when video service unavailable (#693)"

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -402,9 +402,6 @@ extension MeetingModel: AudioVideoObserver {
 
     func videoSessionDidStopWithStatus(sessionStatus: MeetingSessionStatus) {
         logWithFunctionName(message: "\(sessionStatus.statusCode)")
-        if sessionStatus.statusCode == .videoServiceUnavailable {
-            audioSessionDidStopWithStatus(sessionStatus: sessionStatus)
-        }
     }
 
     func audioSessionDidStartConnecting(reconnecting: Bool) {


### PR DESCRIPTION
## ℹ️ Description
revert the change because the workaround is not needed and a fix has been completed on media backend.

### Issue #, if available

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
