### PR TITLE
Add battery level and state to meeting event attributes

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
+++ b/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
@@ -282,6 +282,7 @@
 		CFF1553C2819C123009E257B /* background-ml-test-image.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = CFF1553B2819C123009E257B /* background-ml-test-image.jpeg */; };
 		D81D7BB72E45237800932348 /* PermissionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81D7BB62E45237600932348 /* PermissionError.swift */; };
 		D82D32B32E71E89E009190ED /* BatteryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82D32B22E71E89A009190ED /* BatteryState.swift */; };
+		D846E9AB2E7248E4008086F3 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = D846E9AA2E7248E4008086F3 /* PrivacyInfo.xcprivacy */; };
 		D863BE3329BAD65500D9DE9E /* MeetingEventClientConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D863BE3229BAD65500D9DE9E /* MeetingEventClientConfigurationTests.swift */; };
 		D863BE3529BAD8DA00D9DE9E /* AnyCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D863BE3429BAD8DA00D9DE9E /* AnyCodableTests.swift */; };
 		D863BE3729BAF68B00D9DE9E /* EventAttributeUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D863BE3629BAF68B00D9DE9E /* EventAttributeUtilsTests.swift */; };
@@ -602,6 +603,7 @@
 		CFF1553B2819C123009E257B /* background-ml-test-image.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "background-ml-test-image.jpeg"; sourceTree = "<group>"; };
 		D81D7BB62E45237600932348 /* PermissionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionError.swift; sourceTree = "<group>"; };
 		D82D32B22E71E89A009190ED /* BatteryState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryState.swift; sourceTree = "<group>"; };
+		D846E9AA2E7248E4008086F3 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D863BE3229BAD65500D9DE9E /* MeetingEventClientConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingEventClientConfigurationTests.swift; sourceTree = "<group>"; };
 		D863BE3429BAD8DA00D9DE9E /* AnyCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodableTests.swift; sourceTree = "<group>"; };
 		D863BE3629BAF68B00D9DE9E /* EventAttributeUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventAttributeUtilsTests.swift; sourceTree = "<group>"; };
@@ -885,6 +887,7 @@
 				F86CB7402411B9A6004FD82F /* exported_symbols */,
 				5A15822123C4020D0099F8FA /* Info.plist */,
 				C531A5C5281D37AE00086E73 /* AmazonChimeSDK.h */,
+				D846E9AA2E7248E4008086F3 /* PrivacyInfo.xcprivacy */,
 			);
 			path = AmazonChimeSDK;
 			sourceTree = "<group>";
@@ -1596,6 +1599,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D846E9AB2E7248E4008086F3 /* PrivacyInfo.xcprivacy in Resources */,
 				F86CB7412411B9A6004FD82F /* exported_symbols in Resources */,
 				CFD14AAC281B4A8300C8D8CA /* selfie_segmentation_landscape.tflite in Resources */,
 			);

--- a/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
+++ b/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
@@ -281,6 +281,7 @@
 		CFD14AAD281B4A8300C8D8CA /* selfie_segmentation_landscape.tflite in Resources */ = {isa = PBXBuildFile; fileRef = CFD14AAB281B4A8300C8D8CA /* selfie_segmentation_landscape.tflite */; };
 		CFF1553C2819C123009E257B /* background-ml-test-image.jpeg in Resources */ = {isa = PBXBuildFile; fileRef = CFF1553B2819C123009E257B /* background-ml-test-image.jpeg */; };
 		D81D7BB72E45237800932348 /* PermissionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81D7BB62E45237600932348 /* PermissionError.swift */; };
+		D82D32B32E71E89E009190ED /* BatteryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82D32B22E71E89A009190ED /* BatteryState.swift */; };
 		D863BE3329BAD65500D9DE9E /* MeetingEventClientConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D863BE3229BAD65500D9DE9E /* MeetingEventClientConfigurationTests.swift */; };
 		D863BE3529BAD8DA00D9DE9E /* AnyCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D863BE3429BAD8DA00D9DE9E /* AnyCodableTests.swift */; };
 		D863BE3729BAF68B00D9DE9E /* EventAttributeUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D863BE3629BAF68B00D9DE9E /* EventAttributeUtilsTests.swift */; };
