### PR TITLE
Fix CocoaPods demo CoreML linking

### DIFF
--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo.xcodeproj/project.pbxproj
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo.xcodeproj/project.pbxproj
@@ -1789,6 +1789,7 @@
 				MARKETING_VERSION = 0.6.0;
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = (
+					"$(inherited)",
 					"-lc++",
 					"-ObjC",
 					"-framework",
@@ -1836,6 +1837,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = (
+					"$(inherited)",
 					"-lc++",
 					"-ObjC",
 					"-framework",

--- a/AmazonChimeSDKDemo/AmazonChimeSDKDemo.xcodeproj/project.pbxproj
+++ b/AmazonChimeSDKDemo/AmazonChimeSDKDemo.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		C61D437A270512A100150F03 /* CaptionCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C61D4379270512A100150F03 /* CaptionCell.swift */; };
 		CFD14AAF281B4DAA00C8D8CA /* AmazonChimeSDKMachineLearning.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = CFD14AAE281B4DAA00C8D8CA /* AmazonChimeSDKMachineLearning.xcframework */; };
 		A27B3C4D5E6F708192A3B4C1 /* CoreML.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A27B3C4D5E6F708192A3B4C2 /* CoreML.framework */; };
+		A27B3C4D5E6F708192A3B4C3 /* CoreML.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A27B3C4D5E6F708192A3B4C2 /* CoreML.framework */; };
 		D89046E629834C8B00373566 /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89046E529834C8B00373566 /* Toast.swift */; };
 		D89046E829834D5400373566 /* ToastPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89046E729834D5400373566 /* ToastPosition.swift */; };
 		D89046EB2983BC9800373566 /* PaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D89046EA2983BC9800373566 /* PaddingLabel.swift */; };
@@ -438,6 +439,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4CC2069452049F35E3B82174 /* Pods_AmazonChimeSDKDemoPods.framework in Frameworks */,
+				A27B3C4D5E6F708192A3B4C3 /* CoreML.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1789,7 +1791,6 @@
 				MARKETING_VERSION = 0.6.0;
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = (
-					"$(inherited)",
 					"-lc++",
 					"-ObjC",
 					"-framework",
@@ -1837,7 +1838,6 @@
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = "";
 				OTHER_LDFLAGS = (
-					"$(inherited)",
 					"-lc++",
 					"-ObjC",
 					"-framework",


### PR DESCRIPTION
## Issue

`AmazonChimeSDKMachineLearning` 0.3.3 uses Core ML, but the `AmazonChimeSDKDemoPods` target does not link Apple's CoreML framework. This causes the device build to fail with unresolved Core ML symbols from the machine-learning framework.

## Description

Link the existing SDKROOT `CoreML.framework` reference in the `AmazonChimeSDKDemoPods` Frameworks phase. System frameworks in this phase are linked but not embedded.

## Testing

- [Xcode 16 CocoaPods validation](https://github.com/aws/amazon-chime-sdk-ios/actions/runs/32906264099): all four Release device builds passed.
  - Xcode 16.1 (16B40), standard Media 0.25.4
  - Xcode 16.1 (16B40), Media No Video Codecs 0.25.4
  - Xcode 16.4 (16F6), standard Media 0.25.4
  - Xcode 16.4 (16F6), Media No Video Codecs 0.25.4
- Xcode 26.6 Release device builds passed locally for standard and no-video-codecs variants.
- Every build produced the app and broadcast-extension binaries, included CoreML in the app linker invocation, and contained no unresolved ML symbols.
- The validation used SDK 0.27.4, Media 0.25.4, and Machine Learning 0.3.3 from their release podspecs. Signing and publication were disabled.
