### PR TITLE
feat: Add audio jitter/RTT metrics and toggle audio output API

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/DefaultAudioVideoFacade.swift
@@ -103,6 +103,14 @@ import Foundation
         return realtimeController.realtimeLocalUnmute()
     }
 
+    public func realtimePlaybackMute() -> Bool {
+        return realtimeController.realtimePlaybackMute()
+    }
+
+    public func realtimePlaybackUnmute() -> Bool {
+        return realtimeController.realtimePlaybackUnmute()
+    }
+
     public func addRealtimeObserver(observer: RealtimeObserver) {
         realtimeController.addRealtimeObserver(observer: observer)
     }

--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/metric/ObservableMetric.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/metric/ObservableMetric.swift
@@ -18,6 +18,12 @@ import Foundation
     case audioReceivePacketLossPercent
     /// Percentage of audio packets lost from client to server
     case audioSendPacketLossPercent
+    /// Upstream audio jitter (ms)
+    case audioSendJitterMs
+    /// Downstream audio jitter (ms)
+    case audioReceiveJitterMs
+    /// Audio round-trip time (ms) between client and server
+    case audioRttMs
     /// Estimated uplink bandwidth from perspective of video client
     case videoAvailableSendBandwidth
     /// Estimated downlink bandwidth from perspective of video client
@@ -52,6 +58,12 @@ import Foundation
             return "audioReceivePacketLossPercent"
         case .audioSendPacketLossPercent:
             return "audioSendPacketLossPercent"
+        case .audioSendJitterMs:
+            return "audioSendJitterMs"
+        case .audioReceiveJitterMs:
+            return "audioReceiveJitterMs"
+        case .audioRttMs:
+            return "audioRttMs"
         case .videoAvailableSendBandwidth:
             return "videoAvailableSendBandwidth"
         case .videoAvailableReceiveBandwidth:

--- a/AmazonChimeSDK/AmazonChimeSDK/enums/AudioClientMetric.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/enums/AudioClientMetric.swift
@@ -18,4 +18,7 @@ enum AudioClientMetric: Int {
     case clientSpkMaxJitterMs = 6
     case clientPostJbSpk1sPacketsLostPercent = 7
     case clientPostJbSpk5sPacketsLostPercent = 8
+    case clientRttMs = 9
+    case serverMicJitterMs = 10
+    case clientSpkJitterMs = 11
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/DefaultAudioClientController.swift
@@ -68,6 +68,14 @@ extension DefaultAudioClientController: AudioClientController {
         }
     }
 
