### PR TITLE
fix(tests): Compile unit tests under Xcode 26 / Swift 6.3 strictness

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDKTests/device/DefaultDeviceControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/device/DefaultDeviceControllerTests.swift
@@ -73,12 +73,12 @@ class DefaultDeviceControllerTests: XCTestCase {
         XCTAssertEqual(audioDeviceType, MediaDeviceType.audioBuiltInSpeaker.description)
     }
 
-    func testChooseAudioDevice_nonSpeaker() {
+    func testChooseAudioDevice_nonSpeaker() throws {
         let availableInputs = AVAudioSession.sharedInstance().availableInputs
         let nonSpeakerDevice = MediaDevice.fromAVSessionPort(port: (availableInputs?[0])!)
         defaultDeviceController.chooseAudioDevice(mediaDevice: nonSpeakerDevice)
 
-        verify(audioSessionMock.setPreferredInput(nonSpeakerDevice.port)).wasCalled()
+        try verify(audioSessionMock.setPreferredInput(nonSpeakerDevice.port)).wasCalled()
         
         let captor = ArgumentCaptor<[AnyHashable: Any]>()
         verify(eventAnalyticsControllerMock.publishEvent(name: .audioInputSelected,

--- a/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientControllerTests.swift
+++ b/AmazonChimeSDK/AmazonChimeSDKTests/internal/audio/DefaultAudioClientControllerTests.swift
@@ -40,21 +40,21 @@ class DefaultAudioClientControllerTests: CommonTestCase {
         given(meetingStatsCollectorMock.getMeetingStats()).will { [AnyHashable: Any]() }
 
         given(audioSessionMock.getRecordPermission()).willReturn(.granted)
-        given(audioClientMock.startSession(any(),
-                                           basePort: any(),
-                                           callId: any(),
-                                           profileId: any(),
-                                           microphoneMute: any(),
-                                           speakerMute: any(),
-                                           isPresenter: any(),
-                                           sessionToken: any(),
-                                           audioWsUrl: any(),
-                                           callKitEnabled: any(),
-                                           appInfo: any(),
-                                           audioMode: any(),
-                                           audioDeviceCapabilities: any(),
-                                           enableAudioRedundancy: any(),
-                                           reconnectTimeoutMs: any())).willReturn(AUDIO_CLIENT_OK)
+        given(audioClientMock.startSession(any(String.self),
+                                           basePort: any(Int.self),
+                                           callId: any(String.self),
+                                           profileId: any(String.self),
+                                           microphoneMute: any(Bool.self),
+                                           speakerMute: any(Bool.self),
+                                           isPresenter: any(Bool.self),
+                                           sessionToken: any(String.self),
+                                           audioWsUrl: any(String.self),
+                                           callKitEnabled: any(Bool.self),
+                                           appInfo: any(AppInfo.self),
+                                           audioMode: any(AudioModeInternal.self),
+                                           audioDeviceCapabilities: any(AudioDeviceCapabilitiesInternal.self),
+                                           enableAudioRedundancy: any(Bool.self),
+                                           reconnectTimeoutMs: any(Int.self))).willReturn(AUDIO_CLIENT_OK)
 
         defaultAudioClientController = DefaultAudioClientController(audioClient: audioClientMock,
                                                                     audioClientObserver: audioClientObserverMock,
@@ -328,21 +328,21 @@ class DefaultAudioClientControllerTests: CommonTestCase {
 
     func testStart_failedToStart() {
         DefaultAudioClientController.state = .initialized
-        given(audioClientMock.startSession(any(),
-                                           basePort: any(),
-                                           callId: any(),
-                                           profileId: any(),
-                                           microphoneMute: any(),
-                                           speakerMute: any(),
-                                           isPresenter: any(),
-                                           sessionToken: any(),
-                                           audioWsUrl: any(),
-                                           callKitEnabled: any(),
-                                           appInfo: any(),
-                                           audioMode: any(),
-                                           audioDeviceCapabilities: any(),
-                                           enableAudioRedundancy: any(),
-                                           reconnectTimeoutMs: any())).willReturn(AUDIO_CLIENT_ERR)
+        given(audioClientMock.startSession(any(String.self),
+                                           basePort: any(Int.self),
+                                           callId: any(String.self),
+                                           profileId: any(String.self),
+                                           microphoneMute: any(Bool.self),
+                                           speakerMute: any(Bool.self),
+                                           isPresenter: any(Bool.self),
+                                           sessionToken: any(String.self),
+                                           audioWsUrl: any(String.self),
+                                           callKitEnabled: any(Bool.self),
+                                           appInfo: any(AppInfo.self),
+                                           audioMode: any(AudioModeInternal.self),
+                                           audioDeviceCapabilities: any(AudioDeviceCapabilitiesInternal.self),
+                                           enableAudioRedundancy: any(Bool.self),
+                                           reconnectTimeoutMs: any(Int.self))).willReturn(AUDIO_CLIENT_ERR)
         given(audioClientObserverMock.audioStatus).willReturn(.ok)
         
 


### PR DESCRIPTION
## ℹ️ Description

The unit test target no longer compiles with Swift 6.3, which blocks running the suite on any machine with a current Xcode. Two unrelated causes, both fixed here with type information only — no assertion or behavior changes, and both changes remain valid on older toolchains.

**1. `DefaultDeviceControllerTests.swift`** — `AudioSession.setPreferredInput` is declared `throws`, so Mockingbird generates a throwing mockable and `verify()` is `rethrows`. Swift 6.3 requires the call to be marked with `try` and the test method to propagate it:

```
error: call can throw but is not marked with 'try'
    verify(audioSessionMock.setPreferredInput(nonSpeakerDevice.port)).wasCalled()
```

**2. `DefaultAudioClientControllerTests.swift`** — both `given(audioClientMock.startSession(...))` stubs fail with:

```
error: the compiler is unable to type-check this expression in reasonable time;
       try breaking up the expression into distinct sub-expressions
```

`startSession` has two 15-parameter overloads (the implementation taking `String!`, the generated mockable taking `@autoclosure () -> String`), and `any()` has several overloads of its own, so 15 unconstrained matchers give the constraint solver a large search space. Passing the type explicitly to each matcher (`any(String.self)`, `any(Int.self)`, …) removes the inference.

Note that raising `-solver-expression-time-threshold` does *not* help here — the cost is overload resolution, not per-expression time.

### Issue #, if available

N/A

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?

Ran the full unit test suite on Xcode 26.6 (Swift 6.3, Apple Silicon) against the iOS 26.5 simulator:

```
xcodebuild test -project AmazonChimeSDK.xcodeproj -scheme AmazonChimeSDK \
  -destination 'platform=iOS Simulator,name=iPhone 17' \
  -skip-testing:"AmazonChimeSDKTests/SchedulerTests" -enableCodeCoverage YES
```

`** TEST SUCCEEDED **`. Reverting either change reproduces the corresponding compile error.

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available

N/A — test-only change, no UI impact.

## ✅ Checklist
#### Integration validation (required before release)

- [x] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
