### PR TITLE
Add voice focus/AV interruption meeting events; Add audio/video device type and lowPowerModeEnabled event attribute;

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
+++ b/AmazonChimeSDK/AmazonChimeSDK.xcodeproj/project.pbxproj
@@ -288,10 +288,13 @@
 		D863BE3729BAF68B00D9DE9E /* EventAttributeUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D863BE3629BAF68B00D9DE9E /* EventAttributeUtilsTests.swift */; };
 		D8659BE22E78B013006C1C20 /* VideoClientFailedError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8659BE12E78B013006C1C20 /* VideoClientFailedError.swift */; };
 		D8659BE42E78BCDA006C1C20 /* VideoClientFailedErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8659BE32E78BCD5006C1C20 /* VideoClientFailedErrorTests.swift */; };
+		D86AB6A02E8267D6003FF014 /* VoiceFocusErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86AB69F2E8267D0003FF014 /* VoiceFocusErrorTests.swift */; };
+		D89047E62E7B8E4100A22DFE /* VoiceFocusError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89047E52E7B8E3100A22DFE /* VoiceFocusError.swift */; };
 		D8A1527E2D56CAFE002775BD /* VideoFrameResenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A1527D2D56CAF7002775BD /* VideoFrameResenderTests.swift */; };
 		D8A152832D56F8DF002775BD /* VideoFrameGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8A152822D56F8DA002775BD /* VideoFrameGenerator.swift */; };
 		D8B836602E39A0CB00179ABF /* TestError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B8365F2E39A0C900179ABF /* TestError.swift */; };
 		D8B836622E39A10F00179ABF /* IngestionEventConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B836612E39A10D00179ABF /* IngestionEventConverterTests.swift */; };
+		D8C2EAAB2E89ADEA007BA3C7 /* VideoInterruptionReason.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8C2EAAA2E89ADDE007BA3C7 /* VideoInterruptionReason.swift */; };
 		D8D3F8D32E610E6B003D2EF4 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D3F8D22E610E6A003D2EF4 /* AppState.swift */; };
 		D8D3F8D52E61166A003D2EF4 /* AppStateMonitorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D3F8D42E611669003D2EF4 /* AppStateMonitorDelegate.swift */; };
 		D8D8D9102B91579C00ECE0EE /* StringExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8D8D90F2B91579C00ECE0EE /* StringExtension.swift */; };
