### PR TITLE
Add content share lifecycle Ingestion events

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
+++ b/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
@@ -286,6 +286,8 @@
 		D863BE3329BAD65500D9DE9E /* MeetingEventClientConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D863BE3229BAD65500D9DE9E /* MeetingEventClientConfigurationTests.swift */; };
 		D863BE3529BAD8DA00D9DE9E /* AnyCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D863BE3429BAD8DA00D9DE9E /* AnyCodableTests.swift */; };
 		D863BE3729BAF68B00D9DE9E /* EventAttributeUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D863BE3629BAF68B00D9DE9E /* EventAttributeUtilsTests.swift */; };
+		D8659BE22E78B013006C1C20 /* VideoClientFailedError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8659BE12E78B013006C1C20 /* VideoClientFailedError.swift */; };
+		D8659BE42E78BCDA006C1C20 /* VideoClientFailedErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8659BE32E78BCD5006C1C20 /* VideoClientFailedErrorTests.swift */; };
 		D8A1527E2D56CAFE002775BD /* VideoFrameResenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A1527D2D56CAF7002775BD /* VideoFrameResenderTests.swift */; };
 		D8A152832D56F8DF002775BD /* VideoFrameGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A152822D56F8DA002775BD /* VideoFrameGenerator.swift */; };
 		D8B836602E39A0CB00179ABF /* TestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B8365F2E39A0C900179ABF /* TestError.swift */; };