@@ -600,6 +601,7 @@
 		CFD14AAB281B4A8300C8D8CA /* selfie_segmentation_landscape.tflite */ = {isa = PBXFileReference; lastKnownFileType = file; path = selfie_segmentation_landscape.tflite; sourceTree = "<group>"; };
 		CFF1553B2819C123009E257B /* background-ml-test-image.jpeg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "background-ml-test-image.jpeg"; sourceTree = "<group>"; };
 		D81D7BB62E45237600932348 /* PermissionError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionError.swift; sourceTree = "<group>"; };
+		D82D32B22E71E89A009190ED /* BatteryState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatteryState.swift; sourceTree = "<group>"; };
 		D863BE3229BAD65500D9DE9E /* MeetingEventClientConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingEventClientConfigurationTests.swift; sourceTree = "<group>"; };
 		D863BE3429BAD8DA00D9DE9E /* AnyCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodableTests.swift; sourceTree = "<group>"; };
 		D863BE3629BAF68B00D9DE9E /* EventAttributeUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventAttributeUtilsTests.swift; sourceTree = "<group>"; };
@@ -659,6 +661,7 @@
 		0007BD8F2632402A00A15BB6 /* ingestion */ = {
 			isa = PBXGroup;
 			children = (
+				D82D32B22E71E89A009190ED /* BatteryState.swift */,
 				D8D3F8D42E611669003D2EF4 /* AppStateMonitorDelegate.swift */,
 				D8D3F8D22E610E6A003D2EF4 /* AppState.swift */,
 				D8F829912E569E6A009E9186 /* DefaultAppStateMonitor.swift */,
@@ -1655,6 +1658,7 @@
 				D8F8298A2E564766009E9186 /* AppStateMonitor.swift in Sources */,
 				5403538A27D0C9F9007BABD7 /* TranscriptLanguageWithScore.swift in Sources */,
 				5403538827D0C9E9007BABD7 /* TranscriptEntity.swift in Sources */,
+				D82D32B32E71E89E009190ED /* BatteryState.swift in Sources */,
 				002C1FEA2649D5CD00C9B919 /* EventSender.swift in Sources */,
 				7C0D1BEF241ACC7B00280031 /* ActiveSpeakerDetectorFacade.swift in Sources */,
 				CFA2A15028074FE7008FDFF5 /* ResourceError.swift in Sources */,

--- a/AmazonChimeSDK/AmazonChimeSDK/PrivacyInfo.xcprivacy
+++ b/AmazonChimeSDK/AmazonChimeSDK/PrivacyInfo.xcprivacy
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePerformanceData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>Collects battery level, charging state, and low memory warnings to monitor device health during Amazon Chime SDK meeting sessions. This helps diagnose session quality issues and improve overall performance and reliability.</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/AmazonChimeSDK/AmazonChimeSDK/analytics/DefaultEventAnalyticsController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/analytics/DefaultEventAnalyticsController.swift
@@ -127,7 +127,7 @@ import Foundation
         ]
         
         if let batteryLevel = self.appStateMonitor.getBatteryLevel() {
-            attributes[EventAttributeName.batteryLevel] = batteryLevel.floatValue
+            attributes[EventAttributeName.batteryLevel] = batteryLevel
         }
         
         return attributes

--- a/AmazonChimeSDK/AmazonChimeSDK/analytics/DefaultEventAnalyticsController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/analytics/DefaultEventAnalyticsController.swift
@@ -76,7 +76,7 @@ import Foundation
             break
         }
         
-        mutatedAttributes[EventAttributeName.appState] = self.appStateMonitor.appState
+        mutatedAttributes.merge(getAppAttributes()) { (_, new) in new }
 
         eventReporter?.report(event: SDKEvent(eventName: name, eventAttributes: mutatedAttributes))
         