@@ -611,10 +614,13 @@
 		D863BE3629BAF68B00D9DE9E /* EventAttributeUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventAttributeUtilsTests.swift; sourceTree = "<group>"; };
 		D8659BE12E78B013006C1C20 /* VideoClientFailedError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoClientFailedError.swift; sourceTree = "<group>"; };
 		D8659BE32E78BCD5006C1C20 /* VideoClientFailedErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoClientFailedErrorTests.swift; sourceTree = "<group>"; };
+		D86AB69F2E8267D0003FF014 /* VoiceFocusErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceFocusErrorTests.swift; sourceTree = "<group>"; };
+		D89047E52E7B8E3100A22DFE /* VoiceFocusError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceFocusError.swift; sourceTree = "<group>"; };
 		D8A1527D2D56CAF7002775BD /* VideoFrameResenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoFrameResenderTests.swift; sourceTree = "<group>"; };
 		D8A152822D56F8DA002775BD /* VideoFrameGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoFrameGenerator.swift; sourceTree = "<group>"; };
 		D8B8365F2E39A0C900179ABF /* TestError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestError.swift; sourceTree = "<group>"; };
 		D8B836612E39A10D00179ABF /* IngestionEventConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IngestionEventConverterTests.swift; sourceTree = "<group>"; };
+		D8C2EAAA2E89ADDE007BA3C7 /* VideoInterruptionReason.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoInterruptionReason.swift; sourceTree = "<group>"; };
 		D8D3F8D22E610E6A003D2EF4 /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		D8D3F8D42E611669003D2EF4 /* AppStateMonitorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStateMonitorDelegate.swift; sourceTree = "<group>"; };
 		D8D8D90F2B91579C00ECE0EE /* StringExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtension.swift; sourceTree = "<group>"; };
@@ -667,6 +673,8 @@
 		0007BD8F2632402A00A15BB6 /* ingestion */ = {
 			isa = PBXGroup;
 			children = (
+				D8C2EAAA2E89ADDE007BA3C7 /* VideoInterruptionReason.swift */,
+				D89047E52E7B8E3100A22DFE /* VoiceFocusError.swift */,
 				D82D32B22E71E89A009190ED /* BatteryState.swift */,
 				D8D3F8D42E611669003D2EF4 /* AppStateMonitorDelegate.swift */,
 				D8D3F8D22E610E6A003D2EF4 /* AppState.swift */,
@@ -724,6 +732,7 @@
 		0033D341263B24FD00D8FA0C /* ingestion */ = {
 			isa = PBXGroup;
 			children = (
+				D86AB69F2E8267D0003FF014 /* VoiceFocusErrorTests.swift */,
 				D8F8298F2E56939E009E9186 /* DefaultAppStateMonitorTests.swift */,
 				D8B836612E39A10D00179ABF /* IngestionEventConverterTests.swift */,
 				0033D342263B250C00D8FA0C /* IngestionConfigurationTests.swift */,
@@ -1697,6 +1706,7 @@
 				D8FE1FE629B9232400A62E72 /* AnyCodable.swift in Sources */,
 				C4643F0C2578776E0085D51E /* ModalityType.swift in Sources */,
 				5A6A209B23CB1164000C9157 /* CreateAttendeeResponse.swift in Sources */,
+				D8C2EAAB2E89ADEA007BA3C7 /* VideoInterruptionReason.swift in Sources */,
 				00C35B5F246A015800EA186F /* URLRewriter.swift in Sources */,
 				5A6A209A23CB1164000C9157 /* CreateMeetingResponse.swift in Sources */,
 				0007BD9D2633499600A15BB6 /* EventReporter.swift in Sources */,
@@ -1839,6 +1849,7 @@
 				C6DA0B5D24F8107000028F2B /* AudioLock.swift in Sources */,
 				0064166626290C9400626EB8 /* DirtyEventSQLiteDao.swift in Sources */,
 				0095013423FF372E003260E3 /* VideoClientState.swift in Sources */,
+				D89047E62E7B8E4100A22DFE /* VoiceFocusError.swift in Sources */,
 				5AE121D3240F6A8E0090A2AD /* VolumeUpdate.swift in Sources */,
 				6A68E79F24196773004F5A56 /* VideoPauseState.swift in Sources */,
 				C67E9B6C26F4F5A30084C9B4 /* Transcript.swift in Sources */,
@@ -1884,6 +1895,7 @@
 				C61D43222703BD9D00150F03 /* DefaultVideoClientControllerTests.swift in Sources */,
 				5A2210E524BE577E0038725B /* DefaultMeetingSessionTests.swift in Sources */,
 				CFA2A17028087AE8008FDFF5 /* BackgroundFilterTest.swift in Sources */,
+				D86AB6A02E8267D6003FF014 /* VoiceFocusErrorTests.swift in Sources */,
 				D8F829902E5693A4009E9186 /* DefaultAppStateMonitorTests.swift in Sources */,
 				00E198E1259BC0CF00AD4DAA /* EventNameTests.swift in Sources */,
 				00E198EF259BCA5A00AD4DAA /* EventAttributeNameTests.swift in Sources */,

--- a/AmazonChimeSDK/AmazonChimeSDK/analytics/DefaultEventAnalyticsController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/analytics/DefaultEventAnalyticsController.swift
@@ -121,9 +121,11 @@ import Foundation
     private func getAppAttributes() -> [AnyHashable: Any] {
         let appState = self.appStateMonitor.appState
         let batteryState = self.appStateMonitor.getBatteryState()
+        let lowPowerModeEnabled = self.appStateMonitor.isLowPowerModeEnabled()
         var attributes: [EventAttributeName : Any] = [
             EventAttributeName.appState: appState,
-            EventAttributeName.batteryState: batteryState
+            EventAttributeName.batteryState: batteryState,
+            EventAttributeName.lowPowerModeEnabled: lowPowerModeEnabled
         ]
         
         if let batteryLevel = self.appStateMonitor.getBatteryLevel() {

--- a/AmazonChimeSDK/AmazonChimeSDK/analytics/EventAttributeName.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/analytics/EventAttributeName.swift
@@ -72,6 +72,16 @@ import Foundation
     case batteryLevel
     /// The current battery state
     case batteryState
+    /// The error message explaining why enabling or disabling Voice Focus failed
+    case voiceFocusError
+    /// The selected audio device type
+    case audioDeviceType
+    /// The selected video device type
+    case videoDeviceType
+    /// Whether low power mode is enabled
+    case lowPowerModeEnabled
+    /// The reason explaning why the vidoe is interrupted
+    case videoInterruptionReason
 
     public var description: String {
         switch self {
@@ -133,6 +143,16 @@ import Foundation
             return "batteryLevel"
         case .batteryState:
             return "batteryState"
+        case .voiceFocusError:
+            return "voiceFocusError"
+        case .audioDeviceType:
+            return "audioDeviceType"
+        case .videoDeviceType:
+            return "videoDeviceType"
+        case .lowPowerModeEnabled:
+            return "lowPowerModeEnabled"
+        case .videoInterruptionReason:
+            return "videoInterruptionReason"
         }
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/analytics/EventName.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/analytics/EventName.swift
@@ -10,8 +10,12 @@ import Foundation
 
 /// `EventName` represent some major event that could help builders to analyze the data
 @objc public enum EventName: Int, CaseIterable, CustomStringConvertible {
+    /// The microphone was selected.
+    case audioInputSelected
     /// The microphone selection or access failed
     case audioInputFailed
+    /// The camera was selected.
+    case videoInputSelected
     /// The camera selection or access failed
     case videoInputFailed
     /// The meeting will start
@@ -42,13 +46,33 @@ import Foundation
     case appStateChanged
     /// The application memory is low
     case appMemoryLow
+    /// Voice focus enabled
+    case voiceFocusEnabled
+    /// Voice focus disabled
+    case voiceFocusDisabled
+    /// Failed to enable voice focus
+    case voiceFocusEnableFailed
+    /// Failed to disable voice focus
+    case voiceFocusDisableFailed
+    /// Audio interruption began
+    case audioInterruptionBegan
+    /// Audio interruption ended
+    case audioInterruptionEnded
+    /// Video interruption began
+    case videoInterruptionBegan
+    /// Video interruption ended
+    case videoInterruptionEnded
     // unknown
     case unknown
 
     public var description: String {
         switch self {
+        case .audioInputSelected:
+            return "audioInputSelected"
         case .audioInputFailed:
             return "audioInputFailed"
+        case .videoInputSelected:
+            return "videoInputSelected"
         case .videoInputFailed:
             return "videoInputFailed"
         case .meetingStartRequested:
@@ -79,6 +103,22 @@ import Foundation
             return "appStateChanged"
         case .appMemoryLow:
             return "appMemoryLow"
+        case .voiceFocusEnabled:
+            return "voiceFocusEnabled"
+        case .voiceFocusDisabled:
+            return "voiceFocusDisabled"
+        case .voiceFocusEnableFailed:
+            return "voiceFocusEnableFailed"
+        case .voiceFocusDisableFailed:
+            return "voiceFocusDisableFailed"
+        case .audioInterruptionBegan:
+            return "audioInterruptionBegan"
+        case .audioInterruptionEnded:
+            return "audioInterruptionEnded"
+        case .videoInterruptionBegan:
+            return "videoInterruptionBegan"
+        case .videoInterruptionEnded:
+            return "videoInterruptionEnded"
         case .unknown:
             return "unknown"
         }
@@ -86,8 +126,12 @@ import Foundation
 
     static func toEventName(name: String) -> EventName {
         switch name {
+        case "audioInputSelected":
+            return .audioInputSelected
         case "audioInputFailed":
             return .audioInputFailed
+        case "videoInputSelected":
+            return .videoInputSelected
         case "videoInputFailed":
             return .videoInputFailed
         case "meetingStartRequested":
@@ -118,6 +162,22 @@ import Foundation
             return .appStateChanged
         case "appMemoryLow":
             return .appMemoryLow
+        case "voiceFocusEnabled":
+            return .voiceFocusEnabled
+        case "voiceFocusDisabled":
+            return .voiceFocusDisabled
+        case "voiceFocusEnableFailed":
+            return .voiceFocusEnableFailed
+        case "voiceFocusDisableFailed":
+            return .voiceFocusDisableFailed
+        case "audioInterruptionBegan":
+            return .audioInterruptionBegan
+        case "audioInterruptionEnded":
+            return .audioInterruptionEnded
+        case "videoInterruptionBegan":
+            return .videoInterruptionBegan
+        case "videoInterruptionEnded":
+            return .videoInterruptionEnded
         default:
             return .unknown
         }

--- a/AmazonChimeSDK/AmazonChimeSDK/analytics/MeetingHistoryEventName.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/analytics/MeetingHistoryEventName.swift
@@ -47,6 +47,22 @@ import Foundation
     case appStateChanged
     /// The application memory is low
     case appMemoryLow
+    /// Voice focus enabled
+    case voiceFocusEnabled
+    /// Voice focus disabled
+    case voiceFocusDisabled
+    /// Failed to enable voice focus
+    case voiceFocusEnableFailed
+    /// Failed to disable voice focus
+    case voiceFocusDisableFailed
+    /// Audio interruption began
+    case audioInterruptionBegan
+    /// Audio interruption ended
+    case audioInterruptionEnded
+    /// Video interruption began
+    case videoInterruptionBegan
+    /// Video interruption ended
+    case videoInterruptionEnded
     /// unknown
     case unknown
 
@@ -88,6 +104,22 @@ import Foundation
             return "appStateChanged"
         case .appMemoryLow:
             return "appMemoryLow"
+        case .voiceFocusEnabled:
+            return "voiceFocusEnabled"
+        case .voiceFocusDisabled:
+            return "voiceFocusDisabled"
+        case .voiceFocusEnableFailed:
+            return "voiceFocusEnableFailed"
+        case .voiceFocusDisableFailed:
+            return "voiceFocusDisableFailed"
+        case .audioInterruptionBegan:
+            return "audioInterruptionBegan"
+        case .audioInterruptionEnded:
+            return "audioInterruptionEnded"
+        case .videoInterruptionBegan:
+            return "videoInterruptionBegan"
+        case .videoInterruptionEnded:
+            return "videoInterruptionEnded"
         case .unknown:
             return "unknown"
         }

--- a/AmazonChimeSDK/AmazonChimeSDK/device/DefaultDeviceController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/device/DefaultDeviceController.swift
@@ -76,20 +76,28 @@ import AVFoundation
         if mediaDevice.port == nil {
             do {
                 try audioSession.overrideOutputAudioPort(.speaker)
-                eventAnalyticsController.pushHistory(historyEventName: .audioInputSelected)
+                eventAnalyticsController.publishEvent(name: .audioInputSelected,
+                                                      attributes: [
+                                                        EventAttributeName.audioDeviceType: MediaDeviceType.audioBuiltInSpeaker.description
+                                                      ], notifyObservers: false)
             } catch {
                 eventAnalyticsController.publishEvent(name: .audioInputFailed, attributes: [
-                    EventAttributeName.audioInputError: MediaError.overrideOutputAudioPortFailed
+                    EventAttributeName.audioInputError: MediaError.overrideOutputAudioPortFailed,
+                    EventAttributeName.audioDeviceType: MediaDeviceType.audioBuiltInSpeaker.description
                 ])
                 logger.error(msg: "Error on setting audio input device: \(error.localizedDescription)")
             }
         } else {
             do {
                 try audioSession.setPreferredInput(mediaDevice.port)
-                eventAnalyticsController.pushHistory(historyEventName: .audioInputSelected)
+                eventAnalyticsController.publishEvent(name: .audioInputSelected,
+                                                      attributes: [
+                                                        EventAttributeName.audioDeviceType: mediaDevice.type.description
+                                                      ], notifyObservers: false)
             } catch {
                 eventAnalyticsController.publishEvent(name: .audioInputFailed, attributes: [
-                    EventAttributeName.audioInputError: MediaError.setPreferredAudioInputFailed
+                    EventAttributeName.audioInputError: MediaError.setPreferredAudioInputFailed,
+                    EventAttributeName.audioDeviceType: mediaDevice.type.description
                 ])
                 logger.error(msg: "Error on setting audio input device: \(error.localizedDescription)")
             }

--- a/AmazonChimeSDK/AmazonChimeSDK/ingestion/AppStateMonitor.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/ingestion/AppStateMonitor.swift
@@ -23,4 +23,8 @@
     /// Retrieves the current battery state
     /// Returns the UIDevice.BatteryState indicating charging status
     func getBatteryState() -> BatteryState
+    
+    /// Retrieves whether low power mode is currently enabled
+    /// Returns true if low power mode is enabled, false otherwise
+    func isLowPowerModeEnabled() -> Bool
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/ingestion/DefaultAppStateMonitor.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/ingestion/DefaultAppStateMonitor.swift
@@ -141,6 +141,12 @@ import UIKit
         
         return BatteryState(from: device.batteryState)
     }
+    
+    /// Retrieves whether low power mode is currently enabled
+    /// Returns true if low power mode is enabled, false otherwise
+    public func isLowPowerModeEnabled() -> Bool {
+        return ProcessInfo.processInfo.isLowPowerModeEnabled
+    }
 
     deinit {
         stop()

--- a/AmazonChimeSDK/AmazonChimeSDK/ingestion/IngestionEventConverter.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/ingestion/IngestionEventConverter.swift
@@ -79,6 +79,28 @@ private typealias EAName = EventAttributeName
             attributes[EAName.contentShareError.description] = AnyCodable(contentShareErrorStr)
         }
         
+        if let voiceFocusError = eventAttributes[EAName.voiceFocusError] as? VoiceFocusError {
+            let voiceFocusErrorStr = String(describing: voiceFocusError)
+            attributes[EAName.voiceFocusError.description] = AnyCodable(voiceFocusErrorStr)
+        }
+        
+        if let audioDeviceTypeStr = eventAttributes[EAName.audioDeviceType] as? String {
+            attributes[EAName.audioDeviceType.description] = AnyCodable(audioDeviceTypeStr)
+        }
+        
+        if let videoDeviceTypeStr = eventAttributes[EAName.videoDeviceType] as? String {
+            attributes[EAName.videoDeviceType.description] = AnyCodable(videoDeviceTypeStr)
+        }
+        
+        if let lowPowerModeEnabled = eventAttributes[EAName.lowPowerModeEnabled] as? Bool {
+            attributes[EAName.lowPowerModeEnabled.description] = AnyCodable(lowPowerModeEnabled)
+        }
+        
+        if let videoInterruptionReason = eventAttributes[EAName.videoInterruptionReason] as? VideoInterruptionReason {
+            let reasonStr = String(describing: videoInterruptionReason)
+            attributes[EAName.videoInterruptionReason.description] = AnyCodable(reasonStr)
+        }
+        
         clientConfig.metadataAttributes.forEach({ (key: String, value: Any) in
             attributes[key] = AnyCodable(value)
         })
@@ -192,6 +214,11 @@ private typealias EAName = EventAttributeName
                                 appState: meetingEvent.getAppState(),
                                 batteryLevel: meetingEvent.getBatteryLevel(),
                                 batteryState: meetingEvent.getBatteryState(),
+                                voiceFocusErrorMessage: meetingEvent.getVoiceFocusErrorMessage(),
+                                audioDeviceType: meetingEvent.getAudioDeviceType(),
+                                videoDeviceType: meetingEvent.getVideoDeviceType(),
+                                lowPowerModeEnabled: meetingEvent.isLowPowerModeEnabled(),
+                                videoInterruptionReason: meetingEvent.getVideoInterruptionReason(),
                                 ttl: dirtyMeetingEventTtl)
     }
 

--- a/AmazonChimeSDK/AmazonChimeSDK/ingestion/IngestionPayload.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/ingestion/IngestionPayload.swift
@@ -27,7 +27,12 @@ import Foundation
     public let appState: String?
     public let batteryLevel: Float?
     public let batteryState: String?
+    public let voiceFocusErrorMessage: String?
+    public let audioDeviceType: String?
+    public let videoDeviceType: String?
     public let ttl: Int64?
+    public let lowPowerModeEnabled: Bool?
+    public let videoInterruptionReason: String?
 
     public init(name: String,
                 ts: Int64,
@@ -47,6 +52,11 @@ import Foundation
                 appState: String? = nil,
                 batteryLevel: Float? = nil,
                 batteryState: String? = nil,
+                voiceFocusErrorMessage: String? = nil,
+                audioDeviceType: String? = nil,
+                videoDeviceType: String? = nil,
+                lowPowerModeEnabled: Bool? = nil,
+                videoInterruptionReason: String? = nil,
                 ttl: Int64? = nil) {
         self.name = name
         self.ts = ts
@@ -66,6 +76,11 @@ import Foundation
         self.appState = appState
         self.batteryLevel = batteryLevel
         self.batteryState = batteryState
+        self.voiceFocusErrorMessage = voiceFocusErrorMessage
+        self.audioDeviceType = audioDeviceType
+        self.videoDeviceType = videoDeviceType
+        self.lowPowerModeEnabled = lowPowerModeEnabled
+        self.videoInterruptionReason = videoInterruptionReason
         self.ttl = ttl
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/ingestion/VideoInterruptionReason.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/ingestion/VideoInterruptionReason.swift
@@ -1,0 +1,50 @@
+//
+//  VideoInterruptionReason.swift
+//  AmazonChimeSDK
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import AmazonChimeSDKMedia
+import AVFoundation
+
+@objc public enum VideoInterruptionReason: Int, Error, CustomStringConvertible {
+    
+    case videoDeviceNotAvailableInBackground
+    case videoDeviceInUseByAnotherClient
+    case videoDeviceNotAvailableWithMultipleForegroundApps
+    case videoDeviceNotAvailableDueToSystemPressure
+    case other
+    
+    public init(from reason: AVCaptureSession.InterruptionReason) {
+        switch reason {
+        case AVCaptureSession.InterruptionReason.videoDeviceNotAvailableInBackground:
+            self = .videoDeviceNotAvailableInBackground
+        case AVCaptureSession.InterruptionReason.videoDeviceInUseByAnotherClient:
+            self = .videoDeviceInUseByAnotherClient
+        case AVCaptureSession.InterruptionReason.videoDeviceNotAvailableWithMultipleForegroundApps:
+            self = .videoDeviceNotAvailableWithMultipleForegroundApps
+        case AVCaptureSession.InterruptionReason.videoDeviceNotAvailableDueToSystemPressure:
+            self = .videoDeviceNotAvailableDueToSystemPressure
+        default:
+            self = .other
+        }
+    }
+
+    public var description: String {
+        switch self {
+        case .videoDeviceNotAvailableInBackground:
+            return "videoDeviceNotAvailableInBackground"
+        case .videoDeviceInUseByAnotherClient:
+            return "videoDeviceInUseByAnotherClient"
+        case .videoDeviceNotAvailableWithMultipleForegroundApps:
+            return "notInitialized"
+        case .videoDeviceNotAvailableDueToSystemPressure:
+            return "videoDeviceNotAvailableDueToSystemPressure"
+        case .other:
+            return "other"
+        }
+    }
+}

--- a/AmazonChimeSDK/AmazonChimeSDK/ingestion/VoiceFocusError.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/ingestion/VoiceFocusError.swift
@@ -1,0 +1,47 @@
+//
+//  VoiceFocusError.swift
+//  AmazonChimeSDK
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+import Foundation
+import AmazonChimeSDKMedia
+
+@objc public enum VoiceFocusError: Int, Error, CustomStringConvertible {
+    
+    case audioClientNotStarted
+    case audioClientError
+    case setParamFailed
+    case notInitialized
+    case other
+    
+    public init(from xalError: Int) {
+        switch xalError {
+        case 1:
+            self = .audioClientError
+        case 6:
+            self = .notInitialized
+        case 19:
+            self = .setParamFailed
+        default:
+            self = .other
+        }
+    }
+
+    public var description: String {
+        switch self {
+        case .audioClientNotStarted:
+            return "audioClientNotStarted"
+        case .audioClientError:
+            return "audioClientError"
+        case .notInitialized:
+            return "notInitialized"
+        case .setParamFailed:
+            return "setParamFailed"
+        case .other:
+            return "other"
+        }
+    }
+}

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/ingestion/database/IngestionMeetingEvent.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/ingestion/database/IngestionMeetingEvent.swift
@@ -103,4 +103,31 @@ extension IngestionMeetingEvent {
         let item = eventAttributes[EventAttributeName.batteryState.description]
         return item??.value as? String
     }
+    
+    func getVoiceFocusErrorMessage() -> String? {
+        let item = eventAttributes[EventAttributeName.voiceFocusError.description]
+        return item??.value as? String
+    }
+    
+    func getAudioDeviceType() -> String? {
+        let item = eventAttributes[EventAttributeName.audioDeviceType.description]
+        return item??.value as? String
+    }
+    
+    func getVideoDeviceType() -> String? {
+        let item = eventAttributes[EventAttributeName.videoDeviceType.description]
+        return item??.value as? String
+    }
+    
+    func isLowPowerModeEnabled() -> Bool? {
+        let item = eventAttributes[EventAttributeName.lowPowerModeEnabled.description]
+        return item??.value as? Bool
+    }
+    
+    func getVideoInterruptionReason() -> String? {
+        let item = eventAttributes[EventAttributeName.videoInterruptionReason.description]
+        return item??.value as? String
+    }
+    
+    
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/utils/Converters.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/utils/Converters.swift
@@ -22,8 +22,12 @@ import Foundation
     enum MeetingEventName {
         static func toMeetingHistoryEventName(name: EventName) -> MeetingHistoryEventName {
             switch name {
+            case .audioInputSelected:
+                return .audioInputSelected
             case .audioInputFailed:
                 return .audioInputFailed
+            case .videoInputSelected:
+                return .videoInputSelected
             case .videoInputFailed:
                 return .videoInputFailed
             case .meetingStartRequested:
@@ -54,6 +58,22 @@ import Foundation
                 return .appStateChanged
             case .appMemoryLow:
                 return .appMemoryLow
+            case .voiceFocusEnabled:
+                return .voiceFocusEnabled
+            case .voiceFocusDisabled:
+                return .voiceFocusDisabled
+            case .voiceFocusEnableFailed:
+                return .voiceFocusEnableFailed
+            case .voiceFocusDisableFailed:
+                return .voiceFocusDisableFailed
+            case .audioInterruptionBegan:
+                return .audioInterruptionBegan
+            case .audioInterruptionEnded:
+                return .audioInterruptionEnded
+            case .videoInterruptionBegan:
+                return .videoInterruptionBegan
+            case .videoInterruptionEnded:
+                return .videoInterruptionEnded
             case .unknown:
                 return .unknown
             }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/analytics/DefaultEventAnalyticsControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/analytics/DefaultEventAnalyticsControllerTests.swift
@@ -34,6 +34,7 @@ class DefaultEventAnalyticsControllerTests: CommonTestCase {
         given(appStateMonitorMock.getAppState()).willReturn(.active)
         given(appStateMonitorMock.getBatteryLevel()).willReturn(NSNumber(value: 0.77))
         given(appStateMonitorMock.getBatteryState()).willReturn(BatteryState.charging)
+        given(appStateMonitorMock.isLowPowerModeEnabled()).willReturn(true)
         
         eventAnalyticsController = DefaultEventAnalyticsController(meetingSessionConfig: meetingSessionConfigurationMock,
                                                                    meetingStatsCollector: meetingStatsCollectorMock,
@@ -94,6 +95,7 @@ class DefaultEventAnalyticsControllerTests: CommonTestCase {
         given(appStateMonitorMock.getAppState()).willReturn(.background)
         given(appStateMonitorMock.getBatteryLevel()).willReturn(NSNumber.init(value: 0.17))
         given(appStateMonitorMock.getBatteryState()).willReturn(BatteryState.full)
+        given(appStateMonitorMock.isLowPowerModeEnabled()).willReturn(true)
         
         eventAnalyticsController.publishEvent(name: .meetingStartFailed)
         verify(eventReporterMock.report(event: eventCaptor.any())).wasCalled()

--- a/AmazonChimeSDK/AmazonChimeSDKTests/analytics/EventAttributeNameTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/analytics/EventAttributeNameTests.swift
@@ -38,5 +38,10 @@ class EventAttributeNameTests: XCTestCase {
         XCTAssertEqual(EventAttributeName.videoInputError.description, "videoInputError")
         XCTAssertEqual(EventAttributeName.signalingDroppedError.description, "signalingDroppedError")
         XCTAssertEqual(EventAttributeName.contentShareError.description, "contentShareError")
+        XCTAssertEqual(EventAttributeName.voiceFocusError.description, "voiceFocusError")
+        XCTAssertEqual(EventAttributeName.audioDeviceType.description, "audioDeviceType")
+        XCTAssertEqual(EventAttributeName.videoDeviceType.description, "videoDeviceType")
+        XCTAssertEqual(EventAttributeName.lowPowerModeEnabled.description, "lowPowerModeEnabled")
+        XCTAssertEqual(EventAttributeName.videoInterruptionReason.description, "videoInterruptionReason")
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/analytics/EventNameTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/analytics/EventNameTests.swift
@@ -26,6 +26,14 @@ class EventNameTests: XCTestCase {
         XCTAssertEqual(EventName.contentShareStarted.description, "contentShareStarted")
         XCTAssertEqual(EventName.contentShareStopped.description, "contentShareStopped")
         XCTAssertEqual(EventName.contentShareFailed.description, "contentShareFailed")
+        XCTAssertEqual(EventName.appStateChanged.description, "appStateChanged")
+        XCTAssertEqual(EventName.appMemoryLow.description, "appMemoryLow")
+        XCTAssertEqual(EventName.voiceFocusEnabled.description, "voiceFocusEnabled")
+        XCTAssertEqual(EventName.voiceFocusDisabled.description, "voiceFocusDisabled")
+        XCTAssertEqual(EventName.voiceFocusEnableFailed.description, "voiceFocusEnableFailed")
+        XCTAssertEqual(EventName.voiceFocusDisableFailed.description, "voiceFocusDisableFailed")
+        XCTAssertEqual(EventName.audioInputSelected.description, "audioInputSelected")
+        XCTAssertEqual(EventName.videoInputSelected.description, "videoInputSelected")
         XCTAssertEqual(EventName.unknown.description, "unknown")
     }
     
@@ -58,6 +66,30 @@ class EventNameTests: XCTestCase {
                        EventName.contentShareStopped)
         XCTAssertEqual(EventName.toEventName(name: "contentShareFailed"),
                        EventName.contentShareFailed)
+        XCTAssertEqual(EventName.toEventName(name: "appStateChanged"),
+                       EventName.appStateChanged)
+        XCTAssertEqual(EventName.toEventName(name: "appMemoryLow"),
+                       EventName.appMemoryLow)
+        XCTAssertEqual(EventName.toEventName(name: "voiceFocusEnabled"),
+                       EventName.voiceFocusEnabled)
+        XCTAssertEqual(EventName.toEventName(name: "voiceFocusDisabled"),
+                       EventName.voiceFocusDisabled)
+        XCTAssertEqual(EventName.toEventName(name: "voiceFocusEnableFailed"),
+                       EventName.voiceFocusEnableFailed)
+        XCTAssertEqual(EventName.toEventName(name: "voiceFocusDisableFailed"),
+                       EventName.voiceFocusDisableFailed)
+        XCTAssertEqual(EventName.toEventName(name: "audioInputSelected"),
+                       EventName.audioInputSelected)
+        XCTAssertEqual(EventName.toEventName(name: "videoInputSelected"),
+                       EventName.videoInputSelected)
+        XCTAssertEqual(EventName.toEventName(name: "audioInterruptionBegan"),
+                       EventName.audioInterruptionBegan)
+        XCTAssertEqual(EventName.toEventName(name: "audioInterruptionEnded"),
+                       EventName.audioInterruptionEnded)
+        XCTAssertEqual(EventName.toEventName(name: "videoInterruptionBegan"),
+                       EventName.videoInterruptionBegan)
+        XCTAssertEqual(EventName.toEventName(name: "videoInterruptionEnded"),
+                       EventName.videoInterruptionEnded)
         XCTAssertEqual(EventName.toEventName(name: "invalidEventName"),
                        EventName.unknown)
     }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/analytics/MeetingHistoryEventNameTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/analytics/MeetingHistoryEventNameTests.swift
@@ -29,5 +29,13 @@ class MeetingHistoryEventNameTests: XCTestCase {
         XCTAssertEqual(MeetingHistoryEventName.contentShareFailed.description, "contentShareFailed")
         XCTAssertEqual(MeetingHistoryEventName.appStateChanged.description, "appStateChanged")
         XCTAssertEqual(MeetingHistoryEventName.appMemoryLow.description, "appMemoryLow")
+        XCTAssertEqual(MeetingHistoryEventName.voiceFocusEnabled.description, "voiceFocusEnabled")
+        XCTAssertEqual(MeetingHistoryEventName.voiceFocusDisabled.description, "voiceFocusDisabled")
+        XCTAssertEqual(MeetingHistoryEventName.voiceFocusEnableFailed.description, "voiceFocusEnableFailed")
+        XCTAssertEqual(MeetingHistoryEventName.voiceFocusDisableFailed.description, "voiceFocusDisableFailed")
+        XCTAssertEqual(MeetingHistoryEventName.audioInterruptionBegan.description, "audioInterruptionBegan")
+        XCTAssertEqual(MeetingHistoryEventName.audioInterruptionEnded.description, "audioInterruptionEnded")
+        XCTAssertEqual(MeetingHistoryEventName.videoInterruptionBegan.description, "videoInterruptionBegan")
+        XCTAssertEqual(MeetingHistoryEventName.videoInterruptionEnded.description, "videoInterruptionEnded")
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/device/DefaultDeviceControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/device/DefaultDeviceControllerTests.swift
@@ -63,6 +63,14 @@ class DefaultDeviceControllerTests: XCTestCase {
         defaultDeviceController.chooseAudioDevice(mediaDevice: speakerDevice)
 
         verify(audioSessionMock.overrideOutputAudioPort(.speaker)).wasCalled()
+        
+        let captor = ArgumentCaptor<[AnyHashable: Any]>()
+        verify(eventAnalyticsControllerMock.publishEvent(name: .audioInputSelected,
+                                                         attributes: captor.any(),
+                                                         notifyObservers: false)).wasCalled()
+        
+        let audioDeviceType = captor.value?[EventAttributeName.audioDeviceType] as? String
+        XCTAssertEqual(audioDeviceType, MediaDeviceType.audioBuiltInSpeaker.description)
     }
 
     func testChooseAudioDevice_nonSpeaker() {
@@ -71,6 +79,14 @@ class DefaultDeviceControllerTests: XCTestCase {
         defaultDeviceController.chooseAudioDevice(mediaDevice: nonSpeakerDevice)
 
         verify(audioSessionMock.setPreferredInput(nonSpeakerDevice.port)).wasCalled()
+        
+        let captor = ArgumentCaptor<[AnyHashable: Any]>()
+        verify(eventAnalyticsControllerMock.publishEvent(name: .audioInputSelected,
+                                                         attributes: captor.any(),
+                                                         notifyObservers: false)).wasCalled()
+        
+        let audioDeviceType = captor.value?[EventAttributeName.audioDeviceType] as? String
+        XCTAssertEqual(audioDeviceType, nonSpeakerDevice.type.description)
     }
 
     func testSwitchCamera() {
@@ -124,5 +140,8 @@ class DefaultDeviceControllerTests: XCTestCase {
         
         let error = captor.value?[EventAttributeName.audioInputError] as? MediaError
         XCTAssertEqual(error, MediaError.overrideOutputAudioPortFailed)
+        
+        let deviceType = captor.value?[EventAttributeName.audioDeviceType] as? String
+        XCTAssertEqual(deviceType, MediaDeviceType.audioBuiltInSpeaker.description)
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/ingestion/DefaultAppStateMonitorTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/ingestion/DefaultAppStateMonitorTests.swift
@@ -214,4 +214,19 @@ final class DefaultAppStateMonitorTests: XCTestCase {
         // Cleanup
         device.isBatteryMonitoringEnabled = originalMonitoringState
     }
+    
+    // MARK: - Low Power Mode Tests
+    
+    func testIsLowPowerModeEnabled_ShouldReturnBooleanValue() {
+        // When
+        let isLowPowerModeEnabled = monitor.isLowPowerModeEnabled()
+        
+        // Then
+        XCTAssertTrue(isLowPowerModeEnabled == true || isLowPowerModeEnabled == false, 
+                     "Low power mode should return a valid boolean value")
+        
+        // Verify it matches the system value
+        XCTAssertEqual(isLowPowerModeEnabled, ProcessInfo.processInfo.isLowPowerModeEnabled,
+                      "Low power mode should match ProcessInfo.processInfo.isLowPowerModeEnabled")
+    }
 }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/ingestion/IngestionEventConverterTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/ingestion/IngestionEventConverterTests.swift
@@ -28,7 +28,11 @@ class IngestionEventConverterTests: CommonTestCase {
             EventAttributeName.appState: AppState.background,
             EventAttributeName.batteryLevel: 0.5,
             EventAttributeName.batteryState: BatteryState.charging,
-            EventAttributeName.contentShareError: VideoClientFailedError.authenticationFailed
+            EventAttributeName.lowPowerModeEnabled: true,
+            EventAttributeName.contentShareError: VideoClientFailedError.authenticationFailed,
+            EventAttributeName.voiceFocusError: VoiceFocusError.audioClientError,
+            EventAttributeName.audioDeviceType: MediaDeviceType.audioBluetooth.description,
+            EventAttributeName.videoDeviceType: MediaDeviceType.videoBackCamera.description
         ])
         let result = converter.toIngestionMeetingEvent(event: event,
                                                        ingestionConfiguration: ingestionConfiguration)
@@ -39,7 +43,11 @@ class IngestionEventConverterTests: CommonTestCase {
         XCTAssertEqual(result.getAppState(), String(describing: AppState.background))
         XCTAssertEqual(result.getBatteryLevel(), 0.5)
         XCTAssertEqual(result.getBatteryState(), String(describing: BatteryState.charging))
+        XCTAssertEqual(result.isLowPowerModeEnabled(), true)
         XCTAssertEqual(result.getContentShareErrorMessage(), String(describing: VideoClientFailedError.authenticationFailed))
+        XCTAssertEqual(result.getVoiceFocusErrorMessage(), String(describing: VoiceFocusError.audioClientError))
+        XCTAssertEqual(result.getAudioDeviceType(), String(describing: MediaDeviceType.audioBluetooth.description))
+        XCTAssertEqual(result.getVideoDeviceType(), String(describing: MediaDeviceType.videoBackCamera.description))
     }
     
     func testToIngestionRecord_ShouldReturnAttributes_IfExists() {
@@ -49,7 +57,11 @@ class IngestionEventConverterTests: CommonTestCase {
             EventAttributeName.videoInputError.description: AnyCodable(String(describing: TestError.videoInputError)),
             EventAttributeName.signalingDroppedError.description: AnyCodable(String(describing: TestError.signalingDroppedError)),
             EventAttributeName.appState.description: AnyCodable(String(describing: AppState.background)),
-            EventAttributeName.contentShareError.description: AnyCodable(String(describing: VideoClientFailedError.authenticationFailed))
+            EventAttributeName.lowPowerModeEnabled.description: AnyCodable(true),
+            EventAttributeName.contentShareError.description: AnyCodable(String(describing: VideoClientFailedError.authenticationFailed)),
+            EventAttributeName.voiceFocusError.description: AnyCodable(String(describing: VoiceFocusError.audioClientError)),
+            EventAttributeName.audioDeviceType.description: AnyCodable(String(describing: MediaDeviceType.audioBluetooth.description)),
+            EventAttributeName.videoDeviceType.description: AnyCodable(String(describing: MediaDeviceType.videoBackCamera.description))
         ])
         let meetingEvent = MeetingEventItem(id: "test", data: ingestionMeetingEvent)
         let results = converter.toIngestionRecord(meetingEvents: [meetingEvent],
@@ -65,5 +77,17 @@ class IngestionEventConverterTests: CommonTestCase {
         
         let appStateStr = results.events.first!.payloads.first!.appState
         XCTAssertEqual(appStateStr, String(describing: AppState.background))
+        
+        let voiceFocusErrorMessage = results.events.first!.payloads.first!.voiceFocusErrorMessage
+        XCTAssertEqual(voiceFocusErrorMessage, String(describing: VoiceFocusError.audioClientError))
+        
+        let audioDeviceType = results.events.first!.payloads.first!.audioDeviceType
+        XCTAssertEqual(audioDeviceType, String(describing: MediaDeviceType.audioBluetooth))
+        
+        let videoDeviceType = results.events.first!.payloads.first!.videoDeviceType
+        XCTAssertEqual(videoDeviceType, String(describing: MediaDeviceType.videoBackCamera))
+        
+        let lowPowerModeEnabled = results.events.first!.payloads.first!.lowPowerModeEnabled
+        XCTAssertTrue(lowPowerModeEnabled ?? false)
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDKTests/ingestion/VoiceFocusErrorTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/ingestion/VoiceFocusErrorTests.swift
@@ -1,0 +1,28 @@
+//
+//  VoiceFocusErrorTests.swift
+//  AmazonChimeSDK
+//
+//  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//  SPDX-License-Identifier: Apache-2.0
+//
+
+@testable import AmazonChimeSDK
+import XCTest
+
+class VoiceFocusErrorTests: XCTestCase {
+    
+    func testInitFromXalErrorShouldReturnMatchingError() {
+        XCTAssertEqual(VoiceFocusError.init(from: 1), VoiceFocusError.audioClientError)
+        XCTAssertEqual(VoiceFocusError.init(from: 6), VoiceFocusError.notInitialized)
+        XCTAssertEqual(VoiceFocusError.init(from: 19), VoiceFocusError.setParamFailed)
+        XCTAssertEqual(VoiceFocusError.init(from: 99), VoiceFocusError.other)
+    }
+    
+    func testDescriptionShouldMatch() {
+        XCTAssertEqual(VoiceFocusError.audioClientNotStarted.description, "audioClientNotStarted")
+        XCTAssertEqual(VoiceFocusError.audioClientError.description, "audioClientError")
+        XCTAssertEqual(VoiceFocusError.setParamFailed.description, "setParamFailed")
+        XCTAssertEqual(VoiceFocusError.notInitialized.description, "notInitialized")
+        XCTAssertEqual(VoiceFocusError.other.description, "other")
+    }
+}

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientControllerTests.swift
@@ -388,6 +388,10 @@ class DefaultAudioClientControllerTests: CommonTestCase {
 
         XCTAssertTrue(defaultAudioClientController.setVoiceFocusEnabled(enabled: false))
         verify(audioClientMock.setBliteNSSelected(false)).wasCalled()
+        
+        verify(eventAnalyticsControllerMock.publishEvent(name: EventName.voiceFocusEnabled,
+                                                         attributes: [:],
+                                                         notifyObservers: false)).wasCalled()
     }
 
     func testSetVoiceFocusEnabled_failure_audioClientNotStarted() {
@@ -398,6 +402,15 @@ class DefaultAudioClientControllerTests: CommonTestCase {
 
         XCTAssertFalse(defaultAudioClientController.setVoiceFocusEnabled(enabled: false))
         verify(audioClientMock.setBliteNSSelected(any())).wasNeverCalled()
+        
+        let eventAttributeCaptor = ArgumentCaptor<[AnyHashable: Any]>()
+        
+        verify(eventAnalyticsControllerMock.publishEvent(name: EventName.voiceFocusEnableFailed,
+                                                         attributes: eventAttributeCaptor.any(),
+                                                         notifyObservers: false)).wasCalled()
+        
+        let error = eventAttributeCaptor.value?[EventAttributeName.voiceFocusError] as? VoiceFocusError
+        XCTAssertEqual(error, VoiceFocusError.audioClientNotStarted)
     }
 
     func testSetVoiceFocusEnabled_failure_mediaFailure() {
@@ -410,6 +423,15 @@ class DefaultAudioClientControllerTests: CommonTestCase {
 
         XCTAssertFalse(defaultAudioClientController.setVoiceFocusEnabled(enabled: false))
         verify(audioClientMock.setBliteNSSelected(false)).wasCalled()
+        
+        let eventAttributeCaptor = ArgumentCaptor<[AnyHashable: Any]>()
+        
+        verify(eventAnalyticsControllerMock.publishEvent(name: EventName.voiceFocusEnableFailed,
+                                                         attributes: eventAttributeCaptor.any(),
+                                                         notifyObservers: false)).wasCalled()
+        
+        let error = eventAttributeCaptor.value?[EventAttributeName.voiceFocusError] as? VoiceFocusError
+        XCTAssertEqual(error, VoiceFocusError.audioClientError)
     }
 
     func testIsVoiceFocusEnabled_success() {

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/utils/ConvertersTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/utils/ConvertersTests.swift
@@ -314,6 +314,22 @@ class ConvertersTests: XCTestCase {
                        MeetingHistoryEventName.contentShareStopped)
         XCTAssertEqual(Converters.MeetingEventName.toMeetingHistoryEventName(name: EventName.contentShareFailed),
                        MeetingHistoryEventName.contentShareFailed)
+        XCTAssertEqual(Converters.MeetingEventName.toMeetingHistoryEventName(name: EventName.appStateChanged),
+                       MeetingHistoryEventName.appStateChanged)
+        XCTAssertEqual(Converters.MeetingEventName.toMeetingHistoryEventName(name: EventName.appMemoryLow),
+                       MeetingHistoryEventName.appMemoryLow)
+        XCTAssertEqual(Converters.MeetingEventName.toMeetingHistoryEventName(name: EventName.voiceFocusEnabled),
+                       MeetingHistoryEventName.voiceFocusEnabled)
+        XCTAssertEqual(Converters.MeetingEventName.toMeetingHistoryEventName(name: EventName.voiceFocusDisabled),
+                       MeetingHistoryEventName.voiceFocusDisabled)
+        XCTAssertEqual(Converters.MeetingEventName.toMeetingHistoryEventName(name: EventName.voiceFocusEnableFailed),
+                       MeetingHistoryEventName.voiceFocusEnableFailed)
+        XCTAssertEqual(Converters.MeetingEventName.toMeetingHistoryEventName(name: EventName.voiceFocusDisableFailed),
+                       MeetingHistoryEventName.voiceFocusDisableFailed)
+        XCTAssertEqual(Converters.MeetingEventName.toMeetingHistoryEventName(name: EventName.audioInputSelected),
+                       MeetingHistoryEventName.audioInputSelected)
+        XCTAssertEqual(Converters.MeetingEventName.toMeetingHistoryEventName(name: EventName.videoInputSelected),
+                       MeetingHistoryEventName.videoInputSelected)
         XCTAssertEqual(Converters.MeetingEventName.toMeetingHistoryEventName(name: EventName.unknown),
                        MeetingHistoryEventName.unknown)
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## PENDING
 
 ### Added
-* Added meetingReconnected/audioInputFailed/signalingDropped/appStateChanged/appMemoryLow/contentShareStartRequested/contentShareStarted/contentShareStopped/contentShareFailed meeting event
-* Added meetingReconnectDurationMs/audioInputErrorMessage/signalingDroppedErrorMessage/appState/batteryLevel/batteryState/contentShareErrorMessage to meeting event attributes
+* Added meetingReconnected/audioInputFailed/signalingDropped/appStateChanged/appMemoryLow/contentShareStartRequested/contentShareStarted/contentShareStopped/contentShareFailed/voiceFocusEnabled/voiceFocusDisabled/voiceFocusEnableFailed/voiceFocusDisableFailed/audioInterruptionBegan/audioInterruptionEnded/videoInterruptionBegan/videoInterruptionEnded meeting events
+* Added meetingReconnectDurationMs/audioInputErrorMessage/signalingDroppedErrorMessage/appState/batteryLevel/batteryState/lowPowerModeEnabled/contentShareErrorMessage/videoInterruptionReason to meeting event attributes
 
 ## [0.27.1] - 2025-03-28
 

--- a/guides/meeting_events.md
+++ b/guides/meeting_events.md
@@ -91,8 +91,6 @@ Chime SDK sends these meeting events.
 |`contentShareStopped`              |The content share stopped.
 |`contentShareFailed`               |The content share failed.
 |`contentShareSignalingDropped`     |The content share client signaling websocket failed or closed with an error.
-|`appStateChanged`                  |The application state is changed.
-|`appMemoryLow`                     |The application memory is low.
 
 ### Common attributes
 Chime SDK stores common attributes for builders to identify/filter events.
@@ -139,7 +137,7 @@ The following table describes attributes for a meeting.
 |`appState`|The current app state when the event occurs.| All events
 |`batteryLevel`|The current battery level when the event occurs.| All events
 |`batteryState`|The current battery state when the event occurs.| All events
-
+|`lowPowerModeEnabled`|Whether low power mode is enabled.| All events
 
 ### Device attributes
 The following table describes attributes for the microphone and camera.
@@ -147,6 +145,10 @@ The following table describes attributes for the microphone and camera.
 |--|--|--
 |`audioInputErrorMessage`|The error message that explains why the microphone selection or access failed.|`audioInputFailed`
 |`videoInputErrorMessage`|The error that explains why the camera selection or access failed.|`videoInputFailed`
+|`voiceFocusError`|The error message explaining why enabling or disabling Voice Focus failed.| `voiceFocusEnableFailed`, `voiceFocusDisableFailed`
+|`audioDeviceType`|The selected audio input device.| `audioInputSelected`
+|`videoDeviceType`|The selected video input device.| `videoInputSelected`
+|`videoInterruptionReason`|The reason explaning why the video is interrupted.| `videoInterruptionBegan`
 ### The meeting history attribute
 The meeting history attribute is a list of states. Each state object contains the state name and timestamp.
 
@@ -181,24 +183,32 @@ before sending it to your server application or analytics tool.
 The following table lists available states.
 |State|Description
 |--|--
-|`meetingEnded`                     |The meeting ended.
-|`meetingFailed`                    |The meeting ended with the failure status.
-|`meetingReconnected`               |The meeting reconnected.
-|`meetingStartFailed`               |The meeting failed to start.
-|`meetingStartRequested`            |The meeting will start.
-|`meetingStartSucceeded`            |The meeting started.
-|`audioInputSelected`               |The microphone was selected.
-|`audioInputFailed`                 |The microphone selection failed.
-|`videoInputSelected`               |The camera was selected.
-|`videoInputFailed`                 |The camera selection failed.
-|`videoClientSignalingDropped`      |The video client signaling websocket failed or closed with an error.
-|`contentShareStartRequested`       |The content share start was requested.
-|`contentShareStarted`              |The content share started successfully.
-|`contentShareStopped`              |The content share stopped.
-|`contentShareFailed`               |The content share failed.
-|`contentShareSignalingDropped`     |The content share client signaling websocket failed or closed with an error.
-|`appStateChanged`                  |The application state is changed.
-|`appMemoryLow`                     |The application memory is low.
+|`meetingEnded`                             |The meeting ended.
+|`meetingFailed`                            |The meeting ended with the failure status.
+|`meetingReconnected`                       |The meeting reconnected.
+|`meetingStartFailed`                       |The meeting failed to start.
+|`meetingStartRequested`                    |The meeting will start.
+|`meetingStartSucceeded`                    |The meeting started.
+|`audioInputSelected`                       |The microphone was selected.
+|`audioInputFailed`                         |The microphone selection failed.
+|`videoInputSelected`                       |The camera was selected.
+|`videoInputFailed`                         |The camera selection failed.
+|`videoClientSignalingDropped`              |The video client signaling websocket failed or closed with an error.
+|`contentShareStartRequested`               |The content share start was requested.
+|`contentShareStarted`                      |The content share started successfully.
+|`contentShareStopped`                      |The content share stopped.
+|`contentShareFailed`                       |The content share failed.
+|`contentShareSignalingDropped`             |The content share client signaling websocket failed or closed with an error.
+|`appStateChanged`                          |The application state is changed.
+|`appMemoryLow`                             |The application memory is low.
+|`voiceFocusEnabled`                        |The voice focus is enabled.
+|`voiceFocusDisabled`                       |The voice focus is disabled.
+|`voiceFocusEnableFailed`                   |The voice focus failed to enable.
+|`voiceFocusDisableFailed`                  |The voice focus failed to disable.
+|`audioInterruptionBegan`                   |Audio interruption began.
+|`audioInterruptionEnded`                   |Audio interruption ended.
+|`videoInterruptionBegan`                   |Video interruption began.
+|`videoInterruptionEnded`                   |Video interruption ended.
 
 ## Example
 


### PR DESCRIPTION
## ℹ️ Description
 - Added meeting events: audioInputSelected/videoInputSelected/voiceFocusEnabled/voiceFocusDisabled/voiceFocusEnableFailed/voiceFocusDisableFailed/audioInterruptionBegan/audioInterruptionEnded/videoInterruptionBegan/videoInterruptionEnded
 - Added meeting attributes: voiceFocusError/audioDeviceType/videoDeviceType/lowPowerModeEnabled/videoInterruptionReason

### Issue #, if available

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
    - [ ] README update
    - [x] CHANGELOG update
    - [x] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
 - Manually tested with demo 

### Additional Manual Test
- [x] Pause and resume remote video
- [x] Switch local camera
- [x] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [x] Unit tests pass
- [x] Build SDK against simulator with release options
- [x] Build SDK against device with release options
- [x] Build SDK against simulator with debug options
- [x] Build SDK against device with debug options
- [x] Test Demo against simulator with SDK (debug build) in workspace
- [x] Test Demo against device with SDK (debug build) in workspace
- [x] Test DemoObjC against simulator with SDK (debug build) in workspace
- [x] Test DemoObjC against device with SDK (debug build) in workspace
- [x] Test Demo against simulator with SDK.framework (release build)
- [x] Test Demo against device with SDK.framework (release build)
- [x] Test DemoObjC against simulator with SDK.framework (release build)
- [x] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