+    public func setPlaybackMute(mute: Bool) -> Bool {
+        if Self.state == .started {
+            return audioClient.setSpeakerMuted(mute) == Int(AUDIO_CLIENT_OK.rawValue)
+        } else {
+            return false
+        }
+    }
+
     // swiftlint:disable function_parameter_count
     public func start(audioFallbackUrl: String,
                       audioHostUrl: String,

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientController.swift
@@ -10,6 +10,7 @@ import Foundation
 
 @objc public protocol AudioClientController {
     func setMute(mute: Bool) -> Bool
+    func setPlaybackMute(mute: Bool) -> Bool
     // swiftlint:disable function_parameter_count
     func start(audioFallbackUrl: String,
                audioHostUrl: String,

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientProtocol.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/audio/protocols/AudioClientProtocol.swift
@@ -40,6 +40,8 @@ import Foundation
 
     func setMicrophoneMuted(_ mute: Bool) -> Int
 
+    func setSpeakerMuted(_ mute: Bool) -> Int
+
     func setPresenter(_ presenter: Bool)
 
     func remoteMute()

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/metric/DefaultClientMetricsCollector.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/metric/DefaultClientMetricsCollector.swift
@@ -33,6 +33,12 @@ extension DefaultClientMetricsCollector: ClientMetricsCollector {
             = metrics[AudioClientMetric.serverPostJbMic1sPacketsLostPercent.rawValue]
         cachedObservableMetrics[ObservableMetric.audioReceivePacketLossPercent]
             = metrics[AudioClientMetric.clientPostJbSpk1sPacketsLostPercent.rawValue]
+        cachedObservableMetrics[ObservableMetric.audioSendJitterMs]
+            = metrics[AudioClientMetric.serverMicJitterMs.rawValue]
+        cachedObservableMetrics[ObservableMetric.audioReceiveJitterMs]
+            = metrics[AudioClientMetric.clientSpkJitterMs.rawValue]
+        cachedObservableMetrics[ObservableMetric.audioRttMs]
+            = metrics[AudioClientMetric.clientRttMs.rawValue]
         maybeEmitMetrics()
     }
 

--- a/AmazonChimeSDK/AmazonChimeSDK/realtime/DefaultRealtimeController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/realtime/DefaultRealtimeController.swift
@@ -29,6 +29,14 @@ import Foundation
         return audioClientController.setMute(mute: false)
     }
 
+    public func realtimePlaybackMute() -> Bool {
+        return audioClientController.setPlaybackMute(mute: true)
+    }
+
+    public func realtimePlaybackUnmute() -> Bool {
+        return audioClientController.setPlaybackMute(mute: false)
+    }
+
     public func addRealtimeObserver(observer: RealtimeObserver) {
         audioClientObserver.subscribeToRealTimeEvents(observer: observer)
     }

--- a/AmazonChimeSDK/AmazonChimeSDK/realtime/RealtimeControllerFacade.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/realtime/RealtimeControllerFacade.swift
@@ -27,6 +27,16 @@ import Foundation
     /// - Returns: Whether unmute was successful
     func realtimeLocalUnmute() -> Bool
 
+    /// Mutes the audio output
+    ///
+    /// - Returns: Whether mute was successful
+    func realtimePlaybackMute() -> Bool
+
+    /// Unmutes the audio output
+    ///
+    /// - Returns: Whether unmute was successful
+    func realtimePlaybackUnmute() -> Bool
+
     /// Subscribes to real time events with an observer
     ///
     /// - Parameter observer: Observer that handles real time events

--- a/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/DefaultAudioVideoFacadeTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/audiovideo/DefaultAudioVideoFacadeTests.swift
@@ -102,6 +102,24 @@ class DefaultAudioVideoFacadeTests: CommonTestCase {
         verify(audioVideoControllerMock.startLocalVideo(source: cameraCaptureSourceMock, config: config)).wasCalled()
     }
 
+    func testRealtimePlaybackMute() {
+        given(realtimeControllerMock.realtimePlaybackMute()).willReturn(true)
+
+        let result = defaultAudioVideoFacade.realtimePlaybackMute()
+
+        XCTAssertTrue(result)
+        verify(realtimeControllerMock.realtimePlaybackMute()).wasCalled()
+    }
+
+    func testRealtimePlaybackUnmute() {
+        given(realtimeControllerMock.realtimePlaybackUnmute()).willReturn(true)
+
+        let result = defaultAudioVideoFacade.realtimePlaybackUnmute()
+
+        XCTAssertTrue(result)
+        verify(realtimeControllerMock.realtimePlaybackUnmute()).wasCalled()
+    }
+
     func testStartContentShare() {
         let source = ContentShareSource()
         defaultAudioVideoFacade.startContentShare(source: source)

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModel.swift
@@ -97,6 +97,8 @@ class MeetingModel: NSObject {
         }
     }
 
+    private(set) var isPlaybackMuted = false
+
     private var isEnded = false {
         didSet {
             // This will unbind current tiles.
@@ -187,6 +189,20 @@ class MeetingModel: NSObject {
             CallKitManager.shared().setMuted(for: call, isMuted: isMuted)
         } else {
             self.isMuted = isMuted
+        }
+    }
+
+    func togglePlaybackMute() {
+        if isPlaybackMuted {
+            if currentMeetingSession.audioVideo.realtimePlaybackUnmute() {
+                isPlaybackMuted = false
+                notify(msg: "Playback unmuted")
+            }
+        } else {
+            if currentMeetingSession.audioVideo.realtimePlaybackMute() {
+                isPlaybackMuted = true
+                notify(msg: "Playback muted")
+            }
         }
     }
 

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModule.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModule.swift
@@ -252,8 +252,13 @@ class MeetingModule {
         let audioSession = AVAudioSession.sharedInstance()
         do {
             if audioSession.category != .playAndRecord {
+                #if compiler(>=6.2)
                 try audioSession.setCategory(AVAudioSession.Category.playAndRecord,
-                                             options: AVAudioSession.CategoryOptions.allowBluetooth)
+                                             options: .allowBluetoothHFP)
+                #else
+                try audioSession.setCategory(AVAudioSession.Category.playAndRecord,
+                                             options: .allowBluetooth)
+                #endif
                 try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
             }
             if audioSession.mode != .voiceChat {

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -484,6 +484,15 @@ class MeetingViewController: UIViewController {
             optionMenu.addAction(liveTranscriptionAction)
         }
 
+        let isPlaybackMuted = meetingModel.isPlaybackMuted
+        let playbackMuteTitle = isPlaybackMuted ? "Unmute Playback" : "Mute Playback"
+        let playbackMuteAction = UIAlertAction(title: playbackMuteTitle,
+                                               style: .default,
+                                               handler: { _ in
+                                                  meetingModel.togglePlaybackMute()
+                                               })
+        optionMenu.addAction(playbackMuteAction)
+
         let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
         optionMenu.addAction(cancelAction)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+
+### Added
+* Added `audioSendJitterMs`, `audioReceiveJitterMs`, and `audioRttMs` to `ObservableMetric` for audio quality monitoring
+* Added `realtimePlaybackMute()` and `realtimePlaybackUnmute()` to `RealtimeControllerFacade` for muting/unmuting audio output
+
 ## [0.27.2] - 2025-12-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -361,12 +361,22 @@ meetingSession.audioVideo.start(audioVideoConfiguration) // starts the audio vid
 
 > Note: So far, you've added observers to receive device and session lifecycle events. In the following use cases, you'll use the real-time API methods to send and receive volume indicators and control mute state.
 
-#### Use case 9. Mute and unmute an audio input.
+#### Use case 9. Mute and unmute audio input and output.
+
+To mute and unmute audio input:
 
 ```swift
 let muted = meetingSession.audioVideo.realtimeLocalMute() // returns true if muted, false if failed
 
-let unmuted = meetingSession.audioVideo.realtimeLocalUnmute // returns true if unmuted, false if failed
+let unmuted = meetingSession.audioVideo.realtimeLocalUnmute() // returns true if unmuted, false if failed
+```
+
+To mute and unmute audio playback (output):
+
+```swift
+let muted = meetingSession.audioVideo.realtimePlaybackMute() // returns true if muted, false if failed
+
+let unmuted = meetingSession.audioVideo.realtimePlaybackUnmute() // returns true if unmuted, false if failed
 ```
 
 #### Use case 10. Add an observer to observe realtime events such as volume changes/signal change/muted status of a specific attendee.


### PR DESCRIPTION
## ℹ️ Description
 - Add audioSendJitterMs, audioReceiveJitterMs, and audioRttMs to ObservableMetric and wire them through DefaultClientMetricsCollector from the corresponding AudioClientMetric indices.

 - Add realtimeLocalMuteOutput/realtimeLocalUnmuteOutput to RealtimeControllerFacade, backed by a new setOutputMute method on AudioClientController that calls setSpeakerMuted on the ObjC bridge.

### Issue #, if available

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
    - [x] README update
    - [x] CHANGELOG update
    - [x] guides update
- [x] This change requires a dependency update
    - [x] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
 - Manually tested the changes with the demo app

### Additional Manual Test
- [x] Pause and resume remote video
- [x] Switch local camera
- [x] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