@@ -94,7 +94,11 @@ import Foundation
     // TODO: Remove this, use publishEvent() instead
     public func pushHistory(historyEventName: MeetingHistoryEventName) {
         let currentTimeMs = DateUtils.getCurrentTimeStampMs()
-        let attributes = [EventAttributeName.timestampMs: currentTimeMs]
+        var attributes: [AnyHashable: Any]  = [
+            EventAttributeName.timestampMs: currentTimeMs,
+        ]
+        attributes.merge(getAppAttributes()) { (_, new) in new }
+        
         eventReporter?.report(event: SDKEvent(meetingHistoryEventName: historyEventName,
                                               eventAttributes: attributes))
 
@@ -112,6 +116,21 @@ import Foundation
 
     public func getCommonEventAttributes() -> [AnyHashable: Any] {
         return EventAttributeUtils.getCommonAttributes(meetingSessionConfig: meetingSessionConfig)
+    }
+    
+    private func getAppAttributes() -> [AnyHashable: Any] {
+        let appState = self.appStateMonitor.appState
+        let batteryState = self.appStateMonitor.getBatteryState()
+        var attributes: [EventAttributeName : Any] = [
+            EventAttributeName.appState: appState,
+            EventAttributeName.batteryState: batteryState
+        ]
+        
+        if let batteryLevel = self.appStateMonitor.getBatteryLevel() {
+            attributes[EventAttributeName.batteryLevel] = batteryLevel.floatValue
+        }
+        
+        return attributes
     }
 }
 

--- a/AmazonChimeSDK/AmazonChimeSDK/analytics/EventAttributeName.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/analytics/EventAttributeName.swift
@@ -66,6 +66,10 @@ import Foundation
     case signalingDroppedError
     /// The current app state
     case appState
+    /// The current battery level
+    case batteryLevel
+    /// The current battery state
+    case batteryState
 
     public var description: String {
         switch self {
@@ -121,6 +125,10 @@ import Foundation
             return "signalingDroppedError"
         case .appState:
             return "appState"
+        case .batteryLevel:
+            return "batteryLevel"
+        case .batteryState:
+            return "batteryState"
         }
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/ingestion/AppStateMonitor.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/ingestion/AppStateMonitor.swift
@@ -15,4 +15,12 @@
     func start()
     
     func stop()
+    
+    /// Retrieves the current battery level as a percentage (0.0 to 1.0)
+    /// Returns nil if battery monitoring is not available or disabled
+    func getBatteryLevel() -> NSNumber?
+    
+    /// Retrieves the current battery state
+    /// Returns the UIDevice.BatteryState indicating charging status
+    func getBatteryState() -> BatteryState
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/ingestion/BatteryState.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/ingestion/BatteryState.swift
@@ -1,0 +1,48 @@
+//
+//  BatteryState.swift
+//  AmazonChimeSDK
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+import UIKit
+
+@objc public enum BatteryState: Int, CustomStringConvertible {
+    /// The device is plugged into power and the battery is charging
+    case charging
+    /// The device is unplugged and running on battery power
+    case discharging
+    /// The device is plugged into power and the battery is fully charged
+    case full
+    /// The battery state cannot be determined (battery monitoring may be disabled)
+    case unknown
+    
+    public init(from batteryState: UIDevice.BatteryState) {
+        switch batteryState {
+        case .charging:
+            self = .charging
+        case .unplugged:
+            self = .discharging
+        case .full:
+            self = .full
+        case .unknown:
+            self = .unknown
+        @unknown default:
+            self = .unknown
+        }
+    }
+    
+    public var description: String {
+        switch self {
+        case .charging:
+            return "Charging"
+        case .discharging:
+            return "Discharging"
+        case .full:
+            return "Full"
+        case .unknown:
+            return "Unknown"
+        }
+    }
+}

--- a/AmazonChimeSDK/AmazonChimeSDK/ingestion/DefaultAppStateMonitor.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/ingestion/DefaultAppStateMonitor.swift
@@ -115,6 +115,32 @@ import UIKit
         logger.info(msg: "Application received memory low warning.")
         self.delegate?.didReceiveMemoryWarning(monitor: self)
     }
