### PR TITLE
Fix bug when joining from another device

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/ingestion/IngestionConfigurationBuilder.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/ingestion/IngestionConfigurationBuilder.swift
@@ -32,7 +32,7 @@ import Foundation
         return self
     }
 
-    public func build(disabled: Bool = true,
+    public func build(disabled: Bool = false,
                       ingestionUrl: String,
                       clientConiguration: EventClientConfiguration) -> IngestionConfiguration {
         return IngestionConfiguration(clientConfiguration: clientConiguration,

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/utils/Converters.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/utils/Converters.swift
@@ -41,7 +41,10 @@ import Foundation
     }
 
     enum AudioClientState {
-        static func toSessionStateControllerAction(state: audio_client_state_t) -> SessionStateControllerAction {
+        static func toSessionStateControllerAction(state: audio_client_state_t, status: MeetingSessionStatusCode) -> SessionStateControllerAction {
+            if (shouldCloseAndNotifyEndMeeting(status: status)) {
+                return .finishDisconnecting
+            }
             switch state {
             case AUDIO_CLIENT_STATE_UNKNOWN:
                 return .unknown
@@ -55,15 +58,19 @@ import Foundation
                 return .reconnecting
             case AUDIO_CLIENT_STATE_DISCONNECTING:
                 return .disconnecting
-            case AUDIO_CLIENT_STATE_DISCONNECTED_NORMAL,
-                 AUDIO_CLIENT_STATE_SERVER_HUNGUP:
+            case AUDIO_CLIENT_STATE_DISCONNECTED_NORMAL:
                 return .finishDisconnecting
             case AUDIO_CLIENT_STATE_DISCONNECTED_ABNORMAL,
+                 AUDIO_CLIENT_STATE_SERVER_HUNGUP,
                  AUDIO_CLIENT_STATE_FAILED_TO_CONNECT:
                 return .fail
             default:
                 return .unknown
             }
+        }
+        
+        static func shouldCloseAndNotifyEndMeeting(status: MeetingSessionStatusCode) -> Bool {
+            return status == MeetingSessionStatusCode.audioServerHungup || status == MeetingSessionStatusCode.audioJoinedFromAnotherDevice
         }
     }
 

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/utils/ConvertersTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/utils/ConvertersTests.swift
@@ -117,44 +117,126 @@ class ConvertersTests: XCTestCase {
 
     func testAudioClientStateToSessionStateControllerAction() {
         XCTAssertEqual(
-            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_UNKNOWN),
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_UNKNOWN, status: MeetingSessionStatusCode.ok),
             SessionStateControllerAction.unknown
         )
         XCTAssertEqual(
-            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_INIT),
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_INIT, status: MeetingSessionStatusCode.ok),
             SessionStateControllerAction.initialize
         )
         XCTAssertEqual(
-            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_CONNECTING),
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_CONNECTING, status: MeetingSessionStatusCode.ok),
             SessionStateControllerAction.connecting
         )
         XCTAssertEqual(
-            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_CONNECTED),
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_CONNECTED, status: MeetingSessionStatusCode.ok),
             SessionStateControllerAction.finishConnecting
         )
         XCTAssertEqual(
-            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_RECONNECTING),
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_RECONNECTING, status: MeetingSessionStatusCode.ok),
             SessionStateControllerAction.reconnecting
         )
         XCTAssertEqual(
-            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_DISCONNECTING),
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_DISCONNECTING, status: MeetingSessionStatusCode.ok),
             SessionStateControllerAction.disconnecting
         )
         XCTAssertEqual(
-            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_DISCONNECTED_NORMAL),
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_DISCONNECTED_NORMAL, status: MeetingSessionStatusCode.ok),
             SessionStateControllerAction.finishDisconnecting
         )
         XCTAssertEqual(
-            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_DISCONNECTED_ABNORMAL),
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_DISCONNECTED_ABNORMAL, status: MeetingSessionStatusCode.ok),
             SessionStateControllerAction.fail
         )
         XCTAssertEqual(
-            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_SERVER_HUNGUP),
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_SERVER_HUNGUP, status: MeetingSessionStatusCode.ok),
+            SessionStateControllerAction.fail
+        )
+        XCTAssertEqual(
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_FAILED_TO_CONNECT, status: MeetingSessionStatusCode.ok),
+            SessionStateControllerAction.fail
+        )
+
+        XCTAssertEqual(
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_UNKNOWN, status: MeetingSessionStatusCode.audioServerHungup),
             SessionStateControllerAction.finishDisconnecting
         )
         XCTAssertEqual(
-            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_FAILED_TO_CONNECT),
-            SessionStateControllerAction.fail
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_INIT, status: MeetingSessionStatusCode.audioServerHungup),
+            SessionStateControllerAction.finishDisconnecting
+        )
+        XCTAssertEqual(
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_CONNECTING, status: MeetingSessionStatusCode.audioServerHungup),
+            SessionStateControllerAction.finishDisconnecting
+        )
+        XCTAssertEqual(
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_CONNECTED, status: MeetingSessionStatusCode.audioServerHungup),
+            SessionStateControllerAction.finishDisconnecting
+        )
+        XCTAssertEqual(
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_RECONNECTING, status: MeetingSessionStatusCode.audioServerHungup),
+            SessionStateControllerAction.finishDisconnecting
+        )
+        XCTAssertEqual(
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_DISCONNECTING, status: MeetingSessionStatusCode.audioServerHungup),
+            SessionStateControllerAction.finishDisconnecting
+        )
+        XCTAssertEqual(
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_DISCONNECTED_NORMAL, status: MeetingSessionStatusCode.audioServerHungup),
+            SessionStateControllerAction.finishDisconnecting
+        )
+        XCTAssertEqual(
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_DISCONNECTED_ABNORMAL, status: MeetingSessionStatusCode.audioServerHungup),
+            SessionStateControllerAction.finishDisconnecting
+        )
+        XCTAssertEqual(
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_SERVER_HUNGUP, status: MeetingSessionStatusCode.audioServerHungup),
+            SessionStateControllerAction.finishDisconnecting
+        )
+        XCTAssertEqual(
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_FAILED_TO_CONNECT, status: MeetingSessionStatusCode.audioServerHungup),
+            SessionStateControllerAction.finishDisconnecting
+        )
+
+        XCTAssertEqual(
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_UNKNOWN, status: MeetingSessionStatusCode.audioJoinedFromAnotherDevice),
+            SessionStateControllerAction.finishDisconnecting
+        )
+        XCTAssertEqual(
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_INIT, status: MeetingSessionStatusCode.audioJoinedFromAnotherDevice),
+            SessionStateControllerAction.finishDisconnecting
+        )
+        XCTAssertEqual(
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_CONNECTING, status: MeetingSessionStatusCode.audioJoinedFromAnotherDevice),
+            SessionStateControllerAction.finishDisconnecting
+        )
+        XCTAssertEqual(
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_CONNECTED, status: MeetingSessionStatusCode.audioJoinedFromAnotherDevice),
+            SessionStateControllerAction.finishDisconnecting
+        )
+        XCTAssertEqual(
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_RECONNECTING, status: MeetingSessionStatusCode.audioJoinedFromAnotherDevice),
+            SessionStateControllerAction.finishDisconnecting
+        )
+        XCTAssertEqual(
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_DISCONNECTING, status: MeetingSessionStatusCode.audioJoinedFromAnotherDevice),
+            SessionStateControllerAction.finishDisconnecting
+        )
+        XCTAssertEqual(
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_DISCONNECTED_NORMAL, status: MeetingSessionStatusCode.audioJoinedFromAnotherDevice),
+            SessionStateControllerAction.finishDisconnecting
+        )
+        XCTAssertEqual(
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_DISCONNECTED_ABNORMAL, status: MeetingSessionStatusCode.audioJoinedFromAnotherDevice),
+            SessionStateControllerAction.finishDisconnecting
+        )
+        XCTAssertEqual(
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_SERVER_HUNGUP, status: MeetingSessionStatusCode.audioJoinedFromAnotherDevice),
+            SessionStateControllerAction.finishDisconnecting
+        )
+        XCTAssertEqual(
+            Converters.AudioClientState.toSessionStateControllerAction(state: AUDIO_CLIENT_STATE_FAILED_TO_CONNECT, status: MeetingSessionStatusCode.audioJoinedFromAnotherDevice),
+            SessionStateControllerAction.finishDisconnecting
         )
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Fixed
+* Fixed a bug preventing cleanup after joining from another device and added unit tests.
+
 ## [0.27.0] - 2025-02-20
 
 ### Fixed


### PR DESCRIPTION
## ℹ️ Description
This fixes a bug when joining from another device, the previous device remains connected. This also enables ingestion metric reporting by default.

### Issue #, if available

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
Unit tests. Smoke tested joining from another device and deleting meeting and checking ingestion metrics to ensure the proper events are being emitted and seeing the client closes properly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
