### PR TITLE
feat(demo): Add Enable Higher Definition video controls

### DIFF
--- a/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
+++ b/AmazonChimeSDK/AmazonChimeSDK/internal/video/DefaultVideoClientController.swift
@@ -440,9 +440,7 @@ extension DefaultVideoClientController: VideoClientController {
         if (config.maxBitRateKbps > 0) {
             logger.info(msg: "Setting max bit rate in kbps for local video")
             videoClient?.setMaxBitRateKbps(config.maxBitRateKbps)
-        }
-
-        if (self.configuration.meetingFeatures.videoMaxResolution == VideoResolution.videoResolutionFHD) {
+        } else if (self.configuration.meetingFeatures.videoMaxResolution == VideoResolution.videoResolutionFHD) {
             logger.info(msg: "Setting max bit rate in kbps for local video FHD (2500kbps)")
             videoClient?.setMaxBitRateKbps(VideoBitrateConstants().videoHighResolutionBitrateKbps)
         }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/Base.lproj/Main.storyboard
@@ -1340,6 +1340,17 @@
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits"/>
                             </textField>
+                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="FHD-sw-001">
+                                <rect key="frame" x="64.666666666666686" y="393.66666666666669" width="51" height="31"/>
+                                <accessibility key="accessibilityConfiguration" identifier="FHD Video Switch"/>
+                            </switch>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enable Higher Definition Video" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FHD-lb-001">
+                                <rect key="frame" x="127.66666666666666" y="398.66666666666669" width="238" height="20.666666666666657"/>
+                                <accessibility key="accessibilityConfiguration" identifier="Enable Higher Definition Video Label"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AHd-Vp-rMm">
                                 <rect key="frame" x="189.66666666666666" y="821" width="51" height="41"/>
                                 <accessibility key="accessibilityConfiguration" identifier="Debug Settings Save"/>
@@ -1367,9 +1378,14 @@
                             <constraint firstItem="Dlf-w7-2eY" firstAttribute="centerX" secondItem="F9N-fz-NNe" secondAttribute="centerX" id="mK4-f3-iO1"/>
                             <constraint firstItem="ugh-Cp-DHh" firstAttribute="top" secondItem="Dlf-w7-2eY" secondAttribute="bottom" constant="56" id="oE6-em-IIS"/>
                             <constraint firstItem="AHd-Vp-rMm" firstAttribute="centerX" secondItem="F9N-fz-NNe" secondAttribute="centerX" id="qFv-Dz-fct"/>
+                            <constraint firstItem="FHD-sw-001" firstAttribute="top" secondItem="gob-qw-3MV" secondAttribute="bottom" constant="36" id="FHD-ct-001"/>
+                            <constraint firstItem="FHD-sw-001" firstAttribute="leading" secondItem="gob-qw-3MV" secondAttribute="leading" id="FHD-ct-002"/>
+                            <constraint firstItem="FHD-lb-001" firstAttribute="leading" secondItem="FHD-sw-001" secondAttribute="trailing" constant="12" id="FHD-ct-003"/>
+                            <constraint firstItem="FHD-lb-001" firstAttribute="centerY" secondItem="FHD-sw-001" secondAttribute="centerY" id="FHD-ct-004"/>
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="fhdVideoSwitch" destination="FHD-sw-001" id="FHD-ol-001"/>
                         <outlet property="primaryExternalMeetingIdTextField" destination="gob-qw-3MV" id="8Ta-yH-R6u"/>
                         <outlet property="saveButton" destination="AHd-Vp-rMm" id="wj4-7o-d2P"/>
                         <outlet property="serverEndpointUrlTextField" destination="HWT-wf-Hd8" id="lio-80-fpD"/>

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DebugSettingsModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DebugSettingsModel.swift
@@ -11,4 +11,6 @@ import UIKit
 class DebugSettingsModel: NSObject {
     var endpointUrl: String = ""
     var primaryExternalMeetingId: String = ""
+    // When on, the join request asks the demo backend for FHD video / UHD content features
+    var enableHigherDefinitionVideo: Bool = false
 }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DebugSettingsViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/DebugSettingsViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 class DebugSettingsViewController: UIViewController, UITextFieldDelegate {
     @IBOutlet var serverEndpointUrlTextField: UITextField!
     @IBOutlet var primaryExternalMeetingIdTextField: UITextField!
+    @IBOutlet var fhdVideoSwitch: UISwitch!
     @IBOutlet var saveButton: UIButton!
 
     var model: DebugSettingsModel?
@@ -22,6 +23,7 @@ class DebugSettingsViewController: UIViewController, UITextFieldDelegate {
         serverEndpointUrlTextField.delegate = self
         serverEndpointUrlTextField.text = model?.endpointUrl
         primaryExternalMeetingIdTextField.text = model?.primaryExternalMeetingId
+        fhdVideoSwitch.isOn = model?.enableHigherDefinitionVideo ?? false
     }
 
     @IBAction func saveButtonClicked(_: UIButton) {
@@ -30,6 +32,8 @@ class DebugSettingsViewController: UIViewController, UITextFieldDelegate {
 
         let primaryExternalMeetingId = primaryExternalMeetingIdTextField.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         model?.primaryExternalMeetingId = primaryExternalMeetingId
+
+        model?.enableHigherDefinitionVideo = fhdVideoSwitch.isOn
 
         self.dismiss(animated: true, completion: nil)
     }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/JoiningViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/JoiningViewController.swift
@@ -156,7 +156,8 @@ class JoiningViewController: UIViewController, UITextFieldDelegate {
                                               enableAudioRedundancy: enableAudioRedundancy,
                                               reconnectTimeoutMs: reconnectTimeoutMs,
                                               overriddenEndpoint: debugSettingsModel.endpointUrl,
-                                              primaryExternalMeetingId: debugSettingsModel.primaryExternalMeetingId) { success in
+                                              primaryExternalMeetingId: debugSettingsModel.primaryExternalMeetingId,
+                                              enableHigherDefinitionVideo: debugSettingsModel.enableHigherDefinitionVideo) { success in
             DispatchQueue.main.async {
                 if !success {
                     self.view.hideToast()

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModule.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingModule.swift
@@ -22,6 +22,7 @@ class MeetingModule {
     // These need to be cached in case of primary meeting joins in the future
     var cachedOverriddenEndpoint = ""
     var cachedPrimaryExternalMeetingId = ""
+    var cachedEnableHigherDefinitionVideo = false
 
     static func shared() -> MeetingModule {
         if sharedInstance == nil {
@@ -42,6 +43,7 @@ class MeetingModule {
                         reconnectTimeoutMs: Int,
                         overriddenEndpoint: String,
                         primaryExternalMeetingId: String,
+                        enableHigherDefinitionVideo: Bool,
                         completion: @escaping (Bool) -> Void) {
         requestRecordPermission(audioDeviceCapabilities: audioDeviceCapabilities) { success in
             guard success else {
@@ -50,10 +52,12 @@ class MeetingModule {
             }
             self.cachedOverriddenEndpoint = overriddenEndpoint
             self.cachedPrimaryExternalMeetingId = primaryExternalMeetingId
+            self.cachedEnableHigherDefinitionVideo = enableHigherDefinitionVideo
             JoinRequestService.postJoinRequest(meetingId: meetingId,
                                                name: selfName,
                                                overriddenEndpoint: overriddenEndpoint,
-                                               primaryExternalMeetingId: primaryExternalMeetingId) { joinMeetingResponse in
+                                               primaryExternalMeetingId: primaryExternalMeetingId,
+                                               enableHigherDefinitionVideo: enableHigherDefinitionVideo) { joinMeetingResponse in
                 guard let joinMeetingResponse = joinMeetingResponse else {
                     DispatchQueue.main.async {
                         completion(false)

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/MeetingViewController.swift
@@ -689,7 +689,8 @@ class MeetingViewController: UIViewController {
                 JoinRequestService.postJoinRequest(meetingId: meetingModel.primaryExternalMeetingId,
                                                    name: "promoted-\(meetingModel.selfName)",
                                                    overriddenEndpoint: MeetingModule.shared().cachedOverriddenEndpoint,
-                                                   primaryExternalMeetingId: "") { joinMeetingResponse in
+                                                   primaryExternalMeetingId: "",
+                                                   enableHigherDefinitionVideo: MeetingModule.shared().cachedEnableHigherDefinitionVideo) { joinMeetingResponse in
                     if let joinMeetingResponse = joinMeetingResponse {
                         self.logger.info(msg: "Attempting to promote to primary meeting")
                         let meetingResp = JoinRequestService.getCreateMeetingResponse(from: joinMeetingResponse)
@@ -716,13 +717,14 @@ class MeetingViewController: UIViewController {
         videoConfigAlertController.addTextField { textField in
             textField.keyboardType = .numberPad
             textField.placeholder = "Local Video Max Bitrate in kbps"
+            textField.accessibilityIdentifier = "Local Video Max Bitrate Input"
         }
         let doneAction = UIAlertAction(title: "Done",
                                        style: .default) { [weak videoConfigAlertController] _ in
             guard let textFields = videoConfigAlertController?.textFields else {
                 return
             }
-            let maxBitRateInKbps = UInt32(textFields[0].text ?? "") ?? 0
+            let maxBitRateInKbps = UInt32(textFields[0].text ?? "")
             if let videoModel = self.meetingModel?.videoModel {
                 videoModel.localVideoMaxBitRateKbps = maxBitRateInKbps
                 // if local video is started, restart

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/VideoModel.swift
@@ -67,7 +67,7 @@ class VideoModel: NSObject {
         super.init()
     }
 
-    var localVideoMaxBitRateKbps: UInt32 = 0
+    var localVideoMaxBitRateKbps: UInt32?
 
     var videoTileCount: Int {
         return remoteVideoCountInCurrentPage + 1
@@ -227,13 +227,23 @@ class VideoModel: NSObject {
                         customVideoSource.addVideoSink(sink: self.backgroundReplacementProcessor)
                         customVideoSource = self.backgroundReplacementProcessor
                     }
-                    // customers could set simulcast here
-                    let config = LocalVideoConfiguration(maxBitRateKbps: self.localVideoMaxBitRateKbps)
-                    self.audioVideoFacade.startLocalVideo(source: customVideoSource,
-                                                          config: config)
+                    // customers could set simulcast here. Only pass a LocalVideoConfiguration when a
+                    // max bitrate was actually set; otherwise call the no-config overload (keeps that
+                    // path covered and lets the SDK pick its defaults).
+                    if let maxBitRate = self.localVideoMaxBitRateKbps {
+                        let config = LocalVideoConfiguration(maxBitRateKbps: maxBitRate)
+                        self.audioVideoFacade.startLocalVideo(source: customVideoSource, config: config)
+                    } else {
+                        self.audioVideoFacade.startLocalVideo(source: customVideoSource)
+                    }
                 } else {
                     do {
-                        try self.audioVideoFacade.startLocalVideo()
+                        if let maxBitRate = self.localVideoMaxBitRateKbps {
+                            let config = LocalVideoConfiguration(maxBitRateKbps: maxBitRate)
+                            try self.audioVideoFacade.startLocalVideo(config: config)
+                        } else {
+                            try self.audioVideoFacade.startLocalVideo()
+                        }
                     } catch {
                         self.logger.error(msg: "Error starting local video: \(error.localizedDescription)")
                     }

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo/utils/JoinRequestService.swift
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo/utils/JoinRequestService.swift
@@ -12,16 +12,22 @@ import Foundation
 class JoinRequestService: NSObject {
     static let logger = ConsoleLogger(name: "JoiningRequestService")
 
+    // The demo backend requires a max attendee count to be provided alongside v_rs/c_rs, otherwise it
+    // rejects the join request with "Max attendee count must be provided to enable FHD video or UHD content".
+    static let higherDefinitionVideoQueryParams = "&v_rs=FHD&c_rs=UHD&a_cnt=25"
+
     static func postJoinRequest(meetingId: String,
                                 name: String,
                                 overriddenEndpoint: String,
                                 primaryExternalMeetingId: String,
+                                enableHigherDefinitionVideo: Bool = false,
                                 completion: @escaping (JoinMeetingResponse?) -> Void) {
         var url = overriddenEndpoint.isEmpty ? AppConfiguration.url : overriddenEndpoint
         url = url.hasSuffix("/") ? url : "\(url)/"
         let primaryExternalMeetingIdQueryParam = primaryExternalMeetingId.isEmpty ? "" : "&primaryExternalMeetingId=\(primaryExternalMeetingId)"
+        let higherDefinitionVideoQueryParam = enableHigherDefinitionVideo ? higherDefinitionVideoQueryParams : ""
         let encodedURL = HttpUtils.encodeStrForURL(
-            str: "\(url)join?title=\(meetingId)&name=\(name)&region=\(AppConfiguration.region)\(primaryExternalMeetingIdQueryParam)"
+            str: "\(url)join?title=\(meetingId)&name=\(name)&region=\(AppConfiguration.region)\(primaryExternalMeetingIdQueryParam)\(higherDefinitionVideoQueryParam)"
         )
         HttpUtils.postRequest(url: encodedURL, jsonData: nil, logger: logger) { data, _ in
             guard let data = data else {


### PR DESCRIPTION
Add two demo controls for higher-definition local video and fix the SDK bitrate branch that made an explicit max bitrate a no-op under FHD.

Demo:
- "FHD Video Switch" toggle (DebugSettings) requests FHD local video and sends v_rs=FHD&c_rs=UHD on the join request.
- "Local Video Max Bitrate Input" lets the user set an explicit maxBitRateKbps for the local video source.

SDK:
- DefaultVideoClientController set an explicit config.maxBitRateKbps and then unconditionally overwrote it with the FHD 2500kbps default when videoMaxResolution == FHD. Change the second branch to else-if so an explicit maxBitRateKbps is honored and only falls back to the FHD default when no explicit bitrate was provided.

cr: https://code.amazon.com/reviews/CR-296841686

## ℹ️ Description
*provide a summary of the changes and the related issue, relevant motivation and context*

### Issue #, if available

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
    - [ ] README update
    - [ ] CHANGELOG update
    - [ ] guides update
- [ ] This change requires a dependency update
    - [ ] Amazon Chime SDK Media
    - [ ] Other (update corresponding legal documents)

## 🧪 How Has This Been Tested?
*describe the tests that you ran to verify your changes, any relevant details for your test configuration*

### Additional Manual Test
- [ ] Pause and resume remote video
- [ ] Switch local camera
- [ ] Rotate screen back and forth

## 📱 Screenshots, if available
*provide screenshots/video record if there's a UI change in demo app*

## ✅ Checklist
#### Integration validation (required before release)

- [ ] Unit tests pass
- [ ] Build SDK against simulator with release options
- [ ] Build SDK against device with release options
- [ ] Build SDK against simulator with debug options
- [ ] Build SDK against device with debug options
- [ ] Test Demo against simulator with SDK (debug build) in workspace
- [ ] Test Demo against device with SDK (debug build) in workspace
- [ ] Test DemoObjC against simulator with SDK (debug build) in workspace
- [ ] Test DemoObjC against device with SDK (debug build) in workspace
- [ ] Test Demo against simulator with SDK.framework (release build)
- [ ] Test Demo against device with SDK.framework (release build)
- [ ] Test DemoObjC against simulator with SDK.framework (release build)
- [ ] Test DemoObjC against device with SDK.framework (release build)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