+    
+    // MARK: - Battery Monitoring
+    
+    /// Retrieves the current battery level as a percentage (0.0 to 1.0)
+    /// Returns nil if battery monitoring is not available or disabled
+    public func getBatteryLevel() -> NSNumber? {
+        let device = UIDevice.current
+        
+        if !device.isBatteryMonitoringEnabled {
+            device.isBatteryMonitoringEnabled = true
+        }
+        
+        return device.batteryLevel < 0 ? nil : NSNumber.init(value: device.batteryLevel)
+    }
+    
+    /// Retrieves the current battery state
+    /// Returns the UIDevice.BatteryState indicating charging status
+    public func getBatteryState() -> BatteryState {
+        let device = UIDevice.current
+        
+        if !device.isBatteryMonitoringEnabled {
+            device.isBatteryMonitoringEnabled = true
+        }
+        
+        return BatteryState(from: device.batteryState)
+    }
 
     deinit {
         stop()

--- a/AmazonChimeSDK/AmazonChimeSDK/ingestion/IngestionEventConverter.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/ingestion/IngestionEventConverter.swift
@@ -185,7 +185,7 @@ private typealias EAName = EventAttributeName
                                 audioInputErrorMessage: meetingEvent.getAudioInputErrorMessage(),
                                 signalingDroppedErrorMessage: meetingEvent.getSignalingDroppedErrorMessage(),
                                 appState: meetingEvent.getAppState(),
-                                batteryLevel: meetingEvent.getBatteryLevel(),
+                                batteryLevel: meetingEvent.getBatteryLevel()?.floatValue,
                                 batteryState: meetingEvent.getBatteryState(),
                                 ttl: dirtyMeetingEventTtl)
     }

--- a/AmazonChimeSDK/AmazonChimeSDK/ingestion/IngestionEventConverter.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/ingestion/IngestionEventConverter.swift
@@ -65,6 +65,15 @@ private typealias EAName = EventAttributeName
         attributes[EAName.audioInputError.description] = AnyCodable(audioErrorStr)
         attributes[EAName.signalingDroppedError.description] = AnyCodable(signalingDroppedErrorStr)
         attributes[EAName.appState.description] = AnyCodable(appStateStr)
+        if let batteryLevel = eventAttributes[EventAttributeName.batteryLevel] as? NSNumber {
+            attributes[EAName.batteryLevel.description] = AnyCodable(batteryLevel.floatValue)
+        }
+        
+        if let batteryState = eventAttributes[EventAttributeName.batteryState] as? BatteryState {
+            let batteryStateStr = String(describing: batteryState)
+            attributes[EAName.batteryState.description] = AnyCodable(batteryStateStr)
+        }
+        
         
         clientConfig.metadataAttributes.forEach({ (key: String, value: Any) in
             attributes[key] = AnyCodable(value)
@@ -176,6 +185,8 @@ private typealias EAName = EventAttributeName
                                 audioInputErrorMessage: meetingEvent.getAudioInputErrorMessage(),
                                 signalingDroppedErrorMessage: meetingEvent.getSignalingDroppedErrorMessage(),
                                 appState: meetingEvent.getAppState(),
+                                batteryLevel: meetingEvent.getBatteryLevel(),
+                                batteryState: meetingEvent.getBatteryState(),
                                 ttl: dirtyMeetingEventTtl)
     }
 

--- a/AmazonChimeSDK/AmazonChimeSDK/ingestion/IngestionPayload.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/ingestion/IngestionPayload.swift
@@ -24,6 +24,8 @@ import Foundation
     public let audioInputErrorMessage: String?
     public let signalingDroppedErrorMessage: String?
     public let appState: String?
