### PR TITLE
fix(video): Adopt AmazonChimeSDKMedia removal of setSimulcast and dea…

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/LocalVideoConfiguration.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/audiovideo/video/LocalVideoConfiguration.swift
@@ -13,7 +13,8 @@ import Foundation
 
     /// The flag to disable/enable simulcast, default to true
     /// For local video use only, will not work for content share
-    public var simulcastEnabled: Bool
+    @available(*, deprecated, message: "Simulcast is enabled by default and this flag no longer has any effect.")
+    public var simulcastEnabled: Bool = true
 
     /// The max bit rate for video encoding, should be greater than 0
     /// Actual quality achieved may vary throughout the call depending on what system and network can provide
@@ -21,7 +22,6 @@ import Foundation
 
     public init(maxBitRateKbps: UInt32 = 0, simulcastEnabled: Bool = true) {
         self.maxBitRateKbps = maxBitRateKbps
-        self.simulcastEnabled = simulcastEnabled
         super.init()
     }
 }

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/DefaultContentShareVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/DefaultContentShareVideoClientController.swift
@@ -23,8 +23,6 @@ import Foundation
         let config = VideoConfiguration()
         config.isUsing16by9AspectRatio = true
         config.isUsingPixelBufferRenderer = true
-        // isUsingSendSideBwe and isDisablingSimulcastP2P were removed from VideoConfiguration
-        // in tincan 717a66d24 (dead config); behavior is now the built-in default.
         config.isContentShare = true
         config.isUsingInbandTurnCreds = true
         return config

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/DefaultContentShareVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/contentshare/DefaultContentShareVideoClientController.swift
@@ -22,9 +22,9 @@ import Foundation
     private let videoConfig: VideoConfiguration = {
         let config = VideoConfiguration()
         config.isUsing16by9AspectRatio = true
-        config.isUsingSendSideBwe = true
-        config.isDisablingSimulcastP2P = true
         config.isUsingPixelBufferRenderer = true
+        // isUsingSendSideBwe and isDisablingSimulcastP2P were removed from VideoConfiguration
+        // in tincan 717a66d24 (dead config); behavior is now the built-in default.
         config.isContentShare = true
         config.isUsingInbandTurnCreds = true
         return config

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
@@ -96,12 +96,12 @@ class DefaultVideoClientController: NSObject {
 
         let videoConfig: VideoConfiguration = VideoConfiguration()
         videoConfig.isUsing16by9AspectRatio = true
-        videoConfig.isUsingSendSideBwe = true
-        videoConfig.isDisablingSimulcastP2P = true
         videoConfig.isUsingPixelBufferRenderer = true
-        videoConfig.isUsingOptimizedTwoSimulcastStreamTable = true
         videoConfig.isExcludeSelfContentInIndex = true
         videoConfig.isUsingInbandTurnCreds = true
+        // isUsingSendSideBwe, isDisablingSimulcastP2P and isUsingOptimizedTwoSimulcastStreamTable
+        // were removed from VideoConfiguration in tincan 717a66d24 (dead config); these behaviors
+        // are now built-in defaults (optimized uplink policy / send-side BWE / HW accel).
 
         // Default to idle mode, no video but signaling connection is
         // established for messaging
@@ -433,9 +433,9 @@ extension DefaultVideoClientController: VideoClientController {
         videoClient?.setExternalVideoSource(videoSourceAdapter)
         videoClient?.setSending(true)
 
-        let simulcastEnabled = config.simulcastEnabled
-        logger.info(msg: "Setting simulcast")
-        videoClient?.setSimulcast(simulcastEnabled)
+        // setSimulcast was removed from VideoClient in tincan 717a66d24; simulcast is now
+        // managed by the client's built-in optimized uplink policy. LocalVideoConfiguration
+        // .simulcastEnabled is retained for source compatibility but no longer has an effect.
 
         if (config.maxBitRateKbps > 0) {
             logger.info(msg: "Setting max bit rate in kbps for local video")

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
@@ -99,9 +99,6 @@ class DefaultVideoClientController: NSObject {
         videoConfig.isUsingPixelBufferRenderer = true
         videoConfig.isExcludeSelfContentInIndex = true
         videoConfig.isUsingInbandTurnCreds = true
-        // isUsingSendSideBwe, isDisablingSimulcastP2P and isUsingOptimizedTwoSimulcastStreamTable
-        // were removed from VideoConfiguration in tincan 717a66d24 (dead config); these behaviors
-        // are now built-in defaults (optimized uplink policy / send-side BWE / HW accel).
 
         // Default to idle mode, no video but signaling connection is
         // established for messaging
@@ -432,10 +429,6 @@ extension DefaultVideoClientController: VideoClientController {
         videoSourceAdapter.source = source
         videoClient?.setExternalVideoSource(videoSourceAdapter)
         videoClient?.setSending(true)
-
-        // setSimulcast was removed from VideoClient in tincan 717a66d24; simulcast is now
-        // managed by the client's built-in optimized uplink policy. LocalVideoConfiguration
-        // .simulcastEnabled is retained for source compatibility but no longer has an effect.
 
         if (config.maxBitRateKbps > 0) {
             logger.info(msg: "Setting max bit rate in kbps for local video")

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientProtocol.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientProtocol.swift
@@ -51,7 +51,9 @@ import Foundation
 
     func demoteFromPrimaryMeeting()
 
-    func setSimulcast(_ simulcast: Bool)
+    // setSimulcast was removed from VideoClient in tincan 717a66d24 ("Remove dead
+    // uplink-policy and codec config"); simulcast now runs via the built-in optimized
+    // uplink policy by default, so it is no longer part of this protocol.
 
     func setMaxBitRateKbps(_ maxBitRate: UInt32)
 

--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientProtocol.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/VideoClientProtocol.swift
@@ -51,10 +51,6 @@ import Foundation
 
     func demoteFromPrimaryMeeting()
 
-    // setSimulcast was removed from VideoClient in tincan 717a66d24 ("Remove dead
-    // uplink-policy and codec config"); simulcast now runs via the built-in optimized
-    // uplink policy by default, so it is no longer part of this protocol.
-
     func setMaxBitRateKbps(_ maxBitRate: UInt32)
 
     func setContentMaxResolutionUHD(_ isContentMaxResolutionUHD: Bool)

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/video/DefaultVideoClientControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/video/DefaultVideoClientControllerTests.swift
@@ -137,7 +137,6 @@ class DefaultVideoClientControllerTests: CommonTestCase {
 
         verify(videoClientMock.setExternalVideoSource(any())).wasCalled()
         verify(videoClientMock.setSending(true)).wasCalled()
-        verify(videoClientMock.setSimulcast(true)).wasCalled()
         verify(videoClientMock.setMaxBitRateKbps(300)).wasCalled()
     }
 
@@ -156,7 +155,6 @@ class DefaultVideoClientControllerTests: CommonTestCase {
 
         verify(videoClientMock.setExternalVideoSource(any())).wasCalled()
         verify(videoClientMock.setSending(true)).wasCalled()
-        verify(videoClientMock.setSimulcast(true)).wasCalled()
         verify(videoClientMock.setMaxBitRateKbps(300)).wasCalled()
     }
     

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## [Unreleased]
 
 ### Deprecated
-* Deprecated `LocalVideoConfiguration.simulcastEnabled`. Simulcast is now enabled by default and this flag no longer has any effect.
+* Deprecated `LocalVideoConfiguration.simulcastEnabled`. Simulcast is enabled by default and this flag no longer has any effect.
+
+### Removed
+* Removed `setSimulcast` from `VideoClientProtocol` and stopped setting the dead `VideoConfiguration` flags `isUsingSendSideBwe`, `isDisablingSimulcastP2P`, and `isUsingOptimizedTwoSimulcastStreamTable`. These were removed from the media client as dead configuration; the corresponding behaviors (simulcast, send-side bandwidth estimation, the optimized uplink policy, and hardware acceleration) are now built-in defaults, so there is no behavior change.
 
 ## [0.27.3] - 2026-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Deprecated `LocalVideoConfiguration.simulcastEnabled`. Simulcast is enabled by default and this flag no longer has any effect.
 
 ### Removed
-* Removed `setSimulcast` from `VideoClientProtocol` and stopped setting the dead `VideoConfiguration` flags `isUsingSendSideBwe`, `isDisablingSimulcastP2P`, and `isUsingOptimizedTwoSimulcastStreamTable`. These were removed from the media client as dead configuration; the corresponding behaviors (simulcast, send-side bandwidth estimation, the optimized uplink policy, and hardware acceleration) are now built-in defaults, so there is no behavior change.
+* Removed `setSimulcast` from `VideoClientProtocol` and unused internal flags.
 
 ## [0.27.3] - 2026-06-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+### Deprecated
+* Deprecated `LocalVideoConfiguration.simulcastEnabled`. Simulcast is now enabled by default and this flag no longer has any effect.
+
 ## [0.27.3] - 2026-06-29
 
 ### Added


### PR DESCRIPTION
…d VideoConfiguration flags

AmazonChimeSDKMedia removed VideoClient.setSimulcast and several VideoConfiguration properties (isUsingSendSideBwe, isDisablingSimulcastP2P, isUsingOptimizedTwoSimulcastStreamTable) as dead configuration with no remaining callers. Those behaviors are now built-in defaults (optimized uplink policy / send-side BWE / hardware acceleration), so the SDK no longer needs to set them.

- Drop setSimulcast from VideoClientProtocol and its call in DefaultVideoClientController.
- Stop setting the removed VideoConfiguration flags in the video and content-share controllers.
- Remove the now-invalid setSimulcast test verifications.

No behavior change against a matching AmazonChimeSDKMedia version: the removed flags were no-ops and the underlying features remain enabled by default. LocalVideoConfiguration.simulcastEnabled is retained for source compatibility (now inert; may be deprecated in a follow-up).

## ℹ️ Description
*provide a summary of the changes and the related issue, relevant motivation and context*

### Issue #, if available

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
