### PR TITLE
Fixes incorrect event being published when the meeting is ended normally

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/internal/utils/Converters.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/utils/Converters.swift
@@ -55,10 +55,10 @@ import Foundation
                 return .reconnecting
             case AUDIO_CLIENT_STATE_DISCONNECTING:
                 return .disconnecting
-            case AUDIO_CLIENT_STATE_DISCONNECTED_NORMAL:
+            case AUDIO_CLIENT_STATE_DISCONNECTED_NORMAL,
+                 AUDIO_CLIENT_STATE_SERVER_HUNGUP:
                 return .finishDisconnecting
             case AUDIO_CLIENT_STATE_DISCONNECTED_ABNORMAL,
-                 AUDIO_CLIENT_STATE_SERVER_HUNGUP,
                  AUDIO_CLIENT_STATE_FAILED_TO_CONNECT:
                 return .fail
             default:

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/utils/ConvertersTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/utils/ConvertersTests.swift
@@ -150,7 +150,7 @@ class ConvertersTests: XCTestCase {
         )
         XCTAssertEqual(
             Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_SERVER_HUNGUP),
-            SessionStateControllerAction.fail
+            SessionStateControllerAction.finishDisconnecting
         )
         XCTAssertEqual(
             Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_FAILED_TO_CONNECT),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Fixed
+* When meeting has ended normally, but not initiated by the client, send a meetingEnded event rather than a meetingFailed event.
+
 ## [0.26.2] - 2024-10-16
 
 ### Fixed


### PR DESCRIPTION
## ℹ️ Description
Fixes incorrect event being published when the meeting is ended normally.

### Issue #, if available

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