+    public let batteryLevel: Float?
+    public let batteryState: String?
     public let ttl: Int64?
 
     public init(name: String,
@@ -41,6 +43,8 @@ import Foundation
                 audioInputErrorMessage: String? = nil,
                 signalingDroppedErrorMessage: String? = nil,
                 appState: String? = nil,
+                batteryLevel: Float? = nil,
+                batteryState: String? = nil,
                 ttl: Int64? = nil) {
         self.name = name
         self.ts = ts
@@ -57,6 +61,8 @@ import Foundation
         self.audioInputErrorMessage = audioInputErrorMessage
         self.signalingDroppedErrorMessage = signalingDroppedErrorMessage
         self.appState = appState
+        self.batteryLevel = batteryLevel
+        self.batteryState = batteryState
         self.ttl = ttl
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/ingestion/database/IngestionMeetingEvent.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/ingestion/database/IngestionMeetingEvent.swift
@@ -89,9 +89,9 @@ extension IngestionMeetingEvent {
         return item??.value as? String
     }
     
-    func getBatteryLevel() -> Float? {
+    func getBatteryLevel() -> NSNumber? {
         let item = eventAttributes[EventAttributeName.batteryLevel.description]
-        return item??.value as? Float
+        return item??.value as? NSNumber
     }
     
     func getBatteryState() -> String? {

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/ingestion/database/IngestionMeetingEvent.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/ingestion/database/IngestionMeetingEvent.swift
@@ -88,4 +88,14 @@ extension IngestionMeetingEvent {
         let item = eventAttributes[EventAttributeName.appState.description]
         return item??.value as? String
     }
+    
+    func getBatteryLevel() -> Float? {
+        let item = eventAttributes[EventAttributeName.batteryLevel.description]
+        return item??.value as? Float
+    }
+    
+    func getBatteryState() -> String? {
+        let item = eventAttributes[EventAttributeName.batteryState.description]
+        return item??.value as? String
+    }
 }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/ingestion/IngestionEventConverterTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/ingestion/IngestionEventConverterTests.swift
@@ -25,7 +25,9 @@ class IngestionEventConverterTests: CommonTestCase {
             EventAttributeName.audioInputError: TestError.audioInputError,
             EventAttributeName.videoInputError: TestError.videoInputError,
             EventAttributeName.signalingDroppedError: TestError.signalingDroppedError,
-            EventAttributeName.appState: AppState.background
+            EventAttributeName.appState: AppState.background,
+            EventAttributeName.batteryLevel: 0.5,
+            EventAttributeName.batteryState: BatteryState.charging
         ])
         let result = converter.toIngestionMeetingEvent(event: event,
                                                        ingestionConfiguration: ingestionConfiguration)
@@ -34,6 +36,8 @@ class IngestionEventConverterTests: CommonTestCase {
         XCTAssertEqual(result.getVideoInputErrorMessage(), String(describing: TestError.videoInputError))
         XCTAssertEqual(result.getSignalingDroppedErrorMessage(), String(describing: TestError.signalingDroppedError))
         XCTAssertEqual(result.getAppState(), String(describing: AppState.background))
+        XCTAssertEqual(result.getBatteryLevel(), 0.5)
+        XCTAssertEqual(result.getBatteryState(), String(describing: BatteryState.charging))
     }
     
     func testToIngestionRecord_ShouldReturnAttributes_IfExists() {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 * Added meetingReconnected/audioInputFailed/signalingDropped/appStateChanged/appMemoryLow meeting event
-* Added meetingReconnectDurationMs/audioInputErrorMessage/signalingDroppedErrorMessage/appState meeting event attributes
+* Added meetingReconnectDurationMs/audioInputErrorMessage/signalingDroppedErrorMessage/appState/batteryLevel/batteryState to meeting event attributes
 
 ## [0.27.1] - 2025-03-28
 

--- a/guides/meeting_events.md
+++ b/guides/meeting_events.md
@@ -132,6 +132,8 @@ The following table describes attributes for a meeting.
 |`retryCount`|The number of connection retries performed during the meeting.<br><br>Unit: Count|`meetingStartSucceeded`, `meetingReconnected`, `meetingStartFailed`, `meetingEnded`, `meetingFailed`
 |`signalingDroppedErrorMessage`|The error message that explains why the signaling websocket connection dropped.|`videoClientSignalingDropped`, `contentShareSignalingDropped`
 |`appState`|The current app state when the event occurs.| All events
+|`batteryLevel`|The current battery level when the event occurs.| All events
+|`batteryState`|The current battery state when the event occurs.| All events
 
 
 ### Device attributes


### PR DESCRIPTION
## ℹ️ Description
 - Add battery level and state to meeting event attributes

### Issue #, if available

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
    - [ ] README update
    - [x] CHANGELOG update
    - [x] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Additional Manual Test
- [x] Pause and resume remote video
- [x] Switch local camera
- [x] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [x] Unit tests pass
- [x] Build SDK against simulator with release options
- [x] Build SDK against device with release options
- [x] Build SDK against simulator with debug options
- [x] Build SDK against device with debug options
- [x] Test Demo against simulator with SDK (debug build) in workspace
- [x] Test Demo against device with SDK (debug build) in workspace
- [x] Test DemoObjC against simulator with SDK (debug build) in workspace
- [x] Test DemoObjC against device with SDK (debug build) in workspace
- [x] Test Demo against simulator with SDK.framework (release build)
- [x] Test Demo against device with SDK.framework (release build)
- [x] Test DemoObjC against simulator with SDK.framework (release build)
- [x] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