@@ -607,6 +609,8 @@
 		D863BE3229BAD65500D9DE9E /* MeetingEventClientConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingEventClientConfigurationTests.swift; sourceTree = "<group>"; };
 		D863BE3429BAD8DA00D9DE9E /* AnyCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCodableTests.swift; sourceTree = "<group>"; };
 		D863BE3629BAF68B00D9DE9E /* EventAttributeUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventAttributeUtilsTests.swift; sourceTree = "<group>"; };
+		D8659BE12E78B013006C1C20 /* VideoClientFailedError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoClientFailedError.swift; sourceTree = "<group>"; };
+		D8659BE32E78BCD5006C1C20 /* VideoClientFailedErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoClientFailedErrorTests.swift; sourceTree = "<group>"; };
 		D8A1527D2D56CAF7002775BD /* VideoFrameResenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoFrameResenderTests.swift; sourceTree = "<group>"; };
 		D8A152822D56F8DA002775BD /* VideoFrameGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoFrameGenerator.swift; sourceTree = "<group>"; };
 		D8B8365F2E39A0C900179ABF /* TestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestError.swift; sourceTree = "<group>"; };
@@ -798,6 +802,7 @@
 		00825F4923D90A2D00388D08 /* utils */ = {
 			isa = PBXGroup;
 			children = (
+				D8659BE12E78B013006C1C20 /* VideoClientFailedError.swift */,
 				D8F829832E552C6B009E9186 /* SignalingDroppedError.swift */,
 				D81D7BB62E45237600932348 /* PermissionError.swift */,
 				CFA2A14F28074FE7008FDFF5 /* ResourceError.swift */,
@@ -1264,6 +1269,7 @@
 		5AE132CB23EB47B100BF5997 /* utils */ = {
 			isa = PBXGroup;
 			children = (
+				D8659BE32E78BCD5006C1C20 /* VideoClientFailedErrorTests.swift */,
 				D8F829852E553EB3009E9186 /* SignalingDroppedErrorTests.swift */,
 				5AE1323023EA2FBC00BF5997 /* logger */,
 				5A6F8187246379D80031AE97 /* MediaErrorTests.swift */,
@@ -1853,6 +1859,7 @@
 				00C2A91723F76250008CD687 /* VideoTileState.swift in Sources */,
 				F81104AF276190AA003D17AD /* VideoSubscriptionConfiguration.swift in Sources */,
 				C61475DB26EFC18400CDEC09 /* TranscriptEvent.swift in Sources */,
+				D8659BE22E78B013006C1C20 /* VideoClientFailedError.swift in Sources */,
 				0007BDA126334BA800A15BB6 /* DefaultEventReporter.swift in Sources */,
 				F82D50D823FC752600D8F18C /* VolumeLevel.swift in Sources */,
 				0007BDBB26335E5D00A15BB6 /* IngestionEvent.swift in Sources */,
@@ -1880,6 +1887,7 @@
 				D8F829902E5693A4009E9186 /* DefaultAppStateMonitorTests.swift in Sources */,
 				00E198E1259BC0CF00AD4DAA /* EventNameTests.swift in Sources */,
 				00E198EF259BCA5A00AD4DAA /* EventAttributeNameTests.swift in Sources */,
+				D8659BE42E78BCDA006C1C20 /* VideoClientFailedErrorTests.swift in Sources */,
 				820288D827359A1400B0B5D3 /* AudioModeTests.swift in Sources */,
 				6A01CAE523F8FCAF005C5193 /* ClientMetricsCollectorTests.swift in Sources */,
 				007679FE262DFAE500BBF977 /* DirtyEventSQLiteDaoTests.swift in Sources */,

--- a/AmazonChimeSDK/AmazonChimeSDK/analytics/EventAttributeName.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/analytics/EventAttributeName.swift
@@ -64,6 +64,8 @@ import Foundation
     case audioInputError
     /// The error message that explains why the signaling websocket connection dropped
     case signalingDroppedError
+    /// The error message that explains why content share failed
+    case contentShareError
     /// The current app state
     case appState
     /// The current battery level
@@ -123,6 +125,8 @@ import Foundation
             return "videoInputError"
         case .signalingDroppedError:
             return "signalingDroppedError"
+        case .contentShareError:
+            return "contentShareError"
         case .appState:
             return "appState"
         case .batteryLevel:

--- a/AmazonChimeSDK/AmazonChimeSDK/analytics/EventName.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/analytics/EventName.swift
@@ -30,6 +30,14 @@ import Foundation
     case videoClientSignalingDropped
     /// The content share signaling websocket failed or closed with an error
     case contentShareSignalingDropped
+    /// Content share start was requested.
+    case contentShareStartRequested
+    /// Content share started successfully.
+    case contentShareStarted
+    /// Content share stopped.
+    case contentShareStopped
+    /// Content share failed.
+    case contentShareFailed
     /// The application state is changed
     case appStateChanged
     /// The application memory is low
@@ -59,6 +67,14 @@ import Foundation
             return "videoClientSignalingDropped"
         case .contentShareSignalingDropped:
             return "contentShareSignalingDropped"
+        case .contentShareStartRequested:
+            return "contentShareStartRequested"
+        case .contentShareStarted:
+            return "contentShareStarted"
+        case .contentShareStopped:
+            return "contentShareStopped"
+        case .contentShareFailed:
+            return "contentShareFailed"
         case .appStateChanged:
             return "appStateChanged"
         case .appMemoryLow:
@@ -90,6 +106,14 @@ import Foundation
             return .videoClientSignalingDropped
         case "contentShareSignalingDropped":
             return .contentShareSignalingDropped
+        case "contentShareStartRequested":
+            return .contentShareStartRequested
+        case "contentShareStarted":
+            return .contentShareStarted
+        case "contentShareStopped":
+            return .contentShareStopped
+        case "contentShareFailed":
+            return .contentShareFailed
         case "appStateChanged":
             return .appStateChanged
         case "appMemoryLow":

--- a/AmazonChimeSDK/AmazonChimeSDK/analytics/MeetingHistoryEventName.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/analytics/MeetingHistoryEventName.swift
@@ -35,6 +35,14 @@ import Foundation
     case videoClientSignalingDropped
     /// The content share signaling websocket failed or closed with an error.
     case contentShareSignalingDropped
+    /// Content share start was requested.
+    case contentShareStartRequested
+    /// Content share started successfully.
+    case contentShareStarted
+    /// Content share stopped.
+    case contentShareStopped
+    /// Content share failed.
+    case contentShareFailed
     /// The application state is changed
     case appStateChanged
     /// The application memory is low
@@ -68,6 +76,14 @@ import Foundation
             return "videoClientSignalingDropped"
         case .contentShareSignalingDropped:
             return "contentShareSignalingDropped"
+        case .contentShareStartRequested:
+            return "contentShareStartRequested"
+        case .contentShareStarted:
+            return "contentShareStarted"
+        case .contentShareStopped:
+            return "contentShareStopped"
+        case .contentShareFailed:
+            return "contentShareFailed"
         case .appStateChanged:
             return "appStateChanged"
         case .appMemoryLow:

--- a/AmazonChimeSDK/AmazonChimeSDK/ingestion/IngestionEventConverter.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/ingestion/IngestionEventConverter.swift
@@ -74,6 +74,10 @@ private typealias EAName = EventAttributeName
             attributes[EAName.batteryState.description] = AnyCodable(batteryStateStr)
         }
         
+        if let contentShareError = eventAttributes[EAName.contentShareError] as? VideoClientFailedError {
+            let contentShareErrorStr = String(describing: contentShareError)
+            attributes[EAName.contentShareError.description] = AnyCodable(contentShareErrorStr)
+        }
         
         clientConfig.metadataAttributes.forEach({ (key: String, value: Any) in
             attributes[key] = AnyCodable(value)
@@ -184,8 +188,9 @@ private typealias EAName = EventAttributeName
                                 videoInputErrorMessage: meetingEvent.getVideoInputErrorMessage(),
                                 audioInputErrorMessage: meetingEvent.getAudioInputErrorMessage(),
                                 signalingDroppedErrorMessage: meetingEvent.getSignalingDroppedErrorMessage(),
+                                contentShareErrorMessage: meetingEvent.getContentShareErrorMessage(),
                                 appState: meetingEvent.getAppState(),
-                                batteryLevel: meetingEvent.getBatteryLevel()?.floatValue,
+                                batteryLevel: meetingEvent.getBatteryLevel(),
                                 batteryState: meetingEvent.getBatteryState(),
                                 ttl: dirtyMeetingEventTtl)
     }

--- a/AmazonChimeSDK/AmazonChimeSDK/ingestion/IngestionPayload.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/ingestion/IngestionPayload.swift
@@ -23,6 +23,7 @@ import Foundation
     public let videoInputErrorMessage: String?
     public let audioInputErrorMessage: String?
     public let signalingDroppedErrorMessage: String?
+    public let contentShareErrorMessage: String?
     public let appState: String?
     public let batteryLevel: Float?
     public let batteryState: String?
@@ -42,6 +43,7 @@ import Foundation
                 videoInputErrorMessage: String? = nil,
                 audioInputErrorMessage: String? = nil,
                 signalingDroppedErrorMessage: String? = nil,
+                contentShareErrorMessage: String? = nil,
                 appState: String? = nil,
                 batteryLevel: Float? = nil,
                 batteryState: String? = nil,
@@ -60,6 +62,7 @@ import Foundation
         self.videoInputErrorMessage = videoInputErrorMessage
         self.audioInputErrorMessage = audioInputErrorMessage
         self.signalingDroppedErrorMessage = signalingDroppedErrorMessage
+        self.contentShareErrorMessage = contentShareErrorMessage
         self.appState = appState
         self.batteryLevel = batteryLevel
         self.batteryState = batteryState

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/ingestion/database/IngestionMeetingEvent.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/ingestion/database/IngestionMeetingEvent.swift
@@ -84,14 +84,19 @@ extension IngestionMeetingEvent {
         return item??.value as? String
     }
     
+    func getContentShareErrorMessage() -> String? {
+        let item = eventAttributes[EventAttributeName.contentShareError.description]
+        return item??.value as? String
+    }
+    
     func getAppState() -> String? {
         let item = eventAttributes[EventAttributeName.appState.description]
         return item??.value as? String
     }
     
-    func getBatteryLevel() -> NSNumber? {
+    func getBatteryLevel() -> Float? {
         let item = eventAttributes[EventAttributeName.batteryLevel.description]
-        return item??.value as? NSNumber
+        return (item??.value as? NSNumber)?.floatValue
     }
     
     func getBatteryState() -> String? {

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/utils/Converters.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/utils/Converters.swift
@@ -42,6 +42,14 @@ import Foundation
                 return .videoClientSignalingDropped
             case .contentShareSignalingDropped:
                 return .contentShareSignalingDropped
+            case .contentShareStartRequested:
+                return .contentShareStartRequested
+            case .contentShareStarted:
+                return .contentShareStarted
+            case .contentShareStopped:
+                return .contentShareStopped
+            case .contentShareFailed:
+                return .contentShareFailed
             case .appStateChanged:
                 return .appStateChanged
             case .appMemoryLow:

--- a/AmazonChimeSDK/AmazonChimeSDK/utils/VideoClientFailedError.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/utils/VideoClientFailedError.swift
@@ -1,0 +1,44 @@
+//
+//  VideoClientFailedError.swift
+//  AmazonChimeSDK
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import AmazonChimeSDKMedia
+
+@objc public enum VideoClientFailedError: Int, Error, CustomStringConvertible {
+
+    case authenticationFailed
+    case peerConnectionCreateFailed
+    case maxRetryPeriodExceeded
+    case other
+    
+    public init(from videoClientStatus: video_client_status_t) {
+        switch videoClientStatus {
+        case VIDEO_CLIENT_ERR_PROXY_AUTHENTICATION_FAILED:
+            self = .authenticationFailed
+        case VIDEO_CLIENT_ERR_PEERCONN_CREATE_FAILED:
+            self = .peerConnectionCreateFailed
+        case VIDEO_CLIENT_ERR_MAX_RETRY_PERIOD_EXCEEDED:
+            self = .maxRetryPeriodExceeded
+        default:
+            self = .other
+        }
+    }
+
+    public var description: String {
+        switch self {
+        case .authenticationFailed:
+            return "authenticationFailed"
+        case .peerConnectionCreateFailed:
+            return "peerConnectionCreateFailed"
+        case .maxRetryPeriodExceeded:
+            return "maxRetryPeriodExceeded"
+        case .other:
+            return "other"
+        }
+    }
+}

--- a/AmazonChimeSDK/AmazonChimeSDKTests/analytics/EventAttributeNameTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/analytics/EventAttributeNameTests.swift
@@ -37,5 +37,6 @@ class EventAttributeNameTests: XCTestCase {
         XCTAssertEqual(EventAttributeName.audioInputError.description, "audioInputError")
         XCTAssertEqual(EventAttributeName.videoInputError.description, "videoInputError")
         XCTAssertEqual(EventAttributeName.signalingDroppedError.description, "signalingDroppedError")
+        XCTAssertEqual(EventAttributeName.contentShareError.description, "contentShareError")
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/analytics/EventNameTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/analytics/EventNameTests.swift
@@ -22,6 +22,10 @@ class EventNameTests: XCTestCase {
         XCTAssertEqual(EventName.meetingEnded.description, "meetingEnded")
         XCTAssertEqual(EventName.videoClientSignalingDropped.description, "videoClientSignalingDropped")
         XCTAssertEqual(EventName.contentShareSignalingDropped.description, "contentShareSignalingDropped")
+        XCTAssertEqual(EventName.contentShareStartRequested.description, "contentShareStartRequested")
+        XCTAssertEqual(EventName.contentShareStarted.description, "contentShareStarted")
+        XCTAssertEqual(EventName.contentShareStopped.description, "contentShareStopped")
+        XCTAssertEqual(EventName.contentShareFailed.description, "contentShareFailed")
         XCTAssertEqual(EventName.unknown.description, "unknown")
     }
     
@@ -46,6 +50,14 @@ class EventNameTests: XCTestCase {
                        EventName.videoClientSignalingDropped)
         XCTAssertEqual(EventName.toEventName(name: "contentShareSignalingDropped"),
                        EventName.contentShareSignalingDropped)
+        XCTAssertEqual(EventName.toEventName(name: "contentShareStartRequested"),
+                       EventName.contentShareStartRequested)
+        XCTAssertEqual(EventName.toEventName(name: "contentShareStarted"),
+                       EventName.contentShareStarted)
+        XCTAssertEqual(EventName.toEventName(name: "contentShareStopped"),
+                       EventName.contentShareStopped)
+        XCTAssertEqual(EventName.toEventName(name: "contentShareFailed"),
+                       EventName.contentShareFailed)
         XCTAssertEqual(EventName.toEventName(name: "invalidEventName"),
                        EventName.unknown)
     }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/analytics/MeetingHistoryEventNameTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/analytics/MeetingHistoryEventNameTests.swift
@@ -23,6 +23,10 @@ class MeetingHistoryEventNameTests: XCTestCase {
         XCTAssertEqual(MeetingHistoryEventName.meetingReconnected.description, "meetingReconnected")
         XCTAssertEqual(MeetingHistoryEventName.videoClientSignalingDropped.description, "videoClientSignalingDropped")
         XCTAssertEqual(MeetingHistoryEventName.contentShareSignalingDropped.description, "contentShareSignalingDropped")
+        XCTAssertEqual(MeetingHistoryEventName.contentShareStartRequested.description, "contentShareStartRequested")
+        XCTAssertEqual(MeetingHistoryEventName.contentShareStarted.description, "contentShareStarted")
+        XCTAssertEqual(MeetingHistoryEventName.contentShareStopped.description, "contentShareStopped")
+        XCTAssertEqual(MeetingHistoryEventName.contentShareFailed.description, "contentShareFailed")
         XCTAssertEqual(MeetingHistoryEventName.appStateChanged.description, "appStateChanged")
         XCTAssertEqual(MeetingHistoryEventName.appMemoryLow.description, "appMemoryLow")
     }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/ingestion/IngestionEventConverterTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/ingestion/IngestionEventConverterTests.swift
@@ -27,7 +27,8 @@ class IngestionEventConverterTests: CommonTestCase {
             EventAttributeName.signalingDroppedError: TestError.signalingDroppedError,
             EventAttributeName.appState: AppState.background,
             EventAttributeName.batteryLevel: 0.5,
-            EventAttributeName.batteryState: BatteryState.charging
+            EventAttributeName.batteryState: BatteryState.charging,
+            EventAttributeName.contentShareError: VideoClientFailedError.authenticationFailed
         ])
         let result = converter.toIngestionMeetingEvent(event: event,
                                                        ingestionConfiguration: ingestionConfiguration)
@@ -38,6 +39,7 @@ class IngestionEventConverterTests: CommonTestCase {
         XCTAssertEqual(result.getAppState(), String(describing: AppState.background))
         XCTAssertEqual(result.getBatteryLevel(), 0.5)
         XCTAssertEqual(result.getBatteryState(), String(describing: BatteryState.charging))
+        XCTAssertEqual(result.getContentShareErrorMessage(), String(describing: VideoClientFailedError.authenticationFailed))
     }
     
     func testToIngestionRecord_ShouldReturnAttributes_IfExists() {
@@ -46,7 +48,8 @@ class IngestionEventConverterTests: CommonTestCase {
             EventAttributeName.audioInputError.description: AnyCodable(String(describing: TestError.audioInputError)),
             EventAttributeName.videoInputError.description: AnyCodable(String(describing: TestError.videoInputError)),
             EventAttributeName.signalingDroppedError.description: AnyCodable(String(describing: TestError.signalingDroppedError)),
-            EventAttributeName.appState.description: AnyCodable(String(describing: AppState.background))
+            EventAttributeName.appState.description: AnyCodable(String(describing: AppState.background)),
+            EventAttributeName.contentShareError.description: AnyCodable(String(describing: VideoClientFailedError.authenticationFailed))
         ])
         let meetingEvent = MeetingEventItem(id: "test", data: ingestionMeetingEvent)
         let results = converter.toIngestionRecord(meetingEvents: [meetingEvent],

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/utils/ConvertersTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/utils/ConvertersTests.swift
@@ -306,6 +306,14 @@ class ConvertersTests: XCTestCase {
                        MeetingHistoryEventName.videoClientSignalingDropped)
         XCTAssertEqual(Converters.MeetingEventName.toMeetingHistoryEventName(name: EventName.contentShareSignalingDropped),
                        MeetingHistoryEventName.contentShareSignalingDropped)
+        XCTAssertEqual(Converters.MeetingEventName.toMeetingHistoryEventName(name: EventName.contentShareStartRequested),
+                       MeetingHistoryEventName.contentShareStartRequested)
+        XCTAssertEqual(Converters.MeetingEventName.toMeetingHistoryEventName(name: EventName.contentShareStarted),
+                       MeetingHistoryEventName.contentShareStarted)
+        XCTAssertEqual(Converters.MeetingEventName.toMeetingHistoryEventName(name: EventName.contentShareStopped),
+                       MeetingHistoryEventName.contentShareStopped)
+        XCTAssertEqual(Converters.MeetingEventName.toMeetingHistoryEventName(name: EventName.contentShareFailed),
+                       MeetingHistoryEventName.contentShareFailed)
         XCTAssertEqual(Converters.MeetingEventName.toMeetingHistoryEventName(name: EventName.unknown),
                        MeetingHistoryEventName.unknown)
     }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/utils/VideoClientFailedErrorTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/utils/VideoClientFailedErrorTests.swift
@@ -1,0 +1,36 @@
+//
+//  VideoClientFailedErrorTests.swift
+//  AmazonChimeSDK
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import AmazonChimeSDK
+import XCTest
+import AmazonChimeSDKMedia
+
+class VideoClientFailedErrorTests: XCTestCase {
+    
+    func testInitFromVideoClientStatus_ShouldReturnMatchingError() {
+        XCTAssertEqual(
+            VideoClientFailedError.init(from: VIDEO_CLIENT_ERR_PROXY_AUTHENTICATION_FAILED),
+            VideoClientFailedError.authenticationFailed)
+        XCTAssertEqual(
+            VideoClientFailedError.init(from: VIDEO_CLIENT_ERR_PEERCONN_CREATE_FAILED),
+            VideoClientFailedError.peerConnectionCreateFailed)
+        XCTAssertEqual(
+            VideoClientFailedError.init(from: VIDEO_CLIENT_ERR_MAX_RETRY_PERIOD_EXCEEDED),
+            VideoClientFailedError.maxRetryPeriodExceeded)
+        XCTAssertEqual(
+            VideoClientFailedError.init(from: VIDEO_CLIENT_ERR_INVALID_PARAMETER),
+            VideoClientFailedError.other)
+    }
+    
+    func testDescriptionShouldMatch() {
+        XCTAssertEqual(VideoClientFailedError.authenticationFailed.description, "authenticationFailed")
+        XCTAssertEqual(VideoClientFailedError.peerConnectionCreateFailed.description, "peerConnectionCreateFailed")
+        XCTAssertEqual(VideoClientFailedError.maxRetryPeriodExceeded.description, "maxRetryPeriodExceeded")
+        XCTAssertEqual(VideoClientFailedError.other.description, "other")
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## PENDING
 
 ### Added
-* Added meetingReconnected/audioInputFailed/signalingDropped/appStateChanged/appMemoryLow meeting event
-* Added meetingReconnectDurationMs/audioInputErrorMessage/signalingDroppedErrorMessage/appState/batteryLevel/batteryState to meeting event attributes
+* Added meetingReconnected/audioInputFailed/signalingDropped/appStateChanged/appMemoryLow/contentShareStartRequested/contentShareStarted/contentShareStopped/contentShareFailed meeting event
+* Added meetingReconnectDurationMs/audioInputErrorMessage/signalingDroppedErrorMessage/appState/batteryLevel/batteryState/contentShareErrorMessage to meeting event attributes
 
 ## [0.27.1] - 2025-03-28
 

--- a/guides/meeting_events.md
+++ b/guides/meeting_events.md
@@ -86,6 +86,10 @@ Chime SDK sends these meeting events.
 |`audioInputFailed`      |The microphone selection or access failed.
 |`videoInputFailed`      |The camera selection or access failed.
 |`videoClientSignalingDropped`      |The video client signaling websocket failed or closed with an error.
+|`contentShareStartRequested`       |The content share start was requested.
+|`contentShareStarted`              |The content share started successfully.
+|`contentShareStopped`              |The content share stopped.
+|`contentShareFailed`               |The content share failed.
 |`contentShareSignalingDropped`     |The content share client signaling websocket failed or closed with an error.
 |`appStateChanged`                  |The application state is changed.
 |`appMemoryLow`                     |The application memory is low.
@@ -130,6 +134,7 @@ The following table describes attributes for a meeting.
 |`meetingStatus`|The meeting status when the meeting ended or failed. Note that this attribute indicates an enum name in [MeetingSessionStatusCode](https://aws.github.io/amazon-chime-sdk-ios/Enums/MeetingSessionStatusCode.html)| `meetingStartSucceeded`, `meetingReconnected`, `meetingEnded`, `meetingFailed`
 |`poorConnectionCount`|The number of times the significant packet loss occurred during the meeting. Per count, you receive `AudioVideoObserver.connectionDidBecomePoor`.<br><br>Unit: Count|`meetingStartSucceeded`, `meetingReconnected`, `meetingStartFailed`, `meetingEnded`, `meetingFailed`
 |`retryCount`|The number of connection retries performed during the meeting.<br><br>Unit: Count|`meetingStartSucceeded`, `meetingReconnected`, `meetingStartFailed`, `meetingEnded`, `meetingFailed`
+|`contentShareErrorMessage`|The error message that explains why content share failed.|`contentShareFailed`
 |`signalingDroppedErrorMessage`|The error message that explains why the signaling websocket connection dropped.|`videoClientSignalingDropped`, `contentShareSignalingDropped`
 |`appState`|The current app state when the event occurs.| All events
 |`batteryLevel`|The current battery level when the event occurs.| All events
@@ -187,6 +192,10 @@ The following table lists available states.
 |`videoInputSelected`               |The camera was selected.
 |`videoInputFailed`                 |The camera selection failed.
 |`videoClientSignalingDropped`      |The video client signaling websocket failed or closed with an error.
+|`contentShareStartRequested`       |The content share start was requested.
+|`contentShareStarted`              |The content share started successfully.
+|`contentShareStopped`              |The content share stopped.
+|`contentShareFailed`               |The content share failed.
 |`contentShareSignalingDropped`     |The content share client signaling websocket failed or closed with an error.
 |`appStateChanged`                  |The application state is changed.
 |`appMemoryLow`                     |The application memory is low.


### PR DESCRIPTION
## ℹ️ Description
 - Add contentShareStartRequested/contentShareStarted/contentShareStopped/contentShareFailed meeting events
 - Add contentShareErrorMessage meeting event attribute

### Issue #, if available

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
    - [ ] README update
    - [x] CHANGELOG update
    - [x] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
 - Manually tested the events using demo app

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [x] Unit tests pass
- [x] Build SDK against simulator with release options
- [x] Build SDK against device with release options
- [x] Build SDK against simulator with debug options
- [x] Build SDK against device with debug options
- [x] Test Demo against simulator with SDK (debug build) in workspace
- [x] Test Demo against device with SDK (debug build) in workspace
- [x] Test DemoObjC against simulator with SDK (debug build) in workspace
- [x] Test DemoObjC against device with SDK (debug build) in workspace
- [x] Test Demo against simulator with SDK.framework (release build)
- [x] Test Demo against device with SDK.framework (release build)
- [x] Test DemoObjC against simulator with SDK.framework (release build)
- [x] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
